### PR TITLE
Fix bug in element position calculations for diagnostics

### DIFF
--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -623,10 +623,10 @@ describe('calculateElementPositions', function () {
     const result: Position[] = calculateElementPositions(imageElement)
     assert.deepStrictEqual(result, [expectedStart, expectedEnd])
   })
-  it('should return start and end positions based on tag length when no siblings', async function () {
+  it('should return start and end positions based on attributes when no siblings', async function () {
     const xmlContent = `
       <document>
-        <content><image src="" /></content>
+        <content><image src="value" /></content>
       </document>
     `
     const document = TextDocument.create(
@@ -644,7 +644,7 @@ describe('calculateElementPositions', function () {
     }
     const expectedEnd: Position = {
       line: 2,
-      character: 23
+      character: 35
     }
     const result: Position[] = calculateElementPositions(imageElement)
     assert.deepStrictEqual(result, [expectedStart, expectedEnd])

--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -649,4 +649,30 @@ describe('calculateElementPositions', function () {
     const result: Position[] = calculateElementPositions(imageElement)
     assert.deepStrictEqual(result, [expectedStart, expectedEnd])
   })
+  it('should return start and end positions based on tag when no siblings or attributes', async function () {
+    const xmlContent = `
+      <document>
+        <content><image /></content>
+      </document>
+    `
+    const document = TextDocument.create(
+      'file:///modules/m12345/index.cnxml', '', 0, xmlContent
+    )
+    const xmlData = parseXMLString(document)
+    assert(xmlData != null)
+    const elements = xpath.select('//image', xmlData) as Node[]
+    const imageElement = elements[0] as Element
+
+    assert(imageElement.nextSibling === null)
+    const expectedStart: Position = {
+      line: 2,
+      character: 17
+    }
+    const expectedEnd: Position = {
+      line: 2,
+      character: 23
+    }
+    const result: Position[] = calculateElementPositions(imageElement)
+    assert.deepStrictEqual(result, [expectedStart, expectedEnd])
+  })
 })

--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -10,13 +10,19 @@ import {
   getCurrentModules,
   ValidationQueue,
   ValidationRequest,
-  ModuleInformation
+  ModuleInformation,
+  calculateElementPositions
 } from './../utils'
 
 import assert from 'assert'
 import mockfs from 'mock-fs'
 import sinon from 'sinon'
-import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver'
+import * as xpath from 'xpath-ts'
+import {
+  Diagnostic,
+  DiagnosticSeverity,
+  Position
+} from 'vscode-languageserver'
 
 describe('parseXMLString', function () {
   it('should return null on a new / empty XML', async function () {
@@ -585,5 +591,62 @@ describe('ValidationQueue', function () {
     await (validationQueue as any).processQueue()
     assert.strictEqual(sendDiagnosticsStub.callCount, 1)
     sinon.restore()
+  })
+})
+
+describe('calculateElementPositions', function () {
+  it('should return start and end positions using siblings when available', async function () {
+    const xmlContent = `
+      <document>
+        <content>
+          <image src="" />
+        </content>
+      </document>
+    `
+    const document = TextDocument.create(
+      'file:///modules/m12345/index.cnxml', '', 0, xmlContent
+    )
+    const xmlData = parseXMLString(document)
+    assert(xmlData != null)
+    const elements = xpath.select('//image', xmlData) as Node[]
+    const imageElement = elements[0] as Element
+
+    assert(imageElement.nextSibling != null)
+    const expectedStart: Position = {
+      line: 3,
+      character: 10
+    }
+    const expectedEnd: Position = {
+      line: 3,
+      character: 26
+    }
+    const result: Position[] = calculateElementPositions(imageElement)
+    assert.deepStrictEqual(result, [expectedStart, expectedEnd])
+  })
+  it('should return start and end positions based on tag length when no siblings', async function () {
+    const xmlContent = `
+      <document>
+        <content><image src="" /></content>
+      </document>
+    `
+    const document = TextDocument.create(
+      'file:///modules/m12345/index.cnxml', '', 0, xmlContent
+    )
+    const xmlData = parseXMLString(document)
+    assert(xmlData != null)
+    const elements = xpath.select('//image', xmlData) as Node[]
+    const imageElement = elements[0] as Element
+
+    assert(imageElement.nextSibling === null)
+    const expectedStart: Position = {
+      line: 2,
+      character: 17
+    }
+    const expectedEnd: Position = {
+      line: 2,
+      character: 23
+    }
+    const result: Position[] = calculateElementPositions(imageElement)
+    assert.deepStrictEqual(result, [expectedStart, expectedEnd])
   })
 })

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -259,10 +259,15 @@ export function calculateElementPositions(element: any): Position[] {
   const elementSibling = element.nextSibling
   let endPosition: Position
 
-  // Use the sibling element to get accurate position of the end of the
-  // input element if it's available. Otherwise we'll use the position and
-  // content of the last attribute to establish an end position
-  if (elementSibling === null) {
+  // Establish the end position using as much information as possible
+  // based upon (in order of preference) 1) element sibling 2) final element
+  // attribute 3) the tag
+  if (elementSibling != null) {
+    endPosition = {
+      line: element.nextSibling.lineNumber - 1,
+      character: element.nextSibling.columnNumber - 1
+    }
+  } else if (element.attributes.length > 0) {
     const elementAttributes = element.attributes
     const finalAttribute = elementAttributes[elementAttributes.length - 1]
     const finalAttributeColumn: number = finalAttribute.columnNumber
@@ -273,9 +278,13 @@ export function calculateElementPositions(element: any): Position[] {
       character: finalAttributeColumn + finalAttributeLength + 1
     }
   } else {
+    const elementTag = element.tagName
+    const tagLength: number = elementTag.length
+    const elementStartColumn: number = element.columnNumber
+
     endPosition = {
-      line: element.nextSibling.lineNumber - 1,
-      character: element.nextSibling.columnNumber - 1
+      line: element.lineNumber - 1,
+      character: elementStartColumn + tagLength
     }
   }
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -260,12 +260,17 @@ export function calculateElementPositions(element: any): Position[] {
   let endPosition: Position
 
   // Use the sibling element to get accurate position of the end of the
-  // input element if it's available. Otherwise we'll use the length of the
-  // tag name to establish an end position
+  // input element if it's available. Otherwise we'll use the position and
+  // content of the last attribute to establish an end position
   if (elementSibling === null) {
+    const elementAttributes = element.attributes
+    const finalAttribute = elementAttributes[elementAttributes.length - 1]
+    const finalAttributeColumn: number = finalAttribute.columnNumber
+    const finalAttributeLength: number = finalAttribute.value.length
+
     endPosition = {
-      line: element.lineNumber - 1,
-      character: (element.columnNumber as number) + (element.tagName.length as number)
+      line: finalAttribute.lineNumber - 1,
+      character: finalAttributeColumn + finalAttributeLength + 1
     }
   } else {
     endPosition = {

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -249,16 +249,29 @@ function generateDiagnostic(severity: DiagnosticSeverity,
   return diagnostic
 }
 
-function calculateElementPositions(element: any): Position[] {
+export function calculateElementPositions(element: any): Position[] {
   // Calculate positions accounting for the zero-based convention used by
   // vscode
   const startPosition: Position = {
     line: element.lineNumber - 1,
     character: element.columnNumber - 1
   }
-  const endPosition: Position = {
-    line: element.nextSibling.lineNumber - 1,
-    character: element.nextSibling.columnNumber - 1
+  const elementSibling = element.nextSibling
+  let endPosition: Position
+
+  // Use the sibling element to get accurate position of the end of the
+  // input element if it's available. Otherwise we'll use the length of the
+  // tag name to establish an end position
+  if (elementSibling === null) {
+    endPosition = {
+      line: element.lineNumber - 1,
+      character: (element.columnNumber as number) + (element.tagName.length as number)
+    }
+  } else {
+    endPosition = {
+      line: element.nextSibling.lineNumber - 1,
+      character: element.nextSibling.columnNumber - 1
+    }
   }
 
   return [startPosition, endPosition]


### PR DESCRIPTION
This change addresses the immediate cause of the error which was due to an implicit assumption that elements have siblings (where they can be null). However, the fallback when siblings don't exist is to calculate the end position of the element as just the first few characters of the element using the tag name length. The implication is if a sibling is present the end position captures the entire element, but otherwise it will just capture the tag name. This difference in behavior isn't ideal (see screenshot for an example), but I haven't yet found a simple way to address it. 

![Screen Shot 2021-02-26 at 4 20 36 PM](https://user-images.githubusercontent.com/839025/109361519-ac64c700-784e-11eb-902e-352bec1ee010.png)