### PR TITLE
Add filtering support for ToC trees view

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -7,7 +7,7 @@ import { showCnxmlPreview } from './panel-cnxml-preview'
 import { pushContent } from './push-content'
 import { expect, ensureCatch, launchLanguageServer, populateXsdSchemaFiles } from './utils'
 import { commandToPanelType, OpenstaxCommand, PanelType } from './extension-types'
-import { TocTreesProvider } from './toc-trees'
+import { TocTreeItem, TocTreesProvider, toggleTocTreesFilteringHandler } from './toc-trees'
 
 const resourceRootDir = path.join(__dirname) // extension is running in dist/
 // Only one instance of each type allowed at any given time
@@ -15,6 +15,7 @@ const activePanelsByType: { [key in PanelType]?: vscode.WebviewPanel } = {}
 const extensionExports = {
   activePanelsByType
 }
+let tocTreesView: vscode.TreeView<TocTreeItem>
 let tocTreesProvider: TocTreesProvider
 let client: LanguageClient
 
@@ -84,7 +85,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<(typeo
   vscode.commands.registerCommand(OpenstaxCommand.SHOW_CNXML_PREVIEW, lazilyFocusOrOpenPanelOfType(commandToPanelType[OpenstaxCommand.SHOW_CNXML_PREVIEW], true))
   vscode.commands.registerCommand('openstax.pushContent', ensureCatch(pushContent()))
   vscode.commands.registerCommand('openstax.refreshTocTrees', ensureCatch(async () => tocTreesProvider.refresh()))
-  vscode.window.registerTreeDataProvider('tocTrees', tocTreesProvider)
+  tocTreesView = vscode.window.createTreeView('tocTrees', { treeDataProvider: tocTreesProvider, showCollapseAll: true })
+  vscode.commands.registerCommand('openstax.toggleTocTreesFiltering', ensureCatch(toggleTocTreesFilteringHandler(tocTreesView, tocTreesProvider)))
 
   return extensionExports
 }

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -715,16 +715,21 @@ suite('Extension Test Suite', function (this: Suite) {
       getChildren: getChildrenStub,
       refresh: refreshStub
     } as unknown as TocTreesProvider
-    getChildrenStub.resolves([{ label: 'col1' }, { label: 'col2' }])
+    const fakeChildren = [
+      { label: 'col1', children: [{ label: 'subcol', children: [{ label: 'm2', children: [] }] }] },
+      { label: 'col2', children: [{ label: 'm1', children: [] }] }
+    ]
+    getChildrenStub.resolves(fakeChildren)
 
     const handler = toggleTocTreesFilteringHandler(view, provider)
     await handler()
     assert(toggleFilterStub.calledOnce)
     assert(getChildrenStub.calledOnce)
-    assert(revealStub.calledTwice)
-    assert(revealStub.calledWith({ label: 'col1' }, { expand: 3 }))
-    assert(revealStub.calledWith({ label: 'col2' }, { expand: 3 }))
-    assert(refreshStub.calledTwice)
+    assert(revealStub.calledThrice)
+    assert(revealStub.calledWith(fakeChildren[0], { expand: true }))
+    assert(revealStub.calledWith(fakeChildren[0].children[0], { expand: true }))
+    assert(revealStub.calledWith(fakeChildren[1], { expand: true }))
+    assert(refreshStub.notCalled)
   })
   test('TocTreesProvider fires event on refresh', async () => {
     const mockClient: LanguageClient = {} as any as LanguageClient

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -23,7 +23,7 @@ import * as xpath from 'xpath-ts'
 import { Substitute } from '@fluffy-spoon/substitute'
 import { LanguageClient } from 'vscode-languageclient/node'
 import { ExtensionServerRequest } from '../../../../common/src/requests'
-import { TocTreesProvider, TocTreeItem } from './../../toc-trees'
+import { TocTreesProvider, TocTreeItem, toggleTocTreesFilteringHandler } from './../../toc-trees'
 import * as utils from './../../utils' // Used for dependency mocking in tests
 
 // Test runs in out/client/src/test/suite, not src/client/src/test/suite
@@ -650,6 +650,17 @@ suite('Extension Test Suite', function (this: Suite) {
       },
       'm00003'
     )
+    const module3ItemToggled = new TocTreeItem(
+      'Module3 (m00003)',
+      vscode.TreeItemCollapsibleState.None,
+      [],
+      {
+        title: 'open',
+        command: 'vscode.open',
+        arguments: [vscode.Uri.file(`${fakeWorkspacePath}/modules/m00003/index.cnxml`)]
+      },
+      undefined
+    )
     const subcollectionItem = new TocTreeItem(
       'subcollection',
       vscode.TreeItemCollapsibleState.Collapsed,
@@ -684,6 +695,36 @@ suite('Extension Test Suite', function (this: Suite) {
     assert.deepStrictEqual(await tocTreesProvider.getChildren(undefined), [collection1Item, collection2Item])
     assert.deepStrictEqual(await tocTreesProvider.getChildren(collection2Item), [module3Item])
     assert.deepStrictEqual(tocTreesProvider.getTreeItem(collection2Item), collection2Item)
+    assert.deepStrictEqual(tocTreesProvider.getParent(collection2Item), undefined)
+    assert.deepStrictEqual(tocTreesProvider.getParent(module3Item), collection2Item)
+    assert.deepStrictEqual(tocTreesProvider.getParent(module1Item), subcollectionItem)
+    tocTreesProvider.toggleFilterMode()
+    assert.deepStrictEqual(tocTreesProvider.getTreeItem(module3Item), module3ItemToggled)
+  })
+  test('toggleTocTreesFilteringHandler', async () => {
+    const revealStub = sinon.stub()
+    const toggleFilterStub = sinon.stub()
+    const getChildrenStub = sinon.stub()
+    const refreshStub = sinon.stub()
+
+    const view: vscode.TreeView<TocTreeItem> = {
+      reveal: revealStub
+    } as unknown as vscode.TreeView<TocTreeItem>
+    const provider: TocTreesProvider = {
+      toggleFilterMode: toggleFilterStub,
+      getChildren: getChildrenStub,
+      refresh: refreshStub
+    } as unknown as TocTreesProvider
+    getChildrenStub.resolves([{ label: 'col1' }, { label: 'col2' }])
+
+    const handler = toggleTocTreesFilteringHandler(view, provider)
+    await handler()
+    assert(toggleFilterStub.calledOnce)
+    assert(getChildrenStub.calledOnce)
+    assert(revealStub.calledTwice)
+    assert(revealStub.calledWith({ label: 'col1' }, { expand: 3 }))
+    assert(revealStub.calledWith({ label: 'col2' }, { expand: 3 }))
+    assert(refreshStub.calledTwice)
   })
   test('TocTreesProvider fires event on refresh', async () => {
     const mockClient: LanguageClient = {} as any as LanguageClient
@@ -691,6 +732,13 @@ suite('Extension Test Suite', function (this: Suite) {
     const eventFire = sinon.stub((tocTreesProvider as any)._onDidChangeTreeData, 'fire')
     tocTreesProvider.refresh()
     assert(eventFire.calledOnce)
+  })
+  test('TocTreesProvider calls refresh when toggling filter mode', async () => {
+    const mockClient: LanguageClient = {} as any as LanguageClient
+    const tocTreesProvider = new TocTreesProvider(mockClient)
+    const refresh = sinon.stub(tocTreesProvider, 'refresh')
+    tocTreesProvider.toggleFilterMode()
+    assert(refresh.calledOnce)
   })
   test('invokeRefreshers calls functions', async () => {
     const func1 = sinon.stub().resolves()

--- a/package.json
+++ b/package.json
@@ -72,6 +72,12 @@
         "title": "Refresh ToC Trees",
         "category": "Openstax",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "openstax.toggleTocTreesFiltering",
+        "title": "Toggle ToC Filtering",
+        "category": "Openstax",
+        "icon": "$(filter)"
       }
     ],
     "viewsContainers": {
@@ -133,6 +139,11 @@
       "view/title": [
         {
           "command": "openstax.refreshTocTrees",
+          "when": "view == tocTrees",
+          "group": "navigation"
+        },
+        {
+          "command": "openstax.toggleTocTreesFiltering",
           "when": "view == tocTrees",
           "group": "navigation"
         }


### PR DESCRIPTION
This change allows the ability to filter on title or the string used
in the description field (e.g. for modules the ID) using the built-in
capabilities of the VScode tree widget by clicking on the filter
icon. This fully expands the tree, so a collapse-all button is also
exposed to allow users to close the tree.