### PR TITLE
Add image path validation for open documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@
 
 For debugging, open the webview developer tools by opening the command pallete and selecting `Developer: Open Webview Developer Tools`. This will allow you to inspect the webview contents. **Note:** It can only be opened when the webview is open.
 
+The tests for client and server require running the `test-compile` script beforehand. For example, the server tests can be run via command line as follows:
+
+```bash
+$ npm install
+$ npm run test-compile
+$ npm run test-server
+```
+
+If you use the launch configuration to invoke the client tests from VS Code, the `test-compile` will be run automatically.
+
 ## Enabling the Code editor for Gitpod
 
 Go to your [settings](https://gitpod.io/settings/) view and select "Enable Feature Preview". Then, you can choose Code as your Default IDE (or switch back to Theia). The change will be reflected in any new workspace you create.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
 		"package": "vsce package",
 		"watch": "tsc -b -watch",
 		"lint": "eslint ./client/src ./server/src --ext ts,js,jsx,tsx",
-		"test": "node ./client/out/test/runTest.js",
+		"test-client": "node ./client/out/test/runTest.js",
+		"test-server": "./server/node_modules/.bin/mocha ./server/out/test/server.test.js",
+		"test": "npm run test-client && npm run test-server",
 		"postinstall": "cd client && npm install && cd ../server && npm install"
 	},
 	"activationEvents": [

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -24,14 +24,11 @@
 			"integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==",
 			"dev": true
 		},
-		"@types/xml2js": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
-			"integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
+		"@types/xmldom": {
+			"version": "0.1.30",
+			"resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.30.tgz",
+			"integrity": "sha512-edqgAFXMEtVvaBZ3YnhamvmrHjoYpuxETmnb0lbTZmf/dXpAsO9ZKotUO4K2rn2SIZBDFCMOuA7fOe0H6dRZcA==",
+			"dev": true
 		},
 		"@ungap/promise-all-settled": {
 			"version": "1.1.2",
@@ -436,11 +433,6 @@
 				"p-locate": "^5.0.0"
 			}
 		},
-		"lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-		},
 		"log-symbols": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
@@ -590,11 +582,6 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 			"dev": true
-		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"serialize-javascript": {
 			"version": "5.0.1",
@@ -760,27 +747,15 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
 		},
-		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			}
+		"xmldom": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
+			"integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA=="
 		},
-		"xml2js-xpath": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/xml2js-xpath/-/xml2js-xpath-0.11.0.tgz",
-			"integrity": "sha512-LJJWN9VcZUItBb3R3NmaWuE7+mZzhwGfo9vqekDki02ZnnO7M5QHeqpT49XBfWxZlBuuYVXw3t8rjvekZY43Yg==",
-			"requires": {
-				"lodash": "^4.17.15"
-			}
-		},
-		"xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+		"xpath-ts": {
+			"version": "1.3.13",
+			"resolved": "https://registry.npmjs.org/xpath-ts/-/xpath-ts-1.3.13.tgz",
+			"integrity": "sha512-eNVXzDWbCV9KEB6fGNQ3qHFGC9PWBH7y2h13vZ+CMPNqOTZ+fgYTG4Sb0p5bVHiAwZrzgE6/tx987003P3dYpA=="
 		},
 		"y18n": {
 			"version": "5.0.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3,6 +3,31 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
+		"@types/node": {
+			"version": "14.14.28",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
+			"integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==",
+			"dev": true
+		},
+		"@types/xml2js": {
+			"version": "0.4.8",
+			"resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
+			"integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"lodash": {
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
 		"vscode-jsonrpc": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
@@ -34,6 +59,33 @@
 			"version": "3.16.0",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
 			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+		},
+		"vscode-uri": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+			"integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA=="
+		},
+		"xml2js": {
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"requires": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			}
+		},
+		"xml2js-xpath": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/xml2js-xpath/-/xml2js-xpath-0.11.0.tgz",
+			"integrity": "sha512-LJJWN9VcZUItBb3R3NmaWuE7+mZzhwGfo9vqekDki02ZnnO7M5QHeqpT49XBfWxZlBuuYVXw3t8rjvekZY43Yg==",
+			"requires": {
+				"lodash": "^4.17.15"
+			}
+		},
+		"xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
 		}
 	}
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3,6 +3,21 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
+		"@types/mocha": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.1.tgz",
+			"integrity": "sha512-NysN+bNqj6E0Hv4CTGWSlPzMW6vTKjDpOteycDkV4IWBsO+PU48JonrPzV9ODjiI2XrjmA05KInLgF5ivZ/YGQ==",
+			"dev": true
+		},
+		"@types/mock-fs": {
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.0.tgz",
+			"integrity": "sha512-FUqxhURwqFtFBCuUj3uQMp7rPSQs//b3O9XecAVxhqS9y4/W8SIJEZFq2mmpnFVZBXwR/2OyPLE97CpyYiB8Mw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/node": {
 			"version": "14.14.28",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
@@ -18,15 +33,620 @@
 				"@types/node": "*"
 			}
 		},
+		"@ungap/promise-all-settled": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+			"dev": true
+		},
+		"ansi-colors": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^2.0.1"
+			}
+		},
+		"anymatch": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"dev": true,
+			"requires": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			}
+		},
+		"argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"binary-extensions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"dev": true,
+			"requires": {
+				"fill-range": "^7.0.1"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+			"dev": true
+		},
+		"chalk": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"chokidar": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+			"integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+			"dev": true,
+			"requires": {
+				"anymatch": "~3.1.1",
+				"braces": "~3.0.2",
+				"fsevents": "~2.3.1",
+				"glob-parent": "~5.1.0",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.5.0"
+			}
+		},
+		"cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"debug": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"dev": true,
+			"requires": {
+				"ms": "2.1.2"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
+		"decamelize": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"dev": true
+		},
+		"diff": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"dev": true
+		},
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true
+		},
+		"escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true
+		},
+		"fill-range": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"dev": true,
+			"requires": {
+				"to-regex-range": "^5.0.1"
+			}
+		},
+		"find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			}
+		},
+		"flat": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"dev": true
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"optional": true
+		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-parent": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+			"dev": true,
+			"requires": {
+				"is-glob": "^4.0.1"
+			}
+		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true
+		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"requires": {
+				"binary-extensions": "^2.0.0"
+			}
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-glob": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
+		},
+		"is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true
+		},
+		"is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+			"integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+			"dev": true,
+			"requires": {
+				"argparse": "^2.0.1"
+			}
+		},
+		"locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^5.0.0"
+			}
+		},
 		"lodash": {
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
+		"log-symbols": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"mocha": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
+			"integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+			"dev": true,
+			"requires": {
+				"@ungap/promise-all-settled": "1.1.2",
+				"ansi-colors": "4.1.1",
+				"browser-stdout": "1.3.1",
+				"chokidar": "3.5.1",
+				"debug": "4.3.1",
+				"diff": "5.0.0",
+				"escape-string-regexp": "4.0.0",
+				"find-up": "5.0.0",
+				"glob": "7.1.6",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "4.0.0",
+				"log-symbols": "4.0.0",
+				"minimatch": "3.0.4",
+				"ms": "2.1.3",
+				"nanoid": "3.1.20",
+				"serialize-javascript": "5.0.1",
+				"strip-json-comments": "3.1.1",
+				"supports-color": "8.1.1",
+				"which": "2.0.2",
+				"wide-align": "1.1.3",
+				"workerpool": "6.1.0",
+				"yargs": "16.2.0",
+				"yargs-parser": "20.2.4",
+				"yargs-unparser": "2.0.0"
+			}
+		},
+		"mock-fs": {
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+			"integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==",
+			"dev": true
+		},
+		"ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true
+		},
+		"nanoid": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+			"integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+			"dev": true
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"requires": {
+				"yocto-queue": "^0.1.0"
+			}
+		},
+		"p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^3.0.2"
+			}
+		},
+		"path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"picomatch": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+			"dev": true
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"readdirp": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+			"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+			"dev": true,
+			"requires": {
+				"picomatch": "^2.2.1"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true
+		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"serialize-javascript": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+			"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^3.0.0"
+			}
+		},
+		"strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^4.0.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"requires": {
+				"is-number": "^7.0.0"
+			}
 		},
 		"vscode-jsonrpc": {
 			"version": "6.0.0",
@@ -65,6 +685,81 @@
 			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
 			"integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA=="
 		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			}
+		},
+		"workerpool": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+			"integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
 		"xml2js": {
 			"version": "0.4.23",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -86,6 +781,85 @@
 			"version": "11.0.1",
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
 			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+		},
+		"y18n": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+			"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+			"dev": true
+		},
+		"yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"requires": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "20.2.4",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+			"dev": true
+		},
+		"yargs-unparser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^6.0.0",
+				"decamelize": "^4.0.0",
+				"flat": "^5.0.2",
+				"is-plain-obj": "^2.1.0"
+			}
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
 		}
 	}
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,11 @@
 {
 	"name": "server",
 	"devDependencies": {
-		"@types/xml2js": "^0.4.8"
+		"@types/mocha": "^8.2.1",
+		"@types/mock-fs": "^4.13.0",
+		"@types/xml2js": "^0.4.8",
+		"mocha": "^8.3.0",
+		"mock-fs": "^4.13.0"
 	},
 	"dependencies": {
 		"vscode-languageserver": "^7.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
 	"devDependencies": {
 		"@types/mocha": "^8.2.1",
 		"@types/mock-fs": "^4.13.0",
-		"@types/xml2js": "^0.4.8",
+		"@types/xmldom": "^0.1.30",
 		"mocha": "^8.3.0",
 		"mock-fs": "^4.13.0"
 	},
@@ -11,7 +11,7 @@
 		"vscode-languageserver": "^7.0.0",
 		"vscode-languageserver-textdocument": "^1.0.1",
 		"vscode-uri": "^3.0.2",
-		"xml2js": "^0.4.23",
-		"xml2js-xpath": "^0.11.0"
+		"xmldom": "^0.4.0",
+		"xpath-ts": "^1.3.13"
 	}
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,8 +1,13 @@
 {
 	"name": "server",
-	"devDependencies": {},
+	"devDependencies": {
+		"@types/xml2js": "^0.4.8"
+	},
 	"dependencies": {
 		"vscode-languageserver": "^7.0.0",
-		"vscode-languageserver-textdocument": "^1.0.1"
+		"vscode-languageserver-textdocument": "^1.0.1",
+		"vscode-uri": "^3.0.2",
+		"xml2js": "^0.4.23",
+		"xml2js-xpath": "^0.11.0"
 	}
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -55,12 +55,11 @@ documents.onDidClose(event => {
 documents.onDidChangeContent(async event => {
   const textDocument = event.document
   const diagnostics: Diagnostic[] = []
-  const xmlData = await parseXMLString(textDocument)
+  const xmlData: Document = parseXMLString(textDocument)
 
-  if (xmlData != null) {
-    const imagePathDiagnostics = await validateImagePaths(textDocument, xmlData)
-    diagnostics.push(...imagePathDiagnostics)
-  }
+  const imagePathDiagnostics = await validateImagePaths(textDocument, xmlData)
+  diagnostics.push(...imagePathDiagnostics)
+
   connection.sendDiagnostics({
     uri: textDocument.uri,
     diagnostics

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -55,10 +55,12 @@ documents.onDidClose(event => {
 documents.onDidChangeContent(async event => {
   const textDocument = event.document
   const diagnostics: Diagnostic[] = []
-  const xmlData: Document = parseXMLString(textDocument)
+  const xmlData = parseXMLString(textDocument)
 
-  const imagePathDiagnostics = await validateImagePaths(textDocument, xmlData)
-  diagnostics.push(...imagePathDiagnostics)
+  if (xmlData != null) {
+    const imagePathDiagnostics = await validateImagePaths(textDocument, xmlData)
+    diagnostics.push(...imagePathDiagnostics)
+  }
 
   connection.sendDiagnostics({
     uri: textDocument.uri,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,24 +1,20 @@
 import {
   createConnection,
   TextDocuments,
-  Diagnostic,
-  DiagnosticSeverity,
   ProposedFeatures,
   InitializeParams,
   TextDocumentSyncKind,
-  InitializeResult
+  InitializeResult,
+  Diagnostic
 } from 'vscode-languageserver/node'
 
-import xpath from 'xml2js-xpath'
-import { parseStringPromise } from 'xml2js'
-import {
-  URI
-} from 'vscode-uri'
 import {
   TextDocument
 } from 'vscode-languageserver-textdocument'
-import fs from 'fs'
-import path from 'path'
+
+import {
+  parseXMLString, validateImagePaths
+} from './utils'
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -58,7 +54,17 @@ documents.onDidClose(event => {
 
 documents.onDidChangeContent(async event => {
   const textDocument = event.document
-  await validateImagePaths(textDocument)
+  const diagnostics: Diagnostic[] = []
+  const xmlData = await parseXMLString(textDocument)
+
+  if (xmlData != null) {
+    const imagePathDiagnostics = await validateImagePaths(textDocument, xmlData)
+    diagnostics.push(...imagePathDiagnostics)
+  }
+  connection.sendDiagnostics({
+    uri: textDocument.uri,
+    diagnostics
+  })
 })
 
 // Make the text document manager listen on the connection
@@ -67,58 +73,3 @@ documents.listen(connection)
 
 // Listen on the connection
 connection.listen()
-
-async function validateImagePaths(textDocument: TextDocument): Promise<void> {
-  const text = textDocument.getText()
-  const diagnostics: Diagnostic[] = []
-  const diagnosticSource = 'Image validation'
-  let images = []
-
-  try {
-    const xmlData = await parseStringPromise(text)
-    images = xpath.find(xmlData, '//image')
-  } catch {
-    // Send an error that the validator can't parse file as XML
-    const diagnostic: Diagnostic = {
-      severity: DiagnosticSeverity.Error,
-      range: {
-        start: textDocument.positionAt(0),
-        end: textDocument.positionAt(0)
-      },
-      message: `Cannot parse ${textDocument.uri} as valid XML`,
-      source: diagnosticSource
-    }
-    diagnostics.push(diagnostic)
-  }
-
-  for (const image of images) {
-    // Ignore if this image doesn't have attributes or src (e.g. if it is
-    // being edited).
-    const imageSrc = image !== '' && 'src' in image.$ ? image.$.src : null
-    if (imageSrc == null) {
-      continue
-    }
-
-    const documentPath = URI.parse(textDocument.uri).path
-    // The image path is relative to the document
-    const imagePath = path.join(path.dirname(documentPath), imageSrc)
-    // Track the location of the image path in the text for diagnostic range
-    const imageLocation = text.indexOf(imageSrc)
-
-    if (fs.existsSync(imagePath)) {
-      continue
-    }
-    const diagnostic: Diagnostic = {
-      severity: DiagnosticSeverity.Error,
-      range: {
-        start: textDocument.positionAt(imageLocation),
-        end: textDocument.positionAt(imageLocation + parseInt(imageSrc.length))
-      },
-      message: `Image file ${String(imageSrc)} doesn't exist!`,
-      source: diagnosticSource
-    }
-    diagnostics.push(diagnostic)
-  }
-
-  connection.sendDiagnostics({ uri: textDocument.uri, diagnostics })
-}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -92,7 +92,13 @@ async function validateImagePaths(textDocument: TextDocument): Promise<void> {
   }
 
   for (const image of images) {
-    const imageSrc = image.$.src
+    // Ignore if this image doesn't have attributes or src (e.g. if it is
+    // being edited).
+    const imageSrc = image !== '' && 'src' in image.$ ? image.$.src : null
+    if (imageSrc == null) {
+      continue
+    }
+
     const documentPath = URI.parse(textDocument.uri).path
     // The image path is relative to the document
     const imagePath = path.join(path.dirname(documentPath), imageSrc)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,15 +1,24 @@
 import {
   createConnection,
   TextDocuments,
+  Diagnostic,
+  DiagnosticSeverity,
   ProposedFeatures,
   InitializeParams,
   TextDocumentSyncKind,
   InitializeResult
 } from 'vscode-languageserver/node'
 
+import xpath from 'xml2js-xpath'
+import { parseStringPromise } from 'xml2js'
+import {
+  URI
+} from 'vscode-uri'
 import {
   TextDocument
 } from 'vscode-languageserver-textdocument'
+import fs from 'fs'
+import path from 'path'
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -47,10 +56,9 @@ documents.onDidClose(event => {
   )
 })
 
-documents.onDidChangeContent(event => {
-  connection.console.log(
-    `Language server received a content change event for ${event.document.uri}`
-  )
+documents.onDidChangeContent(async event => {
+  const textDocument = event.document
+  await validateImagePaths(textDocument)
 })
 
 // Make the text document manager listen on the connection
@@ -59,3 +67,52 @@ documents.listen(connection)
 
 // Listen on the connection
 connection.listen()
+
+async function validateImagePaths(textDocument: TextDocument): Promise<void> {
+  const text = textDocument.getText()
+  const diagnostics: Diagnostic[] = []
+  const diagnosticSource = 'Image validation'
+  let images = []
+
+  try {
+    const xmlData = await parseStringPromise(text)
+    images = xpath.find(xmlData, '//image')
+  } catch {
+    // Send an error that the validator can't parse file as XML
+    const diagnostic: Diagnostic = {
+      severity: DiagnosticSeverity.Error,
+      range: {
+        start: textDocument.positionAt(0),
+        end: textDocument.positionAt(0)
+      },
+      message: `Cannot parse ${textDocument.uri} as valid XML`,
+      source: diagnosticSource
+    }
+    diagnostics.push(diagnostic)
+  }
+
+  for (const image of images) {
+    const imageSrc = image.$.src
+    const documentPath = URI.parse(textDocument.uri).path
+    // The image path is relative to the document
+    const imagePath = path.join(path.dirname(documentPath), imageSrc)
+    // Track the location of the image path in the text for diagnostic range
+    const imageLocation = text.indexOf(imageSrc)
+
+    if (fs.existsSync(imagePath)) {
+      continue
+    }
+    const diagnostic: Diagnostic = {
+      severity: DiagnosticSeverity.Error,
+      range: {
+        start: textDocument.positionAt(imageLocation),
+        end: textDocument.positionAt(imageLocation + parseInt(imageSrc.length))
+      },
+      message: `Image file ${String(imageSrc)} doesn't exist!`,
+      source: diagnosticSource
+    }
+    diagnostics.push(diagnostic)
+  }
+
+  connection.sendDiagnostics({ uri: textDocument.uri, diagnostics })
+}

--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -1,0 +1,124 @@
+import {
+  TextDocument
+} from 'vscode-languageserver-textdocument'
+import {
+  parseXMLString, validateImagePaths, IMAGEPATH_DIAGNOSTIC_SOURCE
+} from './../utils'
+
+import assert from 'assert'
+import mockfs from 'mock-fs'
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver'
+
+describe('parseXMLString', function () {
+  it('should return null on bad XML', async function () {
+    const inputContent = `
+      <document></documentt>
+    `
+    const inputDocument = TextDocument.create('', '', 0, inputContent)
+    const result = await parseXMLString(inputDocument)
+    assert.strictEqual(result, null)
+  })
+
+  it('should return an object on valid XML', async function () {
+    const inputContent = `
+      <document>
+        <content></content>
+      </document>
+    `
+    const inputDocument = TextDocument.create('', '', 0, inputContent)
+    const result = await parseXMLString(inputDocument)
+    assert(result instanceof Object)
+  })
+})
+
+describe('validateImagePaths', function () {
+  before(function () {
+    mockfs({
+      '/media/image1.jpg': ''
+    })
+  })
+  after(function () {
+    mockfs.restore()
+  })
+  it('should return empty diagnostics when no images', async function () {
+    const inputContent = `
+      <document>
+        <content></content>
+      </document>
+    `
+    const inputDocument = TextDocument.create(
+      'file:///modules/m12345/index.cnxml', '', 0, inputContent
+    )
+    const xmlData = await parseXMLString(inputDocument)
+    const result = await validateImagePaths(inputDocument, xmlData)
+    assert.deepStrictEqual(result, [])
+  })
+  it('should return empty diagnostics when all images are valid', async function () {
+    const inputContent = `
+      <document>
+        <content>
+          <image src="../../media/image1.jpg" />
+        </content>
+      </document>
+    `
+    const inputDocument = TextDocument.create(
+      'file:///modules/m12345/index.cnxml', '', 0, inputContent
+    )
+    const xmlData = await parseXMLString(inputDocument)
+    const result = await validateImagePaths(inputDocument, xmlData)
+    assert.deepStrictEqual(result, [])
+  })
+  it('should return diagnostics when images are invalid', async function () {
+    const inputContent = `
+      <document>
+        <content>
+          <image src="../../media/image1.jpg" />
+          <image src="../../media/image2.jpg" />
+          <image src="../../media/image3.jpg" />
+        </content>
+      </document>
+    `
+    const inputDocument = TextDocument.create(
+      'file:///modules/m12345/index.cnxml', '', 0, inputContent
+    )
+    const xmlData = await parseXMLString(inputDocument)
+    const result = await validateImagePaths(inputDocument, xmlData)
+    const image2Location = inputContent.indexOf('../../media/image2.jpg')
+    const image3Location = inputContent.indexOf('../../media/image3.jpg')
+    const expectedDiagnostic1: Diagnostic = {
+      severity: DiagnosticSeverity.Error,
+      range: {
+        start: inputDocument.positionAt(image2Location),
+        end: inputDocument.positionAt(image2Location + '../../media/image2.jpg'.length)
+      },
+      message: 'Image file ../../media/image2.jpg doesn\'t exist!',
+      source: IMAGEPATH_DIAGNOSTIC_SOURCE
+    }
+    const expectedDiagnostic2: Diagnostic = {
+      severity: DiagnosticSeverity.Error,
+      range: {
+        start: inputDocument.positionAt(image3Location),
+        end: inputDocument.positionAt(image3Location + '../../media/image3.jpg'.length)
+      },
+      message: 'Image file ../../media/image3.jpg doesn\'t exist!',
+      source: IMAGEPATH_DIAGNOSTIC_SOURCE
+    }
+    assert.deepStrictEqual(result, [expectedDiagnostic1, expectedDiagnostic2])
+  })
+  it('should ignore incomplete image elements', async function () {
+    const inputContent = `
+      <document>
+        <content>
+          <image src="../../media/image1.jpg" />
+          <image />
+        </content>
+      </document>
+    `
+    const inputDocument = TextDocument.create(
+      'file:///modules/m12345/index.cnxml', '', 0, inputContent
+    )
+    const xmlData = await parseXMLString(inputDocument)
+    const result = await validateImagePaths(inputDocument, xmlData)
+    assert.deepStrictEqual(result, [])
+  })
+})

--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -10,6 +10,12 @@ import mockfs from 'mock-fs'
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver'
 
 describe('parseXMLString', function () {
+  it('should return null on a new / empty XML', async function () {
+    const inputContent = ''
+    const inputDocument = TextDocument.create('', '', 0, inputContent)
+    const result = parseXMLString(inputDocument)
+    assert.strictEqual(result, null)
+  })
   it('should return an object on valid XML', async function () {
     const inputContent = `
       <document xmlns="http://cnx.rice.edu/cnxml">
@@ -17,7 +23,7 @@ describe('parseXMLString', function () {
       </document>
     `
     const inputDocument = TextDocument.create('', '', 0, inputContent)
-    const result = await parseXMLString(inputDocument)
+    const result = parseXMLString(inputDocument)
     assert(result instanceof Object)
   })
 })
@@ -40,7 +46,8 @@ describe('validateImagePaths', function () {
     const inputDocument = TextDocument.create(
       'file:///modules/m12345/index.cnxml', '', 0, inputContent
     )
-    const xmlData = await parseXMLString(inputDocument)
+    const xmlData = parseXMLString(inputDocument)
+    assert(xmlData != null)
     const result = await validateImagePaths(inputDocument, xmlData)
     assert.deepStrictEqual(result, [])
   })
@@ -55,7 +62,8 @@ describe('validateImagePaths', function () {
     const inputDocument = TextDocument.create(
       'file:///modules/m12345/index.cnxml', '', 0, inputContent
     )
-    const xmlData = await parseXMLString(inputDocument)
+    const xmlData = parseXMLString(inputDocument)
+    assert(xmlData != null)
     const result = await validateImagePaths(inputDocument, xmlData)
     assert.deepStrictEqual(result, [])
   })
@@ -72,7 +80,8 @@ describe('validateImagePaths', function () {
     const inputDocument = TextDocument.create(
       'file:///modules/m12345/index.cnxml', '', 0, inputContent
     )
-    const xmlData = await parseXMLString(inputDocument)
+    const xmlData = parseXMLString(inputDocument)
+    assert(xmlData != null)
     const result = await validateImagePaths(inputDocument, xmlData)
     const image2Location = inputContent.indexOf('../../media/image2.jpg')
     const image3Location = inputContent.indexOf('../../media/image3.jpg')
@@ -108,7 +117,8 @@ describe('validateImagePaths', function () {
     const inputDocument = TextDocument.create(
       'file:///modules/m12345/index.cnxml', '', 0, inputContent
     )
-    const xmlData = await parseXMLString(inputDocument)
+    const xmlData = parseXMLString(inputDocument)
+    assert(xmlData != null)
     const result = await validateImagePaths(inputDocument, xmlData)
     assert.deepStrictEqual(result, [])
   })

--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -10,18 +10,9 @@ import mockfs from 'mock-fs'
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver'
 
 describe('parseXMLString', function () {
-  it('should return null on bad XML', async function () {
-    const inputContent = `
-      <document></documentt>
-    `
-    const inputDocument = TextDocument.create('', '', 0, inputContent)
-    const result = await parseXMLString(inputDocument)
-    assert.strictEqual(result, null)
-  })
-
   it('should return an object on valid XML', async function () {
     const inputContent = `
-      <document>
+      <document xmlns="http://cnx.rice.edu/cnxml">
         <content></content>
       </document>
     `
@@ -42,7 +33,7 @@ describe('validateImagePaths', function () {
   })
   it('should return empty diagnostics when no images', async function () {
     const inputContent = `
-      <document>
+      <document xmlns="http://cnx.rice.edu/cnxml">
         <content></content>
       </document>
     `
@@ -55,7 +46,7 @@ describe('validateImagePaths', function () {
   })
   it('should return empty diagnostics when all images are valid', async function () {
     const inputContent = `
-      <document>
+      <document xmlns="http://cnx.rice.edu/cnxml">
         <content>
           <image src="../../media/image1.jpg" />
         </content>
@@ -70,7 +61,7 @@ describe('validateImagePaths', function () {
   })
   it('should return diagnostics when images are invalid', async function () {
     const inputContent = `
-      <document>
+      <document xmlns="http://cnx.rice.edu/cnxml">
         <content>
           <image src="../../media/image1.jpg" />
           <image src="../../media/image2.jpg" />
@@ -107,7 +98,7 @@ describe('validateImagePaths', function () {
   })
   it('should ignore incomplete image elements', async function () {
     const inputContent = `
-      <document>
+      <document xmlns="http://cnx.rice.edu/cnxml">
         <content>
           <image src="../../media/image1.jpg" />
           <image />

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -13,9 +13,12 @@ import path from 'path'
 const NS_CNXML = 'http://cnx.rice.edu/cnxml'
 export const IMAGEPATH_DIAGNOSTIC_SOURCE = 'Image validation'
 
-export function parseXMLString(textDocument: TextDocument): Document {
+export function parseXMLString(textDocument: TextDocument): Document | null {
   const text = textDocument.getText()
   const xmlData: Document = new DOMParser().parseFromString(text)
+  if (xmlData === undefined) {
+    return null
+  }
   return xmlData
 }
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,0 +1,73 @@
+import { Diagnostic, DiagnosticSeverity, Position } from 'vscode-languageserver/node'
+import {
+  TextDocument
+} from 'vscode-languageserver-textdocument'
+import { parseStringPromise } from 'xml2js'
+import xpath from 'xml2js-xpath'
+import {
+  URI
+} from 'vscode-uri'
+import fs from 'fs'
+import path from 'path'
+
+export const IMAGEPATH_DIAGNOSTIC_SOURCE = 'Image validation'
+
+export async function parseXMLString(textDocument: TextDocument): Promise<any> {
+  try {
+    const text = textDocument.getText()
+    const xmlData = await parseStringPromise(text)
+    return xmlData
+  } catch {
+    return null
+  }
+}
+
+export async function validateImagePaths(textDocument: TextDocument, xmlData: any): Promise<Diagnostic[]> {
+  const text = textDocument.getText()
+  const diagnostics: Diagnostic[] = []
+  const images = xpath.find(xmlData, '//image')
+
+  for (const image of images) {
+    // Ignore if this image doesn't have attributes or src (e.g. if it is
+    // being edited).
+    const imageSrc = image !== '' && 'src' in image.$ ? image.$.src : null
+    if (imageSrc == null) {
+      continue
+    }
+
+    const documentPath = URI.parse(textDocument.uri).path
+    // The image path is relative to the document
+    const imagePath = path.join(path.dirname(documentPath), imageSrc)
+    // Track the location of the image path in the text for diagnostic range
+    const imageLocation = text.indexOf(imageSrc)
+
+    if (fs.existsSync(imagePath)) {
+      continue
+    }
+    const diagnostic: Diagnostic = generateDiagnostic(
+      DiagnosticSeverity.Error,
+      textDocument.positionAt(imageLocation),
+      textDocument.positionAt(imageLocation + parseInt(imageSrc.length)),
+      `Image file ${String(imageSrc)} doesn't exist!`,
+      IMAGEPATH_DIAGNOSTIC_SOURCE
+    )
+    diagnostics.push(diagnostic)
+  }
+
+  return diagnostics
+}
+
+function generateDiagnostic(severity: DiagnosticSeverity,
+  startPosition: Position, endPosition: Position, message: string,
+  diagnosticSource: string): Diagnostic {
+  const diagnostic: Diagnostic = {
+    severity: severity,
+    range: {
+      start: startPosition,
+      end: endPosition
+    },
+    message: message,
+    source: diagnosticSource
+  }
+  return diagnostic
+}


### PR DESCRIPTION
This PR builds on the branch with [language server setup](https://github.com/openstax/poet/pull/12). ~~The relative additions can be viewed using [this comparison](https://github.com/openstax/poet/compare/cnx1428/add-language-server..cnx1355/image-path-validation) until the base PR is merged.~~