### PR TITLE
Add initial CNXML schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,16 @@ There is a launch configuration to attach to the language server which can be us
 1. Once the extension is launched, execute "Attach to Language Server" from the Run view
 
 You can now set breakpoints, etc. in the server source code.
+
+## Generating XSD schema files
+
+The CNXML schema validation in the extension is performed using XSD files generated using the RelaxNG schema files in the [cnxml repo](https://github.com/openstax/cnxml). The XSD files can be regenerated using [jing-trang](https://github.com/relaxng/jing-trang.git). You can clone that repo and follow the instructions to build `trang.jar` and `jing.jar`. The following steps assume:
+
+* You have the `trang.jar` and `jing.jar` files in the root of this repo (you can simply modify the paths as necessary for your environment)
+* You have the `cnmxl` repo cloned as a peer of this repo
+
+```bash
+$ java -jar jing.jar -s ../cnxml/cnxml/xml/cnxml/schema/rng/0.7/cnxml-jing.rng > cnxml-simplified.rng
+$ java -jar trang.jar -I rng -O xsd cnxml-simplified.rng client/static/xsd/mathml.xsd
+$ rm cnxml-simplified.rng
+```

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -4,7 +4,7 @@ import { LanguageClient } from 'vscode-languageclient/node'
 import { showTocEditor } from './panel-toc-editor'
 import { showImageUpload } from './panel-image-upload'
 import { showCnxmlPreview } from './panel-cnxml-preview'
-import { expect, ensureCatch, launchLanguageServer } from './utils'
+import { expect, ensureCatch, launchLanguageServer, populateXsdSchemaFiles } from './utils'
 import { commandToPanelType, OpenstaxCommand, PanelType } from './extension-types'
 
 const resourceRootDir = path.join(__dirname) // extension is running in dist/
@@ -45,6 +45,7 @@ const extensionExports = {
 
 export function activate(context: vscode.ExtensionContext): typeof extensionExports {
   client = launchLanguageServer(context)
+  populateXsdSchemaFiles(resourceRootDir)
   vscode.commands.registerCommand(OpenstaxCommand.SHOW_TOC_EDITOR, lazilyFocusOrOpenPanelOfType(commandToPanelType[OpenstaxCommand.SHOW_TOC_EDITOR]))
   vscode.commands.registerCommand(OpenstaxCommand.SHOW_IMAGE_UPLOAD, lazilyFocusOrOpenPanelOfType(commandToPanelType[OpenstaxCommand.SHOW_IMAGE_UPLOAD]))
   vscode.commands.registerCommand(OpenstaxCommand.SHOW_CNXML_PREVIEW, lazilyFocusOrOpenPanelOfType(commandToPanelType[OpenstaxCommand.SHOW_CNXML_PREVIEW]))

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,6 +1,7 @@
 
 import vscode from 'vscode'
 import path from 'path'
+import fs from 'fs'
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -90,6 +91,32 @@ export function ensureCatch(func: (...args: any[]) => Promise<any>): (...args: a
       throw err
     })
   }
+}
+
+export function populateXsdSchemaFiles(resourceRootDir: string): void {
+  const relResourcePath = 'xsd'
+  const relTargetPath = '.xsd'
+  const uri = getRootPathUri()
+  if (uri == null) {
+    return
+  }
+
+  const targetPath = path.join(uri.fsPath, relTargetPath)
+  const sourcePath = path.join(resourceRootDir, relResourcePath)
+
+  // Delete any existing directory and create a new one to ensure no old
+  // schema files are kept around
+  fs.rmdirSync(targetPath, { recursive: true })
+  fs.mkdirSync(targetPath)
+
+  // Copy all schema files
+  const schemaFiles = fs.readdirSync(sourcePath)
+  schemaFiles.forEach(val => {
+    fs.copyFileSync(
+      path.join(sourcePath, val),
+      path.join(targetPath, val)
+    )
+  })
 }
 
 export function launchLanguageServer(context: vscode.ExtensionContext): LanguageClient {

--- a/client/static/xsd/catalog.xml
+++ b/client/static/xsd/catalog.xml
@@ -1,0 +1,5 @@
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <uri
+      name="http://cnx.rice.edu/cnxml"
+      uri="./cnxml.xsd" />
+</catalog>

--- a/client/static/xsd/cnxml.xsd
+++ b/client/static/xsd/cnxml.xsd
@@ -1,0 +1,3887 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/cnxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+  <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns1.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
+  <xs:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="mathml.xsd"/>
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:element name="document">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:group ref="mathml:title"/>
+        <xs:element minOccurs="0" ref="cnxml:metadata"/>
+        <xs:element minOccurs="0" ref="cnxml:featured-links"/>
+        <xs:element ref="cnxml:content"/>
+        <xs:element minOccurs="0" ref="cnxml:glossary"/>
+        <xs:element minOccurs="0" ref="ns1:file"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="cnxml-version" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0.7"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="module-id" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="title">
+    <xs:sequence>
+      <xs:element name="title">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="metadata">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mdml:content-id"/>
+        <xs:element ref="mdml:repository"/>
+        <xs:element ref="mdml:content-url"/>
+        <xs:element ref="mdml:title"/>
+        <xs:element ref="mdml:short-title"/>
+        <xs:element ref="mdml:subtitle"/>
+        <xs:element ref="mdml:version"/>
+        <xs:element ref="mdml:created"/>
+        <xs:element ref="mdml:revised"/>
+        <xs:element ref="mdml:actors"/>
+        <xs:element ref="mdml:roles"/>
+        <xs:element ref="mdml:license"/>
+        <xs:element ref="mdml:extended-attribution"/>
+        <xs:element ref="mdml:derived-from"/>
+        <xs:element ref="mdml:keywordlist"/>
+        <xs:element ref="mdml:subjectlist"/>
+        <xs:element ref="mdml:education-levellist"/>
+        <xs:element ref="mdml:abstract"/>
+        <xs:element ref="mdml:language"/>
+        <xs:element ref="mdml:objectives"/>
+        <xs:element ref="mdml:homepage"/>
+        <xs:element ref="mdml:institution"/>
+        <xs:element ref="mdml:course-code"/>
+        <xs:element ref="mdml:instructor"/>
+        <xs:element ref="mdml:uuid"/>
+        <xs:element ref="mdml:canonical-book-uuid"/>
+        <xs:element ref="mdml:slug"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="mdml-version" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0.5"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="featured-links">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="cnxml:link-group"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="content">
+    <xs:complexType>
+      <xs:choice>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="cnxml:section"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+          <xs:group ref="mathml:para"/>
+        </xs:choice>
+        <xs:element ref="qml:problemset"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glossary">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="cnxml:definition"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="link-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:element maxOccurs="unbounded" ref="cnxml:link"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="type" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="section">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="cnxml:section"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+          <xs:group ref="mathml:para"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="div">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="mathml:para"/>
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:group ref="mathml:media_2"/>
+          <xs:element ref="cnxml:footnote"/>
+          <xs:element ref="cnxml:link"/>
+          <xs:element ref="cnxml:newline"/>
+          <xs:element ref="cnxml:space"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="definition">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group ref="mathml:term_2"/>
+        <xs:choice>
+          <xs:element ref="cnxml:seealso"/>
+          <xs:sequence>
+            <xs:sequence maxOccurs="unbounded">
+              <xs:element ref="cnxml:meaning"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:example"/>
+            </xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:seealso"/>
+          </xs:sequence>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="example">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="cnxml:section"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+          <xs:group ref="mathml:para"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="figure">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:media_2"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:code"/>
+          <xs:sequence>
+            <xs:element ref="cnxml:subfigure"/>
+            <xs:element maxOccurs="unbounded" ref="cnxml:subfigure"/>
+          </xs:sequence>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="cnxml:caption"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="orient">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="horizontal"/>
+            <xs:enumeration value="vertical"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="code">
+    <xs:sequence>
+      <xs:element name="code">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:element ref="cnxml:cite-title"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:list_6"/>
+              <xs:group ref="mathml:list_7"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:element ref="cnxml:footnote"/>
+              <xs:element ref="cnxml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+            </xs:choice>
+            <xs:element minOccurs="0" ref="cnxml:caption"/>
+          </xs:sequence>
+          <xs:attribute name="display" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="lang"/>
+          <xs:attribute name="type"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="preformat">
+    <xs:sequence>
+      <xs:element name="preformat">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para"/>
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:element ref="cnxml:cite-title"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:list_6"/>
+              <xs:group ref="mathml:list_7"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:element ref="cnxml:footnote"/>
+              <xs:element ref="cnxml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:element ref="cnxml:div"/>
+              <xs:element ref="cnxml:definition"/>
+              <xs:element ref="cnxml:example"/>
+              <xs:element ref="cnxml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:list_2"/>
+              <xs:group ref="mathml:list_3"/>
+              <xs:element ref="cnxml:table"/>
+              <xs:element ref="cnxml:rule"/>
+              <xs:element ref="cnxml:equation"/>
+              <xs:element ref="cnxml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="quote">
+    <xs:sequence>
+      <xs:element name="quote">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para"/>
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:element ref="cnxml:cite-title"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:list_6"/>
+              <xs:group ref="mathml:list_7"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:element ref="cnxml:footnote"/>
+              <xs:element ref="cnxml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:element ref="cnxml:div"/>
+              <xs:element ref="cnxml:definition"/>
+              <xs:element ref="cnxml:example"/>
+              <xs:element ref="cnxml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:list_2"/>
+              <xs:group ref="mathml:list_3"/>
+              <xs:element ref="cnxml:table"/>
+              <xs:element ref="cnxml:rule"/>
+              <xs:element ref="cnxml:equation"/>
+              <xs:element ref="cnxml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="note">
+    <xs:sequence>
+      <xs:element name="note">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para"/>
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:element ref="cnxml:cite-title"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:list_6"/>
+              <xs:group ref="mathml:list_7"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:element ref="cnxml:footnote"/>
+              <xs:element ref="cnxml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:element ref="cnxml:div"/>
+              <xs:element ref="cnxml:definition"/>
+              <xs:element ref="cnxml:example"/>
+              <xs:element ref="cnxml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:list_2"/>
+              <xs:group ref="mathml:list_3"/>
+              <xs:element ref="cnxml:table"/>
+              <xs:element ref="cnxml:rule"/>
+              <xs:element ref="cnxml:equation"/>
+              <xs:element ref="cnxml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:token">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="note"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="aside"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="warning"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="tip"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="important"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="media">
+    <xs:sequence>
+      <xs:element name="media">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+            <xs:choice>
+              <xs:element ref="cnxml:object"/>
+              <xs:element ref="cnxml:image"/>
+              <xs:element ref="cnxml:audio"/>
+              <xs:element ref="cnxml:video"/>
+              <xs:element ref="cnxml:java-applet"/>
+              <xs:element ref="cnxml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:element ref="cnxml:labview"/>
+              <xs:element ref="cnxml:text"/>
+              <xs:element ref="cnxml:download"/>
+            </xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="cnxml:object"/>
+              <xs:element ref="cnxml:image"/>
+              <xs:element ref="cnxml:audio"/>
+              <xs:element ref="cnxml:video"/>
+              <xs:element ref="cnxml:java-applet"/>
+              <xs:element ref="cnxml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:element ref="cnxml:labview"/>
+              <xs:element ref="cnxml:text"/>
+              <xs:element ref="cnxml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="alt" use="required"/>
+          <xs:attribute name="longdesc"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:item"/>
+          </xs:sequence>
+          <xs:attribute name="list-type">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="bulleted"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="mark-suffix"/>
+          <xs:attribute name="bullet-style"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="mark-prefix"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="item-sep"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list1">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:item"/>
+          </xs:sequence>
+          <xs:attribute name="mark-suffix"/>
+          <xs:attribute name="list-type" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="enumerated"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="number-style">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="arabic"/>
+                <xs:enumeration value="upper-alpha"/>
+                <xs:enumeration value="lower-alpha"/>
+                <xs:enumeration value="upper-roman"/>
+                <xs:enumeration value="lower-roman"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="start-value">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="1"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="mark-prefix"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="item-sep"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list2">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:item"/>
+          </xs:sequence>
+          <xs:attribute name="mark-suffix"/>
+          <xs:attribute name="list-type" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="labeled-item"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="mark-prefix"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="item-sep"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="table">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:element maxOccurs="unbounded" ref="cnxml:tgroup"/>
+        <xs:element minOccurs="0" ref="cnxml:caption"/>
+      </xs:sequence>
+      <xs:attribute name="frame">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="topbot"/>
+            <xs:enumeration value="all"/>
+            <xs:enumeration value="sides"/>
+            <xs:enumeration value="none"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="summary" use="required"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="tabstyle"/>
+      <xs:attribute name="tocentry">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="shortentry">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orient">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="port"/>
+            <xs:enumeration value="land"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="pgwide">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="type"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="rule">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:element maxOccurs="unbounded" ref="cnxml:statement"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="cnxml:proof"/>
+          <xs:element ref="cnxml:example"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="equation">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice minOccurs="0">
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:media_2"/>
+          <xs:element ref="mathml:math"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exercise">
+    <xs:complexType>
+      <xs:choice>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="cnxml:label"/>
+          <xs:group minOccurs="0" ref="mathml:title_3"/>
+          <xs:element ref="cnxml:problem"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:solution"/>
+          <xs:element minOccurs="0" ref="cnxml:commentary"/>
+        </xs:sequence>
+        <xs:element ref="qml:item"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="print-placement">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="here"/>
+            <xs:enumeration value="end"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="para">
+    <xs:sequence>
+      <xs:element name="para">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:element ref="cnxml:cite-title"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:list_6"/>
+              <xs:group ref="mathml:list_7"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:element ref="cnxml:footnote"/>
+              <xs:element ref="cnxml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:element ref="cnxml:div"/>
+              <xs:element ref="cnxml:definition"/>
+              <xs:element ref="cnxml:example"/>
+              <xs:element ref="cnxml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:list_2"/>
+              <xs:group ref="mathml:list_3"/>
+              <xs:element ref="cnxml:table"/>
+              <xs:element ref="cnxml:rule"/>
+              <xs:element ref="cnxml:equation"/>
+              <xs:element ref="cnxml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="para1">
+    <xs:sequence>
+      <xs:element name="para">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:quote_2"/>
+            <xs:group ref="mathml:preformat_2"/>
+            <xs:group ref="mathml:list_4"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="emphasis">
+    <xs:sequence>
+      <xs:element name="emphasis">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:element ref="mathml:math"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="term">
+    <xs:sequence>
+      <xs:element name="term">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:element ref="mathml:math"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="foreign">
+    <xs:sequence>
+      <xs:element name="foreign">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:element ref="mathml:math"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite">
+    <xs:sequence>
+      <xs:element name="cite">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:element ref="mathml:math"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="span">
+    <xs:sequence>
+      <xs:element name="span">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:element ref="mathml:math"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sup">
+    <xs:sequence>
+      <xs:element name="sup">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:element ref="mathml:math"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sub">
+    <xs:sequence>
+      <xs:element name="sub">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:element ref="mathml:math"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="code1">
+    <xs:sequence>
+      <xs:element name="code">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:element ref="mathml:math"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="quote1">
+    <xs:sequence>
+      <xs:element name="quote">
+        <xs:complexType mixed="true">
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="mathml:para_2"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:emphasis"/>
+              <xs:group ref="mathml:term"/>
+              <xs:group ref="mathml:foreign"/>
+              <xs:group ref="mathml:cite"/>
+              <xs:group ref="mathml:span"/>
+              <xs:group ref="mathml:sup"/>
+              <xs:group ref="mathml:sub"/>
+              <xs:group ref="mathml:code_2"/>
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:quote_2"/>
+              <xs:group ref="mathml:preformat_2"/>
+              <xs:group ref="mathml:list_4"/>
+            </xs:choice>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="preformat1">
+    <xs:sequence>
+      <xs:element name="preformat">
+        <xs:complexType mixed="true">
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="mathml:para_2"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:emphasis"/>
+              <xs:group ref="mathml:term"/>
+              <xs:group ref="mathml:foreign"/>
+              <xs:group ref="mathml:cite"/>
+              <xs:group ref="mathml:span"/>
+              <xs:group ref="mathml:sup"/>
+              <xs:group ref="mathml:sub"/>
+              <xs:group ref="mathml:code_2"/>
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:quote_2"/>
+              <xs:group ref="mathml:preformat_2"/>
+              <xs:group ref="mathml:list_4"/>
+            </xs:choice>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list3">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:item_3"/>
+          <xs:attribute name="list-type">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="bulleted"/>
+                <xs:enumeration value="enumerated"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="label">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:math"/>
+        <xs:group ref="mathml:span_2"/>
+        <xs:group ref="mathml:term_2"/>
+        <xs:group ref="mathml:cite_2"/>
+        <xs:element ref="cnxml:cite-title"/>
+        <xs:group ref="mathml:foreign_2"/>
+        <xs:group ref="mathml:emphasis_2"/>
+        <xs:group ref="mathml:sub_2"/>
+        <xs:group ref="mathml:sup_2"/>
+        <xs:group ref="mathml:code_3"/>
+        <xs:group ref="mathml:preformat_3"/>
+        <xs:group ref="mathml:quote_3"/>
+        <xs:group ref="mathml:note_2"/>
+        <xs:group ref="mathml:list_5"/>
+        <xs:group ref="mathml:list_6"/>
+        <xs:group ref="mathml:list_7"/>
+        <xs:group ref="mathml:media_2"/>
+        <xs:element ref="cnxml:footnote"/>
+        <xs:element ref="cnxml:link"/>
+        <xs:element ref="cnxml:newline"/>
+        <xs:element ref="cnxml:space"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="link">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:math"/>
+        <xs:group ref="mathml:span_2"/>
+        <xs:group ref="mathml:term_2"/>
+        <xs:group ref="mathml:cite_2"/>
+        <xs:element ref="cnxml:cite-title"/>
+        <xs:group ref="mathml:foreign_2"/>
+        <xs:group ref="mathml:emphasis_2"/>
+        <xs:group ref="mathml:sub_2"/>
+        <xs:group ref="mathml:sup_2"/>
+        <xs:group ref="mathml:code_3"/>
+        <xs:group ref="mathml:preformat_3"/>
+        <xs:group ref="mathml:quote_3"/>
+        <xs:group ref="mathml:note_2"/>
+        <xs:group ref="mathml:list_5"/>
+        <xs:group ref="mathml:list_6"/>
+        <xs:group ref="mathml:list_7"/>
+        <xs:group ref="mathml:media_2"/>
+        <xs:element ref="cnxml:footnote"/>
+        <xs:element ref="cnxml:link"/>
+        <xs:element ref="cnxml:newline"/>
+        <xs:element ref="cnxml:space"/>
+      </xs:choice>
+      <xs:attribute name="strength">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="window">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="replace"/>
+            <xs:enumeration value="new"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="url"/>
+      <xs:attribute name="document"/>
+      <xs:attribute name="version"/>
+      <xs:attribute name="target-id"/>
+      <xs:attribute name="resource"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="title1">
+    <xs:sequence>
+      <xs:element name="title">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:element ref="cnxml:cite-title"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:list_7"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:element ref="cnxml:footnote"/>
+            <xs:element ref="cnxml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="span1">
+    <xs:sequence>
+      <xs:element name="span">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:element ref="cnxml:cite-title"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:list_7"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:element ref="cnxml:footnote"/>
+            <xs:element ref="cnxml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="effect">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="bold"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="italics"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="underline"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="normal"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="smallcaps"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="term1">
+    <xs:sequence>
+      <xs:element name="term">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:element ref="cnxml:cite-title"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:list_7"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:element ref="cnxml:footnote"/>
+            <xs:element ref="cnxml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite1">
+    <xs:sequence>
+      <xs:element name="cite">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:element ref="cnxml:cite-title"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:list_7"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:element ref="cnxml:footnote"/>
+            <xs:element ref="cnxml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="cite-title">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:math"/>
+        <xs:group ref="mathml:span_2"/>
+        <xs:group ref="mathml:term_2"/>
+        <xs:group ref="mathml:cite_2"/>
+        <xs:element ref="cnxml:cite-title"/>
+        <xs:group ref="mathml:foreign_2"/>
+        <xs:group ref="mathml:emphasis_2"/>
+        <xs:group ref="mathml:sub_2"/>
+        <xs:group ref="mathml:sup_2"/>
+        <xs:group ref="mathml:code_3"/>
+        <xs:group ref="mathml:preformat_3"/>
+        <xs:group ref="mathml:quote_3"/>
+        <xs:group ref="mathml:note_2"/>
+        <xs:group ref="mathml:list_5"/>
+        <xs:group ref="mathml:list_6"/>
+        <xs:group ref="mathml:list_7"/>
+        <xs:group ref="mathml:media_2"/>
+        <xs:element ref="cnxml:footnote"/>
+        <xs:element ref="cnxml:link"/>
+        <xs:element ref="cnxml:newline"/>
+        <xs:element ref="cnxml:space"/>
+      </xs:choice>
+      <xs:attribute name="pub-type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="article"/>
+            <xs:enumeration value="book"/>
+            <xs:enumeration value="booklet"/>
+            <xs:enumeration value="conference"/>
+            <xs:enumeration value="inbook"/>
+            <xs:enumeration value="incollection"/>
+            <xs:enumeration value="inproceedings"/>
+            <xs:enumeration value="manual"/>
+            <xs:enumeration value="mastersthesis"/>
+            <xs:enumeration value="misc"/>
+            <xs:enumeration value="phdthesis"/>
+            <xs:enumeration value="proceedings"/>
+            <xs:enumeration value="techreport"/>
+            <xs:enumeration value="unpublished"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="foreign1">
+    <xs:sequence>
+      <xs:element name="foreign">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:element ref="cnxml:cite-title"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:list_7"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:element ref="cnxml:footnote"/>
+            <xs:element ref="cnxml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="emphasis1">
+    <xs:sequence>
+      <xs:element name="emphasis">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:element ref="cnxml:cite-title"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:list_7"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:element ref="cnxml:footnote"/>
+            <xs:element ref="cnxml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="effect">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="bold"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="italics"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="underline"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="normal"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="smallcaps"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sub1">
+    <xs:sequence>
+      <xs:element name="sub">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:element ref="cnxml:cite-title"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:list_7"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:element ref="cnxml:footnote"/>
+            <xs:element ref="cnxml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sup1">
+    <xs:sequence>
+      <xs:element name="sup">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:element ref="cnxml:cite-title"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:list_7"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:element ref="cnxml:footnote"/>
+            <xs:element ref="cnxml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="code2">
+    <xs:sequence>
+      <xs:element name="code">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:element ref="cnxml:cite-title"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:list_7"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:element ref="cnxml:footnote"/>
+            <xs:element ref="cnxml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="lang"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="preformat2">
+    <xs:sequence>
+      <xs:element name="preformat">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:element ref="cnxml:cite-title"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:list_7"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:element ref="cnxml:footnote"/>
+            <xs:element ref="cnxml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="display" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="quote2">
+    <xs:sequence>
+      <xs:element name="quote">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:element ref="cnxml:cite-title"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:list_6"/>
+              <xs:group ref="mathml:list_7"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:element ref="cnxml:footnote"/>
+              <xs:element ref="cnxml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="display" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+          <xs:attribute name="type"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="note1">
+    <xs:sequence>
+      <xs:element name="note">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:element ref="cnxml:cite-title"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:list_6"/>
+              <xs:group ref="mathml:list_7"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:element ref="cnxml:footnote"/>
+              <xs:element ref="cnxml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="display" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="type">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:token">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="note"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="aside"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="warning"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="tip"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="important"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list4">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:item_4"/>
+          </xs:sequence>
+          <xs:attribute name="list-type">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="bulleted"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="mark-suffix"/>
+          <xs:attribute name="bullet-style"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="mark-prefix"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="display" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="item-sep"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list5">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:item_4"/>
+          </xs:sequence>
+          <xs:attribute name="mark-suffix"/>
+          <xs:attribute name="list-type" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="enumerated"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="number-style">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="arabic"/>
+                <xs:enumeration value="upper-alpha"/>
+                <xs:enumeration value="lower-alpha"/>
+                <xs:enumeration value="upper-roman"/>
+                <xs:enumeration value="lower-roman"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="start-value">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="1"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="mark-prefix"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="display" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="item-sep"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list6">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:item_4"/>
+          </xs:sequence>
+          <xs:attribute name="mark-suffix"/>
+          <xs:attribute name="list-type" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="labeled-item"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="mark-prefix"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="display" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="item-sep"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="media1">
+    <xs:sequence>
+      <xs:element name="media">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+            <xs:choice>
+              <xs:element ref="cnxml:object"/>
+              <xs:element ref="cnxml:image"/>
+              <xs:element ref="cnxml:audio"/>
+              <xs:element ref="cnxml:video"/>
+              <xs:element ref="cnxml:java-applet"/>
+              <xs:element ref="cnxml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:element ref="cnxml:labview"/>
+              <xs:element ref="cnxml:text"/>
+              <xs:element ref="cnxml:download"/>
+            </xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="cnxml:object"/>
+              <xs:element ref="cnxml:image"/>
+              <xs:element ref="cnxml:audio"/>
+              <xs:element ref="cnxml:video"/>
+              <xs:element ref="cnxml:java-applet"/>
+              <xs:element ref="cnxml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:element ref="cnxml:labview"/>
+              <xs:element ref="cnxml:text"/>
+              <xs:element ref="cnxml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="alt" use="required"/>
+          <xs:attribute name="longdesc"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="footnote">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="mathml:para"/>
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:group ref="mathml:media_2"/>
+          <xs:element ref="cnxml:footnote"/>
+          <xs:element ref="cnxml:link"/>
+          <xs:element ref="cnxml:newline"/>
+          <xs:element ref="cnxml:space"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="newline">
+    <xs:complexType>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="count">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="effect">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="italics"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="underline"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="smallcaps"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="space">
+    <xs:complexType>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="count">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="effect">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="italics"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="underline"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="smallcaps"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="seealso">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group maxOccurs="unbounded" ref="mathml:term_2"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="meaning">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="mathml:para"/>
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:group ref="mathml:media_2"/>
+          <xs:element ref="cnxml:footnote"/>
+          <xs:element ref="cnxml:link"/>
+          <xs:element ref="cnxml:newline"/>
+          <xs:element ref="cnxml:space"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subfigure">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:media_2"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:code"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="cnxml:caption"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="caption">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:math"/>
+        <xs:group ref="mathml:span_2"/>
+        <xs:group ref="mathml:term_2"/>
+        <xs:group ref="mathml:cite_2"/>
+        <xs:element ref="cnxml:cite-title"/>
+        <xs:group ref="mathml:foreign_2"/>
+        <xs:group ref="mathml:emphasis_2"/>
+        <xs:group ref="mathml:sub_2"/>
+        <xs:group ref="mathml:sup_2"/>
+        <xs:group ref="mathml:code_3"/>
+        <xs:group ref="mathml:preformat_3"/>
+        <xs:group ref="mathml:quote_3"/>
+        <xs:group ref="mathml:note_2"/>
+        <xs:group ref="mathml:list_5"/>
+        <xs:group ref="mathml:list_6"/>
+        <xs:group ref="mathml:list_7"/>
+        <xs:group ref="mathml:media_2"/>
+        <xs:element ref="cnxml:footnote"/>
+        <xs:element ref="cnxml:link"/>
+        <xs:element ref="cnxml:newline"/>
+        <xs:element ref="cnxml:space"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="longdesc">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="mathml:para"/>
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:group ref="mathml:media_2"/>
+          <xs:element ref="cnxml:footnote"/>
+          <xs:element ref="cnxml:link"/>
+          <xs:element ref="cnxml:newline"/>
+          <xs:element ref="cnxml:space"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="object">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:element ref="cnxml:object"/>
+          <xs:element ref="cnxml:image"/>
+          <xs:element ref="cnxml:audio"/>
+          <xs:element ref="cnxml:video"/>
+          <xs:element ref="cnxml:java-applet"/>
+          <xs:element ref="cnxml:flash"/>
+          <xs:element ref="cnxml:iframe"/>
+          <xs:element ref="cnxml:labview"/>
+          <xs:element ref="cnxml:text"/>
+          <xs:element ref="cnxml:download"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="mime-type" use="required"/>
+      <xs:attribute name="for">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="online"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="pdf"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="longdesc"/>
+      <xs:attribute name="src" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="image">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:element ref="cnxml:object"/>
+          <xs:element ref="cnxml:image"/>
+          <xs:element ref="cnxml:audio"/>
+          <xs:element ref="cnxml:video"/>
+          <xs:element ref="cnxml:java-applet"/>
+          <xs:element ref="cnxml:flash"/>
+          <xs:element ref="cnxml:iframe"/>
+          <xs:element ref="cnxml:labview"/>
+          <xs:element ref="cnxml:text"/>
+          <xs:element ref="cnxml:download"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="mime-type" use="required"/>
+      <xs:attribute name="for">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="online"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="pdf"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="longdesc"/>
+      <xs:attribute name="src" use="required"/>
+      <xs:attribute name="print-width"/>
+      <xs:attribute name="thumbnail"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="audio">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:element ref="cnxml:object"/>
+          <xs:element ref="cnxml:image"/>
+          <xs:element ref="cnxml:audio"/>
+          <xs:element ref="cnxml:video"/>
+          <xs:element ref="cnxml:java-applet"/>
+          <xs:element ref="cnxml:flash"/>
+          <xs:element ref="cnxml:iframe"/>
+          <xs:element ref="cnxml:labview"/>
+          <xs:element ref="cnxml:text"/>
+          <xs:element ref="cnxml:download"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="mime-type" use="required"/>
+      <xs:attribute name="for">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="online"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="pdf"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="longdesc"/>
+      <xs:attribute name="src" use="required"/>
+      <xs:attribute name="standby"/>
+      <xs:attribute name="autoplay">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="loop">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="controller">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="volume">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="100"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="video">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:element ref="cnxml:object"/>
+          <xs:element ref="cnxml:image"/>
+          <xs:element ref="cnxml:audio"/>
+          <xs:element ref="cnxml:video"/>
+          <xs:element ref="cnxml:java-applet"/>
+          <xs:element ref="cnxml:flash"/>
+          <xs:element ref="cnxml:iframe"/>
+          <xs:element ref="cnxml:labview"/>
+          <xs:element ref="cnxml:text"/>
+          <xs:element ref="cnxml:download"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="mime-type" use="required"/>
+      <xs:attribute name="for">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="online"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="pdf"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="longdesc"/>
+      <xs:attribute name="src" use="required"/>
+      <xs:attribute name="standby"/>
+      <xs:attribute name="autoplay">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="loop">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="controller">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="volume">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="100"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="java-applet">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:element ref="cnxml:object"/>
+          <xs:element ref="cnxml:image"/>
+          <xs:element ref="cnxml:audio"/>
+          <xs:element ref="cnxml:video"/>
+          <xs:element ref="cnxml:java-applet"/>
+          <xs:element ref="cnxml:flash"/>
+          <xs:element ref="cnxml:iframe"/>
+          <xs:element ref="cnxml:labview"/>
+          <xs:element ref="cnxml:text"/>
+          <xs:element ref="cnxml:download"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="mime-type" use="required"/>
+      <xs:attribute name="for">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="online"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="pdf"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="longdesc"/>
+      <xs:attribute name="src"/>
+      <xs:attribute name="codebase"/>
+      <xs:attribute name="code" use="required"/>
+      <xs:attribute name="archive"/>
+      <xs:attribute name="name"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="flash">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:element ref="cnxml:object"/>
+          <xs:element ref="cnxml:image"/>
+          <xs:element ref="cnxml:audio"/>
+          <xs:element ref="cnxml:video"/>
+          <xs:element ref="cnxml:java-applet"/>
+          <xs:element ref="cnxml:flash"/>
+          <xs:element ref="cnxml:iframe"/>
+          <xs:element ref="cnxml:labview"/>
+          <xs:element ref="cnxml:text"/>
+          <xs:element ref="cnxml:download"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="mime-type" use="required"/>
+      <xs:attribute name="for">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="online"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="pdf"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="longdesc"/>
+      <xs:attribute name="src" use="required"/>
+      <xs:attribute name="wmode">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="window"/>
+            <xs:enumeration value="opaque"/>
+            <xs:enumeration value="transparent"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="loop">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="quality">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="low"/>
+            <xs:enumeration value="autolow"/>
+            <xs:enumeration value="autohigh"/>
+            <xs:enumeration value="medium"/>
+            <xs:enumeration value="high"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="scale">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="default"/>
+            <xs:enumeration value="noorder"/>
+            <xs:enumeration value="exactfit"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="bgcolor">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:pattern value="#[a-fA-F0-9]{6}"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="flash-vars"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="iframe">
+    <xs:complexType>
+      <xs:attribute name="src" use="required"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="labview">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:element ref="cnxml:object"/>
+          <xs:element ref="cnxml:image"/>
+          <xs:element ref="cnxml:audio"/>
+          <xs:element ref="cnxml:video"/>
+          <xs:element ref="cnxml:java-applet"/>
+          <xs:element ref="cnxml:flash"/>
+          <xs:element ref="cnxml:iframe"/>
+          <xs:element ref="cnxml:labview"/>
+          <xs:element ref="cnxml:text"/>
+          <xs:element ref="cnxml:download"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="mime-type" use="required"/>
+      <xs:attribute name="for">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="online"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="pdf"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="longdesc"/>
+      <xs:attribute name="src" use="required"/>
+      <xs:attribute name="viname" use="required"/>
+      <xs:attribute name="version" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="7.0"/>
+            <xs:enumeration value="8.0"/>
+            <xs:enumeration value="8.2"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="text">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="mathml:para"/>
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:group ref="mathml:media_2"/>
+          <xs:element ref="cnxml:footnote"/>
+          <xs:element ref="cnxml:link"/>
+          <xs:element ref="cnxml:newline"/>
+          <xs:element ref="cnxml:space"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="mime-type"/>
+      <xs:attribute name="longdesc"/>
+      <xs:attribute name="src"/>
+      <xs:attribute name="for">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="online"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="pdf"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="download">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:element ref="cnxml:object"/>
+          <xs:element ref="cnxml:image"/>
+          <xs:element ref="cnxml:audio"/>
+          <xs:element ref="cnxml:video"/>
+          <xs:element ref="cnxml:java-applet"/>
+          <xs:element ref="cnxml:flash"/>
+          <xs:element ref="cnxml:iframe"/>
+          <xs:element ref="cnxml:labview"/>
+          <xs:element ref="cnxml:text"/>
+          <xs:element ref="cnxml:download"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="mime-type" use="required"/>
+      <xs:attribute name="for">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="online"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="pdf"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="longdesc"/>
+      <xs:attribute name="src" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="item">
+    <xs:sequence>
+      <xs:element name="item">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para"/>
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:element ref="cnxml:cite-title"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:list_6"/>
+              <xs:group ref="mathml:list_7"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:element ref="cnxml:footnote"/>
+              <xs:element ref="cnxml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:element ref="cnxml:div"/>
+              <xs:element ref="cnxml:definition"/>
+              <xs:element ref="cnxml:example"/>
+              <xs:element ref="cnxml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:list_2"/>
+              <xs:group ref="mathml:list_3"/>
+              <xs:element ref="cnxml:table"/>
+              <xs:element ref="cnxml:rule"/>
+              <xs:element ref="cnxml:equation"/>
+              <xs:element ref="cnxml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="tgroup">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:spanspec"/>
+        <xs:element minOccurs="0" ref="cnxml:thead"/>
+        <xs:element minOccurs="0" ref="cnxml:tfoot"/>
+        <xs:element ref="cnxml:tbody"/>
+      </xs:sequence>
+      <xs:attribute name="cols" use="required"/>
+      <xs:attribute name="tgroupstyle"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="statement">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="cnxml:section"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+          <xs:group ref="mathml:para"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="proof">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="cnxml:section"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+          <xs:group ref="mathml:para"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="problem">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="cnxml:section"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+          <xs:group ref="mathml:para"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="solution">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="cnxml:section"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+          <xs:group ref="mathml:para"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="print-placement">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="here"/>
+            <xs:enumeration value="end"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="commentary">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="cnxml:label"/>
+        <xs:group minOccurs="0" ref="mathml:title_3"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="mathml:para"/>
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:span_2"/>
+          <xs:group ref="mathml:term_2"/>
+          <xs:group ref="mathml:cite_2"/>
+          <xs:element ref="cnxml:cite-title"/>
+          <xs:group ref="mathml:foreign_2"/>
+          <xs:group ref="mathml:emphasis_2"/>
+          <xs:group ref="mathml:sub_2"/>
+          <xs:group ref="mathml:sup_2"/>
+          <xs:group ref="mathml:code_3"/>
+          <xs:group ref="mathml:preformat_3"/>
+          <xs:group ref="mathml:quote_3"/>
+          <xs:group ref="mathml:note_2"/>
+          <xs:group ref="mathml:list_5"/>
+          <xs:group ref="mathml:list_6"/>
+          <xs:group ref="mathml:list_7"/>
+          <xs:group ref="mathml:media_2"/>
+          <xs:element ref="cnxml:footnote"/>
+          <xs:element ref="cnxml:link"/>
+          <xs:element ref="cnxml:newline"/>
+          <xs:element ref="cnxml:space"/>
+          <xs:element ref="cnxml:div"/>
+          <xs:element ref="cnxml:definition"/>
+          <xs:element ref="cnxml:example"/>
+          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:code"/>
+          <xs:group ref="mathml:preformat"/>
+          <xs:group ref="mathml:quote"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
+          <xs:group ref="mathml:list"/>
+          <xs:group ref="mathml:list_2"/>
+          <xs:group ref="mathml:list_3"/>
+          <xs:element ref="cnxml:table"/>
+          <xs:element ref="cnxml:rule"/>
+          <xs:element ref="cnxml:equation"/>
+          <xs:element ref="cnxml:exercise"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="item1">
+    <xs:sequence>
+      <xs:element name="item">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:quote_2"/>
+            <xs:group ref="mathml:preformat_2"/>
+            <xs:group ref="mathml:list_4"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="item2">
+    <xs:sequence>
+      <xs:element name="item">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:element ref="cnxml:cite-title"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:list_6"/>
+              <xs:group ref="mathml:list_7"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:element ref="cnxml:footnote"/>
+              <xs:element ref="cnxml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="param">
+    <xs:complexType>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="name" use="required"/>
+      <xs:attribute name="value" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="colspec">
+    <xs:complexType>
+      <xs:attribute name="colnum"/>
+      <xs:attribute name="colname"/>
+      <xs:attribute name="colwidth"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="spanspec">
+    <xs:complexType>
+      <xs:attribute name="namest"/>
+      <xs:attribute name="nameend"/>
+      <xs:attribute name="spanname" use="required"/>
+      <xs:attribute name="colwidth"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="thead">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+        <xs:element maxOccurs="unbounded" ref="cnxml:row"/>
+      </xs:sequence>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tfoot">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+        <xs:element maxOccurs="unbounded" ref="cnxml:row"/>
+      </xs:sequence>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tbody">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="cnxml:row"/>
+      </xs:sequence>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="row">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="cnxml:entry"/>
+        <xs:element ref="cnxml:entrytbl"/>
+      </xs:choice>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="entry">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="mathml:para"/>
+        <xs:element ref="mathml:math"/>
+        <xs:group ref="mathml:span_2"/>
+        <xs:group ref="mathml:term_2"/>
+        <xs:group ref="mathml:cite_2"/>
+        <xs:element ref="cnxml:cite-title"/>
+        <xs:group ref="mathml:foreign_2"/>
+        <xs:group ref="mathml:emphasis_2"/>
+        <xs:group ref="mathml:sub_2"/>
+        <xs:group ref="mathml:sup_2"/>
+        <xs:group ref="mathml:code_3"/>
+        <xs:group ref="mathml:preformat_3"/>
+        <xs:group ref="mathml:quote_3"/>
+        <xs:group ref="mathml:note_2"/>
+        <xs:group ref="mathml:list_5"/>
+        <xs:group ref="mathml:list_6"/>
+        <xs:group ref="mathml:list_7"/>
+        <xs:group ref="mathml:media_2"/>
+        <xs:element ref="cnxml:footnote"/>
+        <xs:element ref="cnxml:link"/>
+        <xs:element ref="cnxml:newline"/>
+        <xs:element ref="cnxml:space"/>
+        <xs:element ref="cnxml:div"/>
+        <xs:element ref="cnxml:definition"/>
+        <xs:element ref="cnxml:example"/>
+        <xs:element ref="cnxml:figure"/>
+        <xs:group ref="mathml:code"/>
+        <xs:group ref="mathml:preformat"/>
+        <xs:group ref="mathml:quote"/>
+        <xs:group ref="mathml:note"/>
+        <xs:group ref="mathml:media"/>
+        <xs:group ref="mathml:list"/>
+        <xs:group ref="mathml:list_2"/>
+        <xs:group ref="mathml:list_3"/>
+        <xs:element ref="cnxml:table"/>
+        <xs:element ref="cnxml:rule"/>
+        <xs:element ref="cnxml:equation"/>
+        <xs:element ref="cnxml:exercise"/>
+      </xs:choice>
+      <xs:attribute name="colname"/>
+      <xs:attribute name="namest"/>
+      <xs:attribute name="nameend"/>
+      <xs:attribute name="spanname"/>
+      <xs:attribute name="morerows"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="rotate">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="entrytbl">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:spanspec"/>
+        <xs:element minOccurs="0" ref="cnxml:thead"/>
+        <xs:element ref="cnxml:tbody"/>
+      </xs:sequence>
+      <xs:attribute name="cols" use="required"/>
+      <xs:attribute name="tgroupstyle"/>
+      <xs:attribute name="colname"/>
+      <xs:attribute name="spanname"/>
+      <xs:attribute name="namest"/>
+      <xs:attribute name="nameend"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/client/static/xsd/mathml.xsd
+++ b/client/static/xsd/mathml.xsd
@@ -1,0 +1,8622 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/1998/Math/MathML" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+  <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns1.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:group name="title">
+    <xs:sequence>
+      <xs:group ref="cnxml:title"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="code">
+    <xs:sequence>
+      <xs:group ref="cnxml:code"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="preformat">
+    <xs:sequence>
+      <xs:group ref="cnxml:preformat"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="quote">
+    <xs:sequence>
+      <xs:group ref="cnxml:quote"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="note">
+    <xs:sequence>
+      <xs:group ref="cnxml:note"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="media">
+    <xs:sequence>
+      <xs:group ref="cnxml:media"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list">
+    <xs:sequence>
+      <xs:group ref="cnxml:list"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:list1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:list2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="para">
+    <xs:sequence>
+      <xs:group ref="cnxml:para"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="para_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:para1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="emphasis">
+    <xs:sequence>
+      <xs:group ref="cnxml:emphasis"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="term">
+    <xs:sequence>
+      <xs:group ref="cnxml:term"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="foreign">
+    <xs:sequence>
+      <xs:group ref="cnxml:foreign"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite">
+    <xs:sequence>
+      <xs:group ref="cnxml:cite"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="span">
+    <xs:sequence>
+      <xs:group ref="cnxml:span"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sup">
+    <xs:sequence>
+      <xs:group ref="cnxml:sup"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sub">
+    <xs:sequence>
+      <xs:group ref="cnxml:sub"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="code_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:code1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="math">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="macros"/>
+      <xs:attribute name="mode"/>
+      <xs:attribute name="display"/>
+      <xs:attribute name="type"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="baseline"/>
+      <xs:attribute name="overflow">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="scroll"/>
+            <xs:enumeration value="elide"/>
+            <xs:enumeration value="truncate"/>
+            <xs:enumeration value="scale"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="altimg"/>
+      <xs:attribute name="alttext"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="quote_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:quote1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="preformat_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:preformat1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:list3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="title_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:title1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="span_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:span1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="term_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:term1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:cite1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="foreign_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:foreign1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="emphasis_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:emphasis1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sub_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:sub1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sup_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:sup1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="code_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:code2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="preformat_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:preformat2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="quote_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:quote2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="note_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:note1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list_5">
+    <xs:sequence>
+      <xs:group ref="cnxml:list4"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list_6">
+    <xs:sequence>
+      <xs:group ref="cnxml:list5"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list_7">
+    <xs:sequence>
+      <xs:group ref="cnxml:list6"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="media_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:media1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="item">
+    <xs:sequence>
+      <xs:group ref="cnxml:item"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="mi">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mglyph"/>
+        <xs:element ref="mathml:malignmark"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="fontsize"/>
+      <xs:attribute name="fontweight">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="bold"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontstyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="italic"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontfamily"/>
+      <xs:attribute name="color"/>
+      <xs:attribute name="mathvariant"/>
+      <xs:attribute name="mathsize"/>
+      <xs:attribute name="mathcolor"/>
+      <xs:attribute name="mathbackground"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mn">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mglyph"/>
+        <xs:element ref="mathml:malignmark"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="fontsize"/>
+      <xs:attribute name="fontweight">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="bold"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontstyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="italic"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontfamily"/>
+      <xs:attribute name="color"/>
+      <xs:attribute name="mathvariant"/>
+      <xs:attribute name="mathsize"/>
+      <xs:attribute name="mathcolor"/>
+      <xs:attribute name="mathbackground"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mo">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mglyph"/>
+        <xs:element ref="mathml:malignmark"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="fontsize"/>
+      <xs:attribute name="fontweight">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="bold"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontstyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="italic"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontfamily"/>
+      <xs:attribute name="color"/>
+      <xs:attribute name="mathvariant"/>
+      <xs:attribute name="mathsize"/>
+      <xs:attribute name="mathcolor"/>
+      <xs:attribute name="mathbackground"/>
+      <xs:attribute name="form">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="prefix"/>
+            <xs:enumeration value="infix"/>
+            <xs:enumeration value="postfix"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fence">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="separator">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="lspace"/>
+      <xs:attribute name="rspace"/>
+      <xs:attribute name="stretchy">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="symmetric">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="maxsize"/>
+      <xs:attribute name="minsize"/>
+      <xs:attribute name="largeop">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="movablelimits">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="accent">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mtext">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mglyph"/>
+        <xs:element ref="mathml:malignmark"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="fontsize"/>
+      <xs:attribute name="fontweight">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="bold"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontstyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="italic"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontfamily"/>
+      <xs:attribute name="color"/>
+      <xs:attribute name="mathvariant"/>
+      <xs:attribute name="mathsize"/>
+      <xs:attribute name="mathcolor"/>
+      <xs:attribute name="mathbackground"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ms">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mglyph"/>
+        <xs:element ref="mathml:malignmark"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="fontsize"/>
+      <xs:attribute name="fontweight">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="bold"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontstyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="italic"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontfamily"/>
+      <xs:attribute name="color"/>
+      <xs:attribute name="mathvariant"/>
+      <xs:attribute name="mathsize"/>
+      <xs:attribute name="mathcolor"/>
+      <xs:attribute name="mathbackground"/>
+      <xs:attribute name="lquote"/>
+      <xs:attribute name="rquote"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mspace">
+    <xs:complexType>
+      <xs:attribute name="width"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="depth"/>
+      <xs:attribute name="linebreak"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mrow">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mfrac">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="bevelled"/>
+      <xs:attribute name="numalign"/>
+      <xs:attribute name="denomalign"/>
+      <xs:attribute name="linethickness"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msqrt">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mroot">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="menclose">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="notation"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mstyle">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="fontsize"/>
+      <xs:attribute name="fontweight">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="bold"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontstyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="italic"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontfamily"/>
+      <xs:attribute name="color"/>
+      <xs:attribute name="mathvariant"/>
+      <xs:attribute name="mathsize"/>
+      <xs:attribute name="mathcolor"/>
+      <xs:attribute name="mathbackground"/>
+      <xs:attribute name="form">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="prefix"/>
+            <xs:enumeration value="infix"/>
+            <xs:enumeration value="postfix"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fence">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="separator">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="lspace"/>
+      <xs:attribute name="rspace"/>
+      <xs:attribute name="stretchy">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="symmetric">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="maxsize"/>
+      <xs:attribute name="minsize"/>
+      <xs:attribute name="largeop">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="movablelimits">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="accent">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="lquote"/>
+      <xs:attribute name="rquote"/>
+      <xs:attribute name="linethickness"/>
+      <xs:attribute name="scriptlevel"/>
+      <xs:attribute name="scriptsizemultiplier"/>
+      <xs:attribute name="scriptminsize"/>
+      <xs:attribute name="background"/>
+      <xs:attribute name="veryverythinmathspace"/>
+      <xs:attribute name="verythinmathspace"/>
+      <xs:attribute name="thinmathspace"/>
+      <xs:attribute name="mediummathspace"/>
+      <xs:attribute name="thickmathspace"/>
+      <xs:attribute name="verythickmathspace"/>
+      <xs:attribute name="veryverythickmathspace"/>
+      <xs:attribute name="open"/>
+      <xs:attribute name="close"/>
+      <xs:attribute name="separators"/>
+      <xs:attribute name="subscriptshift"/>
+      <xs:attribute name="superscriptshift"/>
+      <xs:attribute name="accentunder">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align"/>
+      <xs:attribute name="rowalign"/>
+      <xs:attribute name="columnalign"/>
+      <xs:attribute name="columnwidth"/>
+      <xs:attribute name="groupalign"/>
+      <xs:attribute name="alignmentscope"/>
+      <xs:attribute name="side">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="leftoverlap"/>
+            <xs:enumeration value="rightoverlap"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowspacing"/>
+      <xs:attribute name="columnspacing"/>
+      <xs:attribute name="rowlines"/>
+      <xs:attribute name="columnlines"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="frame">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="solid"/>
+            <xs:enumeration value="dashed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="framespacing"/>
+      <xs:attribute name="equalrows"/>
+      <xs:attribute name="equalcolumns"/>
+      <xs:attribute name="displaystyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowspan"/>
+      <xs:attribute name="columnspan"/>
+      <xs:attribute name="edge">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="actiontype"/>
+      <xs:attribute name="selection"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="merror">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mpadded">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="height"/>
+      <xs:attribute name="depth"/>
+      <xs:attribute name="lspace"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mphantom">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mfenced">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="open"/>
+      <xs:attribute name="close"/>
+      <xs:attribute name="separators"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msub">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="subscriptshift"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msup">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="superscriptshift"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msubsup">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="subscriptshift"/>
+      <xs:attribute name="superscriptshift"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="munder">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="accentunder">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mover">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="accent">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="munderover">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="accent">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="accentunder">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mmultiscripts">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="subscriptshift"/>
+      <xs:attribute name="superscriptshift"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mtable">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="align"/>
+      <xs:attribute name="rowalign"/>
+      <xs:attribute name="columnalign"/>
+      <xs:attribute name="columnwidth"/>
+      <xs:attribute name="groupalign"/>
+      <xs:attribute name="alignmentscope"/>
+      <xs:attribute name="side">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="leftoverlap"/>
+            <xs:enumeration value="rightoverlap"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowspacing"/>
+      <xs:attribute name="columnspacing"/>
+      <xs:attribute name="rowlines"/>
+      <xs:attribute name="columnlines"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="frame">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="solid"/>
+            <xs:enumeration value="dashed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="framespacing"/>
+      <xs:attribute name="equalrows"/>
+      <xs:attribute name="equalcolumns"/>
+      <xs:attribute name="displaystyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mtr">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="rowalign"/>
+      <xs:attribute name="columnalign"/>
+      <xs:attribute name="groupalign"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mlabeledtr">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="rowalign"/>
+      <xs:attribute name="columnalign"/>
+      <xs:attribute name="groupalign"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mtd">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="rowalign"/>
+      <xs:attribute name="columnalign"/>
+      <xs:attribute name="groupalign"/>
+      <xs:attribute name="rowspan"/>
+      <xs:attribute name="columnspan"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="maligngroup">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="groupalign"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="malignmark">
+    <xs:complexType>
+      <xs:attribute name="edge">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="maction">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:declare"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="actiontype"/>
+      <xs:attribute name="selection"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ci">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mglyph"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="type"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="csymbol">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mglyph"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="encoding"/>
+      <xs:attribute name="type"/>
+      <xs:attribute name="definitionURL"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cn">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mglyph"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="type"/>
+      <xs:attribute name="base"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="integers">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="reals">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="rationals">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="naturalnumbers">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="complexes">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="primes">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exponentiale">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="imaginaryi">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="notanumber">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="true">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="false">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="emptyset">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="pi">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="eulergamma">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="infinity">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="apply">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fn">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="lambda">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="reln">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="interval">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="closure"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="list">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="order"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="matrix">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="matrixrow">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="set">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="vector">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="piecewise">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="mathml:piece"/>
+        <xs:element minOccurs="0" ref="mathml:otherwise"/>
+      </xs:sequence>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="semantics">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="declare">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="type"/>
+      <xs:attribute name="scope"/>
+      <xs:attribute name="nargs"/>
+      <xs:attribute name="occurrence"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="item_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:item1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="item_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:item2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="mglyph">
+    <xs:complexType>
+      <xs:attribute name="alt"/>
+      <xs:attribute name="fontfamily"/>
+      <xs:attribute name="index"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mprescripts">
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="none">
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="sep">
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="condition">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="annotation">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="annotation-xml">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mprescripts"/>
+        <xs:element ref="mathml:none"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:mglyph"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:piece"/>
+        <xs:element ref="mathml:otherwise"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maction"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:math"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="lowlimit">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="uplimit">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bvar">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="degree">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="logbase">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="momentabout">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="domainofapplication">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="inverse">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ident">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="domain">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="codomain">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="image">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="abs">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conjugate">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exp">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="factorial">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arg">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="real">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="imaginary">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="floor">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ceiling">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="not">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ln">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sin">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cos">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tan">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sec">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="csc">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cot">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sinh">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cosh">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tanh">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sech">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="csch">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="coth">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arcsin">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arccos">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arctan">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arccosh">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arccot">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arccoth">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arccsc">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arccsch">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arcsec">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arcsech">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arcsinh">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arctanh">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="determinant">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="transpose">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="card">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="quotient">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="divide">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="power">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="rem">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="implies">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="vectorproduct">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="scalarproduct">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="outerproduct">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="setdiff">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="compose">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="plus">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="times">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="max">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="min">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="gcd">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="lcm">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="and">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="or">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="xor">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="union">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="intersect">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cartesianproduct">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mean">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sdev">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="variance">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="median">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mode">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="selector">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="minus">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="log">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="int">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="diff">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="partialdiff">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="divergence">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="grad">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="curl">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="laplacian">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sum">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="product">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="limit">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="moment">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exists">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="forall">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="neq">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="factorof">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="in">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="notin">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="notsubset">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="notprsubset">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tendsto">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+      <xs:attribute name="type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="eq">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="leq">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="lt">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="geq">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="gt">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="equivalent">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="approx">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subset">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="prsubset">
+    <xs:complexType>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+      <xs:attribute name="definitionURL"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="piece">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="otherwise">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mathml:csymbol"/>
+        <xs:element ref="mathml:ci"/>
+        <xs:element ref="mathml:cn"/>
+        <xs:element ref="mathml:apply"/>
+        <xs:element ref="mathml:reln"/>
+        <xs:element ref="mathml:lambda"/>
+        <xs:element ref="mathml:condition"/>
+        <xs:element ref="mathml:declare"/>
+        <xs:element ref="mathml:sep"/>
+        <xs:element ref="mathml:semantics"/>
+        <xs:element ref="mathml:annotation"/>
+        <xs:element ref="mathml:annotation-xml"/>
+        <xs:element ref="mathml:integers"/>
+        <xs:element ref="mathml:reals"/>
+        <xs:element ref="mathml:rationals"/>
+        <xs:element ref="mathml:naturalnumbers"/>
+        <xs:element ref="mathml:complexes"/>
+        <xs:element ref="mathml:primes"/>
+        <xs:element ref="mathml:exponentiale"/>
+        <xs:element ref="mathml:imaginaryi"/>
+        <xs:element ref="mathml:notanumber"/>
+        <xs:element ref="mathml:true"/>
+        <xs:element ref="mathml:false"/>
+        <xs:element ref="mathml:emptyset"/>
+        <xs:element ref="mathml:pi"/>
+        <xs:element ref="mathml:eulergamma"/>
+        <xs:element ref="mathml:infinity"/>
+        <xs:element ref="mathml:interval"/>
+        <xs:element ref="mathml:list"/>
+        <xs:element ref="mathml:matrix"/>
+        <xs:element ref="mathml:matrixrow"/>
+        <xs:element ref="mathml:set"/>
+        <xs:element ref="mathml:vector"/>
+        <xs:element ref="mathml:piecewise"/>
+        <xs:element ref="mathml:lowlimit"/>
+        <xs:element ref="mathml:uplimit"/>
+        <xs:element ref="mathml:bvar"/>
+        <xs:element ref="mathml:degree"/>
+        <xs:element ref="mathml:logbase"/>
+        <xs:element ref="mathml:momentabout"/>
+        <xs:element ref="mathml:domainofapplication"/>
+        <xs:element ref="mathml:inverse"/>
+        <xs:element ref="mathml:ident"/>
+        <xs:element ref="mathml:domain"/>
+        <xs:element ref="mathml:codomain"/>
+        <xs:element ref="mathml:image"/>
+        <xs:element ref="mathml:abs"/>
+        <xs:element ref="mathml:conjugate"/>
+        <xs:element ref="mathml:exp"/>
+        <xs:element ref="mathml:factorial"/>
+        <xs:element ref="mathml:arg"/>
+        <xs:element ref="mathml:real"/>
+        <xs:element ref="mathml:imaginary"/>
+        <xs:element ref="mathml:floor"/>
+        <xs:element ref="mathml:ceiling"/>
+        <xs:element ref="mathml:not"/>
+        <xs:element ref="mathml:ln"/>
+        <xs:element ref="mathml:sin"/>
+        <xs:element ref="mathml:cos"/>
+        <xs:element ref="mathml:tan"/>
+        <xs:element ref="mathml:sec"/>
+        <xs:element ref="mathml:csc"/>
+        <xs:element ref="mathml:cot"/>
+        <xs:element ref="mathml:sinh"/>
+        <xs:element ref="mathml:cosh"/>
+        <xs:element ref="mathml:tanh"/>
+        <xs:element ref="mathml:sech"/>
+        <xs:element ref="mathml:csch"/>
+        <xs:element ref="mathml:coth"/>
+        <xs:element ref="mathml:arcsin"/>
+        <xs:element ref="mathml:arccos"/>
+        <xs:element ref="mathml:arctan"/>
+        <xs:element ref="mathml:arccosh"/>
+        <xs:element ref="mathml:arccot"/>
+        <xs:element ref="mathml:arccoth"/>
+        <xs:element ref="mathml:arccsc"/>
+        <xs:element ref="mathml:arccsch"/>
+        <xs:element ref="mathml:arcsec"/>
+        <xs:element ref="mathml:arcsech"/>
+        <xs:element ref="mathml:arcsinh"/>
+        <xs:element ref="mathml:arctanh"/>
+        <xs:element ref="mathml:determinant"/>
+        <xs:element ref="mathml:transpose"/>
+        <xs:element ref="mathml:card"/>
+        <xs:element ref="mathml:quotient"/>
+        <xs:element ref="mathml:divide"/>
+        <xs:element ref="mathml:power"/>
+        <xs:element ref="mathml:rem"/>
+        <xs:element ref="mathml:implies"/>
+        <xs:element ref="mathml:vectorproduct"/>
+        <xs:element ref="mathml:scalarproduct"/>
+        <xs:element ref="mathml:outerproduct"/>
+        <xs:element ref="mathml:setdiff"/>
+        <xs:element ref="mathml:fn"/>
+        <xs:element ref="mathml:compose"/>
+        <xs:element ref="mathml:plus"/>
+        <xs:element ref="mathml:times"/>
+        <xs:element ref="mathml:max"/>
+        <xs:element ref="mathml:min"/>
+        <xs:element ref="mathml:gcd"/>
+        <xs:element ref="mathml:lcm"/>
+        <xs:element ref="mathml:and"/>
+        <xs:element ref="mathml:or"/>
+        <xs:element ref="mathml:xor"/>
+        <xs:element ref="mathml:union"/>
+        <xs:element ref="mathml:intersect"/>
+        <xs:element ref="mathml:cartesianproduct"/>
+        <xs:element ref="mathml:mean"/>
+        <xs:element ref="mathml:sdev"/>
+        <xs:element ref="mathml:variance"/>
+        <xs:element ref="mathml:median"/>
+        <xs:element ref="mathml:mode"/>
+        <xs:element ref="mathml:selector"/>
+        <xs:element ref="mathml:root"/>
+        <xs:element ref="mathml:minus"/>
+        <xs:element ref="mathml:log"/>
+        <xs:element ref="mathml:int"/>
+        <xs:element ref="mathml:diff"/>
+        <xs:element ref="mathml:partialdiff"/>
+        <xs:element ref="mathml:divergence"/>
+        <xs:element ref="mathml:grad"/>
+        <xs:element ref="mathml:curl"/>
+        <xs:element ref="mathml:laplacian"/>
+        <xs:element ref="mathml:sum"/>
+        <xs:element ref="mathml:product"/>
+        <xs:element ref="mathml:limit"/>
+        <xs:element ref="mathml:moment"/>
+        <xs:element ref="mathml:exists"/>
+        <xs:element ref="mathml:forall"/>
+        <xs:element ref="mathml:neq"/>
+        <xs:element ref="mathml:factorof"/>
+        <xs:element ref="mathml:in"/>
+        <xs:element ref="mathml:notin"/>
+        <xs:element ref="mathml:notsubset"/>
+        <xs:element ref="mathml:notprsubset"/>
+        <xs:element ref="mathml:tendsto"/>
+        <xs:element ref="mathml:eq"/>
+        <xs:element ref="mathml:leq"/>
+        <xs:element ref="mathml:lt"/>
+        <xs:element ref="mathml:geq"/>
+        <xs:element ref="mathml:gt"/>
+        <xs:element ref="mathml:equivalent"/>
+        <xs:element ref="mathml:approx"/>
+        <xs:element ref="mathml:subset"/>
+        <xs:element ref="mathml:prsubset"/>
+        <xs:element ref="mathml:mi"/>
+        <xs:element ref="mathml:mn"/>
+        <xs:element ref="mathml:mo"/>
+        <xs:element ref="mathml:mtext"/>
+        <xs:element ref="mathml:ms"/>
+        <xs:element ref="mathml:mspace"/>
+        <xs:element ref="mathml:mrow"/>
+        <xs:element ref="mathml:mfrac"/>
+        <xs:element ref="mathml:msqrt"/>
+        <xs:element ref="mathml:mroot"/>
+        <xs:element ref="mathml:menclose"/>
+        <xs:element ref="mathml:mstyle"/>
+        <xs:element ref="mathml:merror"/>
+        <xs:element ref="mathml:mpadded"/>
+        <xs:element ref="mathml:mphantom"/>
+        <xs:element ref="mathml:mfenced"/>
+        <xs:element ref="mathml:msub"/>
+        <xs:element ref="mathml:msup"/>
+        <xs:element ref="mathml:msubsup"/>
+        <xs:element ref="mathml:munder"/>
+        <xs:element ref="mathml:mover"/>
+        <xs:element ref="mathml:munderover"/>
+        <xs:element ref="mathml:mmultiscripts"/>
+        <xs:element ref="mathml:mtable"/>
+        <xs:element ref="mathml:mtr"/>
+        <xs:element ref="mathml:mlabeledtr"/>
+        <xs:element ref="mathml:mtd"/>
+        <xs:element ref="mathml:maligngroup"/>
+        <xs:element ref="mathml:malignmark"/>
+        <xs:element ref="mathml:maction"/>
+      </xs:choice>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:type"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref" type="xs:IDREF"/>
+      <xs:attribute name="other"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/client/static/xsd/mdml.xsd
+++ b/client/static/xsd/mdml.xsd
@@ -1,0 +1,395 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/mdml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+  <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns1.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
+  <xs:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="mathml.xsd"/>
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:element name="content-id">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:NMTOKEN">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="repository">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="content-url">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="title">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="short-title">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subtitle">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="version">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="created">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="revised">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="actors">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="mdml:person"/>
+        <xs:element ref="mdml:organization"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="roles">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="mdml:role"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="license">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="url" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="extended-attribution">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="cnxml:link-group"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="derived-from">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mdml:content-id"/>
+        <xs:element ref="mdml:repository"/>
+        <xs:element ref="mdml:content-url"/>
+        <xs:element ref="mdml:title"/>
+        <xs:element ref="mdml:short-title"/>
+        <xs:element ref="mdml:subtitle"/>
+        <xs:element ref="mdml:version"/>
+        <xs:element ref="mdml:created"/>
+        <xs:element ref="mdml:revised"/>
+        <xs:element ref="mdml:actors"/>
+        <xs:element ref="mdml:roles"/>
+        <xs:element ref="mdml:license"/>
+        <xs:element ref="mdml:extended-attribution"/>
+        <xs:element ref="mdml:derived-from"/>
+        <xs:element ref="mdml:keywordlist"/>
+        <xs:element ref="mdml:subjectlist"/>
+        <xs:element ref="mdml:education-levellist"/>
+        <xs:element ref="mdml:abstract"/>
+        <xs:element ref="mdml:language"/>
+        <xs:element ref="mdml:objectives"/>
+        <xs:element ref="mdml:homepage"/>
+        <xs:element ref="mdml:institution"/>
+        <xs:element ref="mdml:course-code"/>
+        <xs:element ref="mdml:instructor"/>
+        <xs:element ref="mdml:uuid"/>
+        <xs:element ref="mdml:canonical-book-uuid"/>
+        <xs:element ref="mdml:slug"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:implementation"/>
+      <xs:attribute name="url"/>
+      <xs:attribute name="document"/>
+      <xs:attribute name="version"/>
+      <xs:attribute name="repository"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="keywordlist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="mdml:keyword"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subjectlist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="mdml:subject"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="education-levellist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="mdml:education-level"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="abstract">
+    <xs:complexType mixed="true">
+      <xs:choice maxOccurs="unbounded">
+        <xs:group ref="mathml:para_2"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="mathml:emphasis"/>
+          <xs:group ref="mathml:term"/>
+          <xs:group ref="mathml:foreign"/>
+          <xs:group ref="mathml:cite"/>
+          <xs:group ref="mathml:span"/>
+          <xs:group ref="mathml:sup"/>
+          <xs:group ref="mathml:sub"/>
+          <xs:group ref="mathml:code_2"/>
+          <xs:element ref="mathml:math"/>
+          <xs:group ref="mathml:quote_2"/>
+          <xs:group ref="mathml:preformat_2"/>
+          <xs:group ref="mathml:list_4"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="language">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="objectives">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="homepage">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="institution">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="course-code">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="instructor">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="uuid">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="canonical-book-uuid">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="slug">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="person">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mdml:honorific"/>
+        <xs:element ref="mdml:firstname"/>
+        <xs:element ref="mdml:othername"/>
+        <xs:element ref="mdml:surname"/>
+        <xs:element ref="mdml:lineage"/>
+        <xs:element ref="mdml:fullname"/>
+        <xs:element ref="mdml:email"/>
+        <xs:element ref="mdml:homepage"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="userid"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="organization">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="mdml:fullname"/>
+        <xs:element ref="mdml:shortname"/>
+        <xs:element ref="mdml:email"/>
+        <xs:element ref="mdml:homepage"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="userid"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="role">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="type" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="keyword">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subject">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="source"/>
+      <xs:attribute name="key"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="education-level">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute name="source"/>
+      <xs:attribute name="key"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="honorific">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="firstname">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="othername">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="surname">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="lineage">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fullname">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="email">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="shortname">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/client/static/xsd/ns1.xsd
+++ b/client/static/xsd/ns1.xsd
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://bibtexml.sf.net/" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+  <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
+  <xs:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="mathml.xsd"/>
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:element name="file">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="ns1:entry"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="entry">
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element ref="ns1:article"/>
+        <xs:element ref="ns1:book"/>
+        <xs:element ref="ns1:booklet"/>
+        <xs:element ref="ns1:manual"/>
+        <xs:element ref="ns1:techreport"/>
+        <xs:element ref="ns1:mastersthesis"/>
+        <xs:element ref="ns1:phdthesis"/>
+        <xs:element ref="ns1:inbook"/>
+        <xs:element ref="ns1:incollection"/>
+        <xs:element ref="ns1:proceedings"/>
+        <xs:element ref="ns1:inproceedings"/>
+        <xs:element ref="ns1:conference"/>
+        <xs:element ref="ns1:unpublished"/>
+        <xs:element ref="ns1:misc"/>
+      </xs:choice>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="article">
+    <xs:complexType>
+      <xs:sequence minOccurs="0">
+        <xs:element ref="ns1:author"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element ref="ns1:journal"/>
+        <xs:element ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:volume"/>
+        <xs:element minOccurs="0" ref="ns1:number"/>
+        <xs:element minOccurs="0" ref="ns1:pages"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="book">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element ref="ns1:author"/>
+          <xs:element ref="ns1:editor"/>
+        </xs:choice>
+        <xs:element ref="ns1:title"/>
+        <xs:element ref="ns1:publisher"/>
+        <xs:element ref="ns1:year"/>
+        <xs:choice minOccurs="0">
+          <xs:element ref="ns1:volume"/>
+          <xs:element ref="ns1:number"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="ns1:series"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:edition"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="booklet">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="ns1:author"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element minOccurs="0" ref="ns1:howpublished"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="manual">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="ns1:author"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element minOccurs="0" ref="ns1:organization"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:edition"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="techreport">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ns1:author"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element ref="ns1:institution"/>
+        <xs:element ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:type"/>
+        <xs:element minOccurs="0" ref="ns1:number"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mastersthesis">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ns1:author"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element ref="ns1:school"/>
+        <xs:element ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:type"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="phdthesis">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ns1:author"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element ref="ns1:school"/>
+        <xs:element ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:type"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="inbook">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element ref="ns1:author"/>
+          <xs:element ref="ns1:editor"/>
+        </xs:choice>
+        <xs:element ref="ns1:title"/>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element ref="ns1:chapter"/>
+            <xs:element minOccurs="0" ref="ns1:pages"/>
+          </xs:sequence>
+          <xs:element ref="ns1:pages"/>
+        </xs:choice>
+        <xs:element ref="ns1:publisher"/>
+        <xs:element ref="ns1:year"/>
+        <xs:choice minOccurs="0">
+          <xs:element ref="ns1:volume"/>
+          <xs:element ref="ns1:number"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="ns1:series"/>
+        <xs:element minOccurs="0" ref="ns1:type"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:edition"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="incollection">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ns1:author"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element ref="ns1:booktitle"/>
+        <xs:element ref="ns1:publisher"/>
+        <xs:element ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:editor"/>
+        <xs:choice minOccurs="0">
+          <xs:element ref="ns1:volume"/>
+          <xs:element ref="ns1:number"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="ns1:series"/>
+        <xs:element minOccurs="0" ref="ns1:type"/>
+        <xs:element minOccurs="0" ref="ns1:chapter"/>
+        <xs:element minOccurs="0" ref="ns1:pages"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:edition"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="proceedings">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="ns1:editor"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element ref="ns1:year"/>
+        <xs:choice minOccurs="0">
+          <xs:element ref="ns1:volume"/>
+          <xs:element ref="ns1:number"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="ns1:series"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:organization"/>
+        <xs:element minOccurs="0" ref="ns1:publisher"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="inproceedings">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ns1:author"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element ref="ns1:booktitle"/>
+        <xs:element ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:editor"/>
+        <xs:choice minOccurs="0">
+          <xs:element ref="ns1:volume"/>
+          <xs:element ref="ns1:number"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="ns1:series"/>
+        <xs:element minOccurs="0" ref="ns1:pages"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:organization"/>
+        <xs:element minOccurs="0" ref="ns1:publisher"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conference">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ns1:author"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element ref="ns1:booktitle"/>
+        <xs:element ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:editor"/>
+        <xs:choice minOccurs="0">
+          <xs:element ref="ns1:volume"/>
+          <xs:element ref="ns1:number"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="ns1:series"/>
+        <xs:element minOccurs="0" ref="ns1:pages"/>
+        <xs:element minOccurs="0" ref="ns1:address"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:organization"/>
+        <xs:element minOccurs="0" ref="ns1:publisher"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="unpublished">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ns1:author"/>
+        <xs:element ref="ns1:title"/>
+        <xs:element ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="misc">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="ns1:author"/>
+        <xs:element minOccurs="0" ref="ns1:title"/>
+        <xs:element minOccurs="0" ref="ns1:howpublished"/>
+        <xs:element minOccurs="0" ref="ns1:month"/>
+        <xs:element minOccurs="0" ref="ns1:year"/>
+        <xs:element minOccurs="0" ref="ns1:note"/>
+        <xs:element minOccurs="0" ref="ns1:key"/>
+        <xs:element minOccurs="0" ref="ns1:crossref"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="author" type="xs:string"/>
+  <xs:element name="title" type="xs:string"/>
+  <xs:element name="journal" type="xs:string"/>
+  <xs:element name="year" type="xs:string"/>
+  <xs:element name="volume" type="xs:string"/>
+  <xs:element name="number" type="xs:string"/>
+  <xs:element name="pages" type="xs:string"/>
+  <xs:element name="month" type="xs:string"/>
+  <xs:element name="note" type="xs:string"/>
+  <xs:element name="key" type="xs:string"/>
+  <xs:element name="crossref" type="xs:string"/>
+  <xs:element name="editor" type="xs:string"/>
+  <xs:element name="publisher" type="xs:string"/>
+  <xs:element name="series" type="xs:string"/>
+  <xs:element name="address" type="xs:string"/>
+  <xs:element name="edition" type="xs:string"/>
+  <xs:element name="howpublished" type="xs:string"/>
+  <xs:element name="organization" type="xs:string"/>
+  <xs:element name="institution" type="xs:string"/>
+  <xs:element name="type" type="xs:string"/>
+  <xs:element name="school" type="xs:string"/>
+  <xs:element name="chapter" type="xs:string"/>
+  <xs:element name="booktitle" type="xs:string"/>
+</xs:schema>

--- a/client/static/xsd/qml.xsd
+++ b/client/static/xsd/qml.xsd
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/qml/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+  <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns1.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
+  <xs:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="mathml.xsd"/>
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:element name="problemset">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="qml:item"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="item">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="qml:question"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="qml:resource"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="qml:answer"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="qml:hint"/>
+        <xs:element minOccurs="0" ref="qml:feedback"/>
+        <xs:element minOccurs="0" ref="qml:key"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="single-response"/>
+            <xs:enumeration value="multiple-response"/>
+            <xs:enumeration value="text-response"/>
+            <xs:enumeration value="ordered-response"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="question">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cnxml:section"/>
+        <xs:group ref="mathml:media"/>
+        <xs:group ref="mathml:media_2"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="resource">
+    <xs:complexType>
+      <xs:attribute name="uri" use="required"/>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="answer">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="qml:response"/>
+        <xs:sequence minOccurs="0">
+          <xs:element ref="qml:feedback"/>
+          <xs:element minOccurs="0" ref="qml:feedback"/>
+        </xs:sequence>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="hint">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cnxml:section"/>
+        <xs:group ref="mathml:media"/>
+        <xs:group ref="mathml:media_2"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="feedback">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cnxml:section"/>
+        <xs:group ref="mathml:media"/>
+        <xs:group ref="mathml:media_2"/>
+      </xs:choice>
+      <xs:attribute name="correct">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="key">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cnxml:section"/>
+        <xs:group ref="mathml:media"/>
+        <xs:group ref="mathml:media_2"/>
+      </xs:choice>
+      <xs:attribute name="answer"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="response">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cnxml:section"/>
+        <xs:group ref="mathml:media"/>
+        <xs:group ref="mathml:media_2"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/client/static/xsd/s.xsd
+++ b/client/static/xsd/s.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/system-info" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+  <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns1.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
+  <xs:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="mathml.xsd"/>
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:attribute name="implementation"/>
+</xs:schema>

--- a/client/static/xsd/xlink.xsd
+++ b/client/static/xsd/xlink.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/1999/xlink" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+  <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns1.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
+  <xs:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="mathml.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:attribute name="href" type="xs:anyURI"/>
+  <xs:attribute name="type">
+    <xs:simpleType>
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="simple"/>
+        <xs:enumeration value="none"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+</xs:schema>

--- a/client/static/xsd/xml.xsd
+++ b/client/static/xsd/xml.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+  <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns1.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
+  <xs:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="mathml.xsd"/>
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+  <xs:attribute name="lang"/>
+</xs:schema>

--- a/package.json
+++ b/package.json
@@ -141,6 +141,9 @@
       }
     }
   },
+  "extensionDependencies": [
+    "redhat.vscode-xml"
+  ],
   "devDependencies": {
     "@babel/cli": "^7.12.10",
     "@babel/plugin-transform-react-jsx": "^7.12.12",


### PR DESCRIPTION
This PR includes the following changes:

* It adds the `redhat.vscode-xml` extension as a dependency in our manifest so that it's automatically installed with ours
* It adds XSD schema files generated using our RelaxNG files (and documentation updates to reflect steps)
* It populates schema files stored in the package to the content repo during activation (this allows us to update schema files with our package while also working with the `xml.catalogs` setting the `vscode-xml` plugin needs to associate schema files with CNXML)

This PR is tied to content repo PRs as well:
* [osbooks-university-physics](https://github.com/openstax/osbooks-university-physics/pull/3)
* [osbooks-college-algebra-bundle](https://github.com/openstax/osbooks-college-algebra-bundle/pull/3)