### PR TITLE
Fix UI issue in ToC editor when adding modules

### DIFF
--- a/server/src/bundle-validation.ts
+++ b/server/src/bundle-validation.ts
@@ -25,8 +25,8 @@ export class BundleValidationQueue {
   addRequest(request?: BundleValidationRequest): void {
     this.clearQueue()
     if (request != null) {
-      const priorityItem = expect(this.bundle.bundleItemFromUri(request.causeUri), 'caller must verify uri resides in this bundle')
-      if (priorityItem.type === 'collections' || priorityItem.type === 'modules') {
+      const priorityItem = this.bundle.bundleItemFromUri(request.causeUri)
+      if ((priorityItem !== null) && (priorityItem.type === 'collections' || priorityItem.type === 'modules')) {
         this.queue.push(priorityItem)
       }
     }

--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -507,6 +507,15 @@ describe('ValidationQueue', function () {
     validationQueue.addRequest(validationRequest)
     await assert.rejects((validationQueue as any).processQueue())
   })
+  it('will queue items when bundleItemFromUri returns null', async () => {
+    const bundle = await BookBundle.from('/bundle')
+    const validationQueue = new BundleValidationQueue(bundle, noConnection)
+    sinon.stub(bundle, 'bundleItemFromUri').returns(null)
+    sinon.stub(validationQueue, 'trigger' as any)
+    const validationRequest: BundleValidationRequest = { causeUri: '' }
+    validationQueue.addRequest(validationRequest)
+    assert.strictEqual((validationQueue as any).queue.length, 4)
+  })
   it('will log error when validation is requested for an uri that is not in the bundle', async () => {
     const clock = sinon.useFakeTimers()
     const bundle = await BookBundle.from('/bundle')


### PR DESCRIPTION
Quick context for this change: `bundleItemFromUri` is expected to return `null` when the input is a directory, and it also [turns out](https://github.com/openstax/cnx/issues/1509#issuecomment-822723468) sometimes we may only receive a single directory event when specific file changes occur. So, in this PR I made the change where we won't queue a `priorityItem` when `bundleItemFromUri` returns `null`, but we'll go ahead and queue all modules and collections since something like a module directory deletion could result in validation errors in those files.