### PR TITLE
Update environment variable check for Theia editor

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -54,7 +54,7 @@ export const forwardOnDidChangeWorkspaceFolders = (clientInner: LanguageClient) 
 
 export async function activate(context: vscode.ExtensionContext): Promise<(typeof extensionExports)> {
   // detect Theia. Alert the user if they are running Theia
-  expect(process.env.GITPOD_HOST != null && process.env.EDITOR !== 'code' ? undefined : true, 'You seem to be running the Theia editor. Change your Settings in your profile')
+  expect(process.env.GITPOD_HOST != null && process.env.EDITOR?.includes('code') === false ? undefined : true, 'You seem to be running the Theia editor. Change your Settings in your profile')
 
   client = launchLanguageServer(context)
   populateXsdSchemaFiles(resourceRootDir)


### PR DESCRIPTION
In recent Gitpod updates some of the environment variable values are
slightly different. This softens the check logic a bit so hopefully
we don't get future false positives, but leaves the check in there
even though the default editor is now VS Code just in case users may
still somehow wind up loading Theia.