### PR TITLE
Support development inside gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,17 @@
+FROM gitpod/workspace-full-vnc
+
+# From https://community.gitpod.io/t/is-there-an-easy-way-to-debug-a-vscode-extension-inside-gitpod/596/63
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install vscode and cypress dependencies
+# RUN sudo apt-get update \
+#     && sudo apt-get install --no-install-recommends -y libx11-xcb1 libasound2 x11-apps libice6 libsm6 libxaw7 libxft2 libxmu6 libxpm4 libxt6 x11-apps xbitmaps \
+#     && sudo apt-get install --no-install-recommends -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
+RUN wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | sudo apt-key add -; \
+    sudo add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" \
+    && sudo apt-get update \
+    && sudo apt-get install --no-install-recommends -y libx11-xcb1 libasound2 x11-apps libice6 libsm6 libxaw7 libxft2 libxmu6 libxpm4 libxt6 x11-apps xbitmaps \
+    && sudo apt-get install --no-install-recommends -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb \
+    && sudo apt-get install -y code

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,14 +1,9 @@
-FROM gitpod/workspace-full-vnc
-
 # From https://community.gitpod.io/t/is-there-an-easy-way-to-debug-a-vscode-extension-inside-gitpod/596/63
+FROM gitpod/workspace-full-vnc
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install vscode and cypress dependencies
-# RUN sudo apt-get update \
-#     && sudo apt-get install --no-install-recommends -y libx11-xcb1 libasound2 x11-apps libice6 libsm6 libxaw7 libxft2 libxmu6 libxpm4 libxt6 x11-apps xbitmaps \
-#     && sudo apt-get install --no-install-recommends -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-
 RUN wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | sudo apt-key add -; \
     sudo add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" \
     && sudo apt-get update \

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,16 @@
+image:
+  file: .gitpod.Dockerfile
+
+# List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/config-ports/
+# ports:
+#   - port: 3000
+#     onOpen: open-preview
+
+# List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
+# tasks:
+#   - init: echo 'init script' # runs during prebuild
+#     command: echo 'start script'
+
+tasks:
+  - init: npm install && npm run build && npm run package
+    command: printf '\n\n 🎉🎉 The plugin is available in the Explorer 🎉🎉\n\nRight-click the .vsix file and click "Install Extension VSIX" to test it.\n\nRun "npm test" to run tests\n'

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,15 +1,6 @@
+# https://www.gitpod.io/docs/config-gitpod-file/
 image:
   file: .gitpod.Dockerfile
-
-# List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/config-ports/
-# ports:
-#   - port: 3000
-#     onOpen: open-preview
-
-# List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
-# tasks:
-#   - init: echo 'init script' # runs during prebuild
-#     command: echo 'start script'
 
 tasks:
   - init: npm install && npm run build && npm run package

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,16 @@
     "outFiles": ["${workspaceFolder}/client/out/test/**/*.js"],
     "preLaunchTask": "npm: test:compile"
   }, {
+    "name": "Run Extension <gitpod>. Make sure .vscode-test/ exists by running the client tests. Open port 6080 to see the app inside vnc",
+    "type": "node",
+    "request": "launch",
+    "runtimeExecutable": "${workspaceFolder}/.vscode-test/vscode-linux-x64-1.54.1/VSCode-linux-x64/code",
+    "args": [
+      "${workspaceFolder}/out/test/data/test-repo",
+      "--no-sandbox",
+      "--extensionDevelopmentPath=${workspaceFolder}"
+    ]
+  }, {
     "type": "node",
     "request": "attach",
     "name": "Attach to Language Server",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # VSCode Extension that runs in gitpod
 [![Coverage Status](https://img.shields.io/codecov/c/github/openstax/poet.svg)](https://codecov.io/gh/openstax/poet)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 ![installing and enabling the preview](./editor.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VSCode Extension that runs in gitpod
+# VSCode Extension to edit textbooks [in gitpod](https://gitpod.io/from-referrer/)
 [![Coverage Status](https://img.shields.io/codecov/c/github/openstax/poet.svg)](https://codecov.io/gh/openstax/poet)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 

--- a/client/src/test/runTest.ts
+++ b/client/src/test/runTest.ts
@@ -4,7 +4,7 @@ import { runTests } from 'vscode-test'
 
 async function main(): Promise<void> {
   try {
-    const vscodeExecutablePath = undefined // !!process.env['GITPOD_HOST'] ? '/ide/bin/code' : undefined
+    const version = '1.54.1' // Update this in .vscode/launch.json too when it changes
 
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
     const testDataFolder = path.resolve(extensionDevelopmentPath, 'out/test/data/test-repo')
 
     // Download VS Code, unzip it and run the integration test
-    await runTests({ vscodeExecutablePath, extensionDevelopmentPath, extensionTestsPath, launchArgs: [testDataFolder, '--disable-extensions'] })
+    await runTests({ version, extensionDevelopmentPath, extensionTestsPath, launchArgs: [testDataFolder, '--disable-extensions'] })
   } catch (err) {
     console.error('Failed to run tests')
     process.exit(1)

--- a/client/src/test/runTest.ts
+++ b/client/src/test/runTest.ts
@@ -4,6 +4,8 @@ import { runTests } from 'vscode-test'
 
 async function main(): Promise<void> {
   try {
+    const vscodeExecutablePath = undefined // !!process.env['GITPOD_HOST'] ? '/ide/bin/code' : undefined
+
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
     const extensionDevelopmentPath = path.resolve(__dirname, '../../')
@@ -15,7 +17,7 @@ async function main(): Promise<void> {
     const testDataFolder = path.resolve(extensionDevelopmentPath, 'out/test/data/test-repo')
 
     // Download VS Code, unzip it and run the integration test
-    await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: [testDataFolder, '--disable-extensions'] })
+    await runTests({ vscodeExecutablePath, extensionDevelopmentPath, extensionTestsPath, launchArgs: [testDataFolder, '--disable-extensions'] })
   } catch (err) {
     console.error('Failed to run tests')
     process.exit(1)


### PR DESCRIPTION
This makes code review easier since the extension is built and all the dependencies are installed.

# [Click here](https://gitpod.io/#https://github.com/openstax/poet/pull/24) to try it out!

1. Click the link above
1. wait until 🎉  message shows up in the terminal
1. right-click the `editor-0.0.0.vsix` file and click `[Install Extension]`

Now, the dev extension is installed in GitPod for testing


https://user-images.githubusercontent.com/253202/110684030-422f1900-81a2-11eb-8f70-2d851b5d5f63.mp4



# ToDone

- [x] install dependencies
- [x] build `.vsix` package
- [x] add prebuild hooks so reviewing code can start sooner
- [x] run all tests (including the extension tests)
- [x] launch a session in the embedded VNC


https://user-images.githubusercontent.com/253202/110683547-c208b380-81a1-11eb-9b38-5b9b6d413b3d.mp4



# Stretch-goals

- [x] add files to the repo so POET is a valid book too (for easier testing in gitpod). Done in #29
- [ ] launch a debugging session. maybe [this](https://github.com/gitpod-io/gitpod/issues/1400) or [this](https://community.gitpod.io/t/is-there-an-easy-way-to-debug-a-vscode-extension-inside-gitpod/596/63)
    - [Adding the features](https://github.com/gitpod-io/gitpod/issues/1400#issuecomment-799191047) to make this possible is in their [March milestone](https://github.com/gitpod-io/gitpod/milestone/12) `[code] CLI enhanchment`. 
