### PR TITLE
Re-add redhat xml extension as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     }
   },
   "extensionDependencies": [
+    "redhat.vscode-xml",
     "vscode.git"
   ],
   "devDependencies": {


### PR DESCRIPTION
This was accidentally removed at some point, so putting it back into
the extension configuration.