### PR TITLE
Limit directories to commit / push with git add

### DIFF
--- a/client/src/push-content.ts
+++ b/client/src/push-content.ts
@@ -127,6 +127,10 @@ export const _pushContent = (
   }
 
   await gitAddCmd(validContentUris)
+  if ((await repo.diff(true)).length === 0) {
+    void errorReporter('No changes to push.')
+    return
+  }
 
   let commitSucceeded = false
 
@@ -137,12 +141,8 @@ export const _pushContent = (
     commitSucceeded = true
   } catch (e) {
     if (e.stdout == null) { throw e }
-    if ((e.stdout as string).includes('nothing to commit')) {
-      void errorReporter('No changes to push.')
-    } else {
-      const message: string = e.gitErrorCode === undefined ? e.message : e.gitErrorCode
-      void errorReporter(`Push failed: ${message}`)
-    }
+    const message: string = e.gitErrorCode === undefined ? e.message : e.gitErrorCode
+    void errorReporter(`Push failed: ${message}`)
   }
 
   if (commitSucceeded) {

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -1144,6 +1144,7 @@ suite('Push Button Test Suite', function (this: Suite) {
       commit: sinon.stub(),
       pull: sinon.stub(),
       push: sinon.stub(),
+      diff: sinon.stub().resolves(['changes']),
       state: repoState,
       rootUri: {
         fsPath: TEST_DATA_DIR
@@ -1167,6 +1168,7 @@ suite('Push Button Test Suite', function (this: Suite) {
     const captureMessage = makeCaptureMessage(messages)
     const mockMessageInput = makeMockDialog('poet commit')
     const addStub = (stubRepo as any)._repository.add as SinonRoot.SinonStub
+    const diffStub = (stubRepo as any).diff as SinonRoot.SinonStub
 
     const getRepo = (): Repository => {
       return stubRepo
@@ -1183,6 +1185,7 @@ suite('Push Button Test Suite', function (this: Suite) {
     assert(commitStub.calledOnceWithExactly('poet commit'))
     assert(addStub.calledOnce)
     assert(addStub.getCall(0).args[0].length === 3)
+    assert(diffStub.calledOnceWithExactly(true))
   })
   test('push with merge conflict', async () => {
     const messages: string[] = []
@@ -1260,12 +1263,10 @@ suite('Push Button Test Suite', function (this: Suite) {
     const messages: string[] = []
     const captureMessage = makeCaptureMessage(messages)
     const mockMessageInput = makeMockDialog('poet commit')
-    const error: any = { _fake: 'FakeSoStackTraceIsNotInConsole', message: '' }
     const stubRepo = makeBaseMockRepo()
-    const commitStub = stubRepo.commit as SinonRoot.SinonStub
+    const diffStub = (stubRepo as any).diff as SinonRoot.SinonStub
 
-    error.stdout = 'nothing to commit.'
-    commitStub.rejects(error)
+    diffStub.resolves([])
 
     const getRepo = (): Repository => {
       return stubRepo

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -53,6 +53,20 @@ export function getRootPathUri(): vscode.Uri | null {
 }
 
 /**
+ * Helper function to check if a directory exists
+ */
+export const directoryExistsAt = async (path: string): Promise<boolean> => {
+  let exists = true
+  try {
+    const stat = await fs.promises.stat(path)
+    exists = stat.isDirectory()
+  } catch (err) {
+    exists = false
+  }
+  return exists
+}
+
+/**
  * Return the URI of a module based upon the expected convention
  */
 export function constructModuleUri(workspaceUri: vscode.Uri, moduleid: string): vscode.Uri {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3667,12 +3667,6 @@
         }
       }
     },
-    "@fluffy-spoon/substitute": {
-      "version": "1.198.0",
-      "resolved": "https://registry.npmjs.org/@fluffy-spoon/substitute/-/substitute-1.198.0.tgz",
-      "integrity": "sha512-dxRe6XEhh4/+cMp+Evg+/OTeDrKv8M9D2hqHGa+mnbLy975L2aGOqlVeKlZyGHCOmEE9bue7ztl0bFx0ygYgMQ==",
-      "dev": true
-    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,6 @@
     "@babel/cli": "^7.12.10",
     "@babel/plugin-transform-react-jsx": "^7.12.12",
     "@cypress/code-coverage": "^3.9.2",
-    "@fluffy-spoon/substitute": "^1.197.0",
     "@types/chai": "^4.2.14",
     "@types/fs-extra": "^9.0.7",
     "@types/sinon": "^9.0.11",


### PR DESCRIPTION
This PR modifies the `Push` button to only stage / commit files in a specific set of directories. However, it doesn't seem like the exposed `commit()` method provides a way to do this scoping, so instead it uses the private `add` method which isn't ideal (we may want to create an issue similar to [cnx 1519](https://github.com/openstax/cnx/issues/1519) to upstream exposing this in the public API). A benefit, however, is we can explicitly check for staged differences to determine if there are changes to push prior to prompting for a commit message versus checking the `stdout` of errors after attempting to commit.

The PR doesn't make any changes to the tagging flow as that currently uses `diffWithHEAD()` to detect un-pushed changes which should continue working as desired.