### PR TITLE
Detect and handle bundle directory deletions

### DIFF
--- a/server/src/book-bundle.ts
+++ b/server/src/book-bundle.ts
@@ -630,7 +630,10 @@ export class BookBundle {
       return true
     }
 
-    return (deletedPath.includes(this.moduleDirectory()) && !deletedPath.endsWith('index.cnxml'))
+    const indexOfLastSep = deletedPath.lastIndexOf(FS_SEP)
+    const maybeModuleId = deletedPath.substring(indexOfLastSep + 1)
+    return ((deletedPath === this.moduleDirectory()) ||
+            (deletedPath.includes(this.moduleDirectory()) && this.moduleExists(maybeModuleId)))
   }
 
   processDirectoryDeletion(change: FileEvent): void {

--- a/server/src/book-bundle.ts
+++ b/server/src/book-bundle.ts
@@ -595,6 +595,15 @@ export class BookBundle {
   }
 
   processChange(change: FileEvent): void {
+    if (this.isDirectoryDeletion(change)) {
+      // Special casing directory deletion processing since while these might
+      // be rare / unexpected, the file watcher events don't necessarily notify
+      // us of every impacted file. Hopefully this gets addressed by the underlying
+      // file watcher implementation in the future and we can remove this
+      // codepath altogether.
+      this.processDirectoryDeletion(change)
+      return
+    }
     const item = this.bundleItemFromUri(change.uri)
     if (item == null) {
       return

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -126,7 +126,16 @@ connection.onDidChangeWatchedFiles(({ changes }) => {
         return
       }
       const [bundleChanged, bundleValidator] = expect(workspaceBookBundles.get(workspaceChanged.uri), 'already returned if key missing')
-      bundleChanged.processChange(change)
+      if (bundleChanged.isDirectoryDeletion(change)) {
+        // Special casing directory deletion processing since while these might
+        // be rare / unexpected, the file watcher events don't necessarily notify
+        // us of every impacted file. Hopefully this gets addressed by the underlying
+        // file watcher implementation in the future and we can remove this
+        // codepath altogether.
+        bundleChanged.processDirectoryDeletion(change)
+      } else {
+        bundleChanged.processChange(change)
+      }
       bundleValidator.addRequest({ causeUri: change.uri })
     }
     await connection.sendRequest('onDidChangeWatchedFiles')

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -126,16 +126,7 @@ connection.onDidChangeWatchedFiles(({ changes }) => {
         return
       }
       const [bundleChanged, bundleValidator] = expect(workspaceBookBundles.get(workspaceChanged.uri), 'already returned if key missing')
-      if (bundleChanged.isDirectoryDeletion(change)) {
-        // Special casing directory deletion processing since while these might
-        // be rare / unexpected, the file watcher events don't necessarily notify
-        // us of every impacted file. Hopefully this gets addressed by the underlying
-        // file watcher implementation in the future and we can remove this
-        // codepath altogether.
-        bundleChanged.processDirectoryDeletion(change)
-      } else {
-        bundleChanged.processChange(change)
-      }
+      bundleChanged.processChange(change)
       bundleValidator.addRequest({ causeUri: change.uri })
     }
     await connection.sendRequest('onDidChangeWatchedFiles')

--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -1151,6 +1151,7 @@ describe('BookBundle', () => {
     assert(!bundle.isDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/other' }))
     assert(!bundle.isDirectoryDeletion({ type: FileChangeType.Changed, uri: '/bundle/modules/m00001/index.cnxml' }))
     assert(!bundle.isDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/modules/m00001/index.cnxml' }))
+    assert(!bundle.isDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/modules/m00001/random.txt' }))
   })
   it('processes media directory deletions appropriately', async () => {
     const bundle = await BookBundle.from('/bundle')

--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -1158,7 +1158,7 @@ describe('BookBundle', () => {
     const initialModuleCount = bundle.modules().length
     const initialCollectionsCount = bundle.collections().length
 
-    bundle.processDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/media' })
+    bundle.processChange({ type: FileChangeType.Deleted, uri: '/bundle/media' })
     assert(bundle.images().length === 0)
     assert(bundle.modules().length === initialModuleCount)
     assert(bundle.collections().length === initialCollectionsCount)
@@ -1168,7 +1168,7 @@ describe('BookBundle', () => {
     const initialModuleCount = bundle.modules().length
     const initialImagesCount = bundle.images().length
 
-    bundle.processDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/collections' })
+    bundle.processChange({ type: FileChangeType.Deleted, uri: '/bundle/collections' })
     assert(bundle.collections().length === 0)
     assert(bundle.modules().length === initialModuleCount)
     assert(bundle.images().length === initialImagesCount)
@@ -1179,14 +1179,14 @@ describe('BookBundle', () => {
     const initialCollectionsCount = bundle.collections().length
     const initialImagesCount = bundle.images().length
 
-    bundle.processDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/modules/m00001' })
+    bundle.processChange({ type: FileChangeType.Deleted, uri: '/bundle/modules/m00001' })
     assert(bundle.collections().length === initialCollectionsCount)
     assert(bundle.images().length === initialImagesCount)
     assert(initialModuleCount === (bundle.modules().length + 1))
     assert(!bundle.moduleExists('m00001'))
     assert(bundle.moduleExists('m00002'))
 
-    bundle.processDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/modules' })
+    bundle.processChange({ type: FileChangeType.Deleted, uri: '/bundle/modules' })
     assert(bundle.collections().length === initialCollectionsCount)
     assert(bundle.images().length === initialImagesCount)
     assert(bundle.modules().length === 0)

--- a/server/src/test/server.test.ts
+++ b/server/src/test/server.test.ts
@@ -1142,6 +1142,54 @@ describe('BookBundle', () => {
     const orphanedModulesAgain = await bundle.orphanedModules()
     assert(!cacheEquals(orphanedModules, orphanedModulesAgain))
   })
+  it('detects directory deletions correctly', async () => {
+    const bundle = await BookBundle.from('/bundle')
+    assert(bundle.isDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/media' }))
+    assert(bundle.isDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/collections' }))
+    assert(bundle.isDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/modules' }))
+    assert(bundle.isDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/modules/m00001' }))
+    assert(!bundle.isDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/other' }))
+    assert(!bundle.isDirectoryDeletion({ type: FileChangeType.Changed, uri: '/bundle/modules/m00001/index.cnxml' }))
+    assert(!bundle.isDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/modules/m00001/index.cnxml' }))
+  })
+  it('processes media directory deletions appropriately', async () => {
+    const bundle = await BookBundle.from('/bundle')
+    const initialModuleCount = bundle.modules().length
+    const initialCollectionsCount = bundle.collections().length
+
+    bundle.processDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/media' })
+    assert(bundle.images().length === 0)
+    assert(bundle.modules().length === initialModuleCount)
+    assert(bundle.collections().length === initialCollectionsCount)
+  })
+  it('processes collections directory deletions appropriately', async () => {
+    const bundle = await BookBundle.from('/bundle')
+    const initialModuleCount = bundle.modules().length
+    const initialImagesCount = bundle.images().length
+
+    bundle.processDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/collections' })
+    assert(bundle.collections().length === 0)
+    assert(bundle.modules().length === initialModuleCount)
+    assert(bundle.images().length === initialImagesCount)
+  })
+  it('processes modules directory deletions appropriately', async () => {
+    const bundle = await BookBundle.from('/bundle')
+    const initialModuleCount = bundle.modules().length
+    const initialCollectionsCount = bundle.collections().length
+    const initialImagesCount = bundle.images().length
+
+    bundle.processDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/modules/m00001' })
+    assert(bundle.collections().length === initialCollectionsCount)
+    assert(bundle.images().length === initialImagesCount)
+    assert(initialModuleCount === (bundle.modules().length + 1))
+    assert(!bundle.moduleExists('m00001'))
+    assert(bundle.moduleExists('m00002'))
+
+    bundle.processDirectoryDeletion({ type: FileChangeType.Deleted, uri: '/bundle/modules' })
+    assert(bundle.collections().length === initialCollectionsCount)
+    assert(bundle.images().length === initialImagesCount)
+    assert(bundle.modules().length === 0)
+  })
 })
 describe('BookBundle caching', () => {
   describe('cachify', () => {


### PR DESCRIPTION
This PR attempts to handle an uncommon case reasonably, without accounting for all corner cases (e.g. a directory is accidentally moved and then moved back, but the latter doesn't necessarily seem to trigger a create event for each individual file in all situations) to keep things simple for now. Specifically, per comments in the [parent issue](https://github.com/openstax/cnx/issues/1510), it seems the current file watcher implementation in VScode may not always send all file-level changes when a directory is deleted or renamed. The first scenario in the original description in the bug issue was an instance of a side effect of this limitation. In this PR I tried to handle some limited cases to ensure our bundle model (and consequently validations) at least get triggered to update. In practice I'd expect these situations would only arise if:

* Modules - A user deletes a module directory after creating (this seems like a pretty reasonable thing we want to make sure is covered and the main impetus for this PR) or accidentally renames / drags and drops it somewhere
* Collections - A user accidentally renames or drags and drops this somewhere
* Media - A user accidentally renames or drags and drops this somewhere

