### PR TITLE
Add schema validation for collection files

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,13 @@ You can now set breakpoints, etc. in the server source code.
 
 The CNXML schema validation in the extension is performed using XSD files generated using the RelaxNG schema files in the `poet-schema` branch of the [cnxml repo](https://github.com/openstax/cnxml). The XSD files can be regenerated using [jing-trang](https://github.com/relaxng/jing-trang.git). You can clone that repo and follow the instructions to build `trang.jar` and `jing.jar`. The following steps assume:
 
-* You have the `trang.jar` and `jing.jar` files in the root of this repo (you can simply modify the paths as necessary for your environment)
+* You have the `jing-trang` repo cloned as a peer of this repo and successfully built the JAR files there (you can otherwise simply modify the paths as necessary for your environment)
 * You have the `cnmxl` repo cloned as a peer of this repo
 
 ```bash
 $ git -C ../cnxml checkout poet-schema
-$ java -jar jing.jar -s ../cnxml/cnxml/xml/cnxml/schema/rng/0.7/cnxml-jing.rng > cnxml-simplified.rng
-$ java -jar trang.jar -I rng -O xsd cnxml-simplified.rng client/static/xsd/mathml.xsd
-$ rm cnxml-simplified.rng
+$ java -jar ../jing-trang/build/jing.jar -s ../cnxml/cnxml/xml/poet/schema/rng/poet-jing.rng > poet-simplified.rng
+$ java -jar ../jing-trang/build/trang.jar -I rng -O xsd poet-simplified.rng client/static/xsd/mathml.xsd
+$ patch -p1 < client/static/xsd/trang.patch
+$ rm poet-simplified.rng
 ```

--- a/client/static/xsd/catalog.xml
+++ b/client/static/xsd/catalog.xml
@@ -1,5 +1,8 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
   <uri
-      name="http://cnx.rice.edu/cnxml"
-      uri="./cnxml.xsd" />
+    name="http://cnx.rice.edu/cnxml"
+    uri="./cnxml.xsd" />
+  <uri
+    name="http://cnx.rice.edu/collxml"
+    uri="./collxml.xsd" />
 </catalog>

--- a/client/static/xsd/cmlnle.xsd
+++ b/client/static/xsd/cmlnle.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://katalysteducation.org/cmlnle/1.0" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://katalysteducation.org/cmlnle/1.0" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>

--- a/client/static/xsd/cnxml.xsd
+++ b/client/static/xsd/cnxml.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/cnxml" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/cnxml" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
@@ -65,33 +66,33 @@
   <xs:element name="metadata">
     <xs:complexType>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mdml:content-id"/>
-        <xs:element ref="mdml:repository"/>
-        <xs:element ref="mdml:content-url"/>
-        <xs:element ref="mdml:title"/>
-        <xs:element ref="mdml:short-title"/>
-        <xs:element ref="mdml:subtitle"/>
-        <xs:element ref="mdml:version"/>
-        <xs:element ref="mdml:created"/>
-        <xs:element ref="mdml:revised"/>
-        <xs:element ref="mdml:actors"/>
-        <xs:element ref="mdml:roles"/>
-        <xs:element ref="mdml:license"/>
-        <xs:element ref="mdml:extended-attribution"/>
-        <xs:element ref="mdml:derived-from"/>
-        <xs:element ref="mdml:keywordlist"/>
-        <xs:element ref="mdml:subjectlist"/>
-        <xs:element ref="mdml:education-levellist"/>
-        <xs:element ref="mdml:abstract"/>
-        <xs:element ref="mdml:language"/>
-        <xs:element ref="mdml:objectives"/>
-        <xs:element ref="mdml:homepage"/>
-        <xs:element ref="mdml:institution"/>
-        <xs:element ref="mdml:course-code"/>
-        <xs:element ref="mdml:instructor"/>
-        <xs:element ref="mdml:uuid"/>
-        <xs:element ref="mdml:canonical-book-uuid"/>
-        <xs:element ref="mdml:slug"/>
+        <xs:group ref="mathml:content-id_2"/>
+        <xs:group ref="mathml:repository_2"/>
+        <xs:group ref="mathml:content-url_2"/>
+        <xs:group ref="mathml:title_3"/>
+        <xs:group ref="mathml:short-title_2"/>
+        <xs:group ref="mathml:subtitle_2"/>
+        <xs:group ref="mathml:version_2"/>
+        <xs:group ref="mathml:created_2"/>
+        <xs:group ref="mathml:revised_2"/>
+        <xs:group ref="mathml:actors_2"/>
+        <xs:group ref="mathml:roles_2"/>
+        <xs:group ref="mathml:license_2"/>
+        <xs:group ref="mathml:extended-attribution_2"/>
+        <xs:group ref="mathml:derived-from_2"/>
+        <xs:group ref="mathml:keywordlist_2"/>
+        <xs:group ref="mathml:subjectlist_2"/>
+        <xs:group ref="mathml:education-levellist_2"/>
+        <xs:group ref="mathml:abstract_2"/>
+        <xs:group ref="mathml:objectives_2"/>
+        <xs:group ref="mathml:homepage_2"/>
+        <xs:group ref="mathml:institution_2"/>
+        <xs:group ref="mathml:course-code_2"/>
+        <xs:group ref="mathml:instructor_2"/>
+        <xs:group ref="mathml:uuid_2"/>
+        <xs:group ref="mathml:canonical-book-uuid_2"/>
+        <xs:group ref="mathml:slug_2"/>
+        <xs:group ref="mathml:language_2"/>
       </xs:choice>
       <xs:attribute ref="cmlnle:case"/>
       <xs:attribute ref="cmlnle:reference"/>
@@ -116,9 +117,7 @@
   </xs:element>
   <xs:element name="featured-links">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="cnxml:link-group"/>
-      </xs:sequence>
+      <xs:group maxOccurs="unbounded" ref="mathml:link-group_2"/>
       <xs:attribute ref="cmlnle:case"/>
       <xs:attribute ref="cmlnle:reference"/>
       <xs:attribute ref="cxlxt:born"/>
@@ -137,21 +136,21 @@
     <xs:complexType>
       <xs:choice>
         <xs:choice maxOccurs="unbounded">
-          <xs:element ref="cnxml:section"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
+          <xs:group ref="mathml:section"/>
+          <xs:group ref="mathml:div"/>
+          <xs:group ref="mathml:definition"/>
+          <xs:group ref="mathml:example"/>
+          <xs:group ref="mathml:figure"/>
           <xs:group ref="mathml:code"/>
           <xs:group ref="mathml:preformat"/>
           <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
+          <xs:group ref="mathml:note"/>
+          <xs:group ref="mathml:media"/>
           <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
+          <xs:group ref="mathml:table"/>
+          <xs:group ref="mathml:rule"/>
+          <xs:group ref="mathml:equation"/>
+          <xs:group ref="mathml:exercise"/>
           <xs:group ref="mathml:para"/>
         </xs:choice>
         <xs:element ref="qml:problemset"/>
@@ -172,9 +171,7 @@
   </xs:element>
   <xs:element name="glossary">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="cnxml:definition"/>
-      </xs:sequence>
+      <xs:group maxOccurs="unbounded" ref="mathml:definition"/>
       <xs:attribute ref="cmlnle:case"/>
       <xs:attribute ref="cmlnle:reference"/>
       <xs:attribute ref="cxlxt:born"/>
@@ -189,281 +186,330 @@
       <xs:attribute name="id" type="xs:ID"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="link-group">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:element maxOccurs="unbounded" ref="cnxml:link"/>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="type" use="required"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="section">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice maxOccurs="unbounded">
-          <xs:element ref="cnxml:section"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-          <xs:group ref="mathml:para"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="div">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:group ref="mathml:para"/>
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:element ref="cnxml:footnote"/>
-          <xs:element ref="cnxml:link"/>
-          <xs:element ref="cnxml:newline"/>
-          <xs:element ref="cnxml:space"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="definition">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group ref="mathml:term_2"/>
-        <xs:choice>
-          <xs:element ref="cnxml:seealso"/>
+  <xs:group name="link-group">
+    <xs:sequence>
+      <xs:element name="link-group">
+        <xs:complexType>
           <xs:sequence>
-            <xs:sequence maxOccurs="unbounded">
-              <xs:element ref="cnxml:meaning"/>
-              <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:example"/>
-            </xs:sequence>
-            <xs:element minOccurs="0" ref="cnxml:seealso"/>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:link"/>
           </xs:sequence>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="example">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice maxOccurs="unbounded">
-          <xs:element ref="cnxml:section"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-          <xs:group ref="mathml:para"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="figure">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice>
-          <xs:element ref="cnxml:media"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:group ref="mathml:code"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="type" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="link-group1">
+    <xs:sequence>
+      <xs:element name="link-group">
+        <xs:complexType>
           <xs:sequence>
-            <xs:element ref="cnxml:subfigure"/>
-            <xs:element maxOccurs="unbounded" ref="cnxml:subfigure"/>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:link_2"/>
           </xs:sequence>
-        </xs:choice>
-        <xs:element minOccurs="0" ref="cnxml:caption"/>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="orient">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="horizontal"/>
-            <xs:enumeration value="vertical"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="type" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="section">
+    <xs:sequence>
+      <xs:element name="section">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+              <xs:group ref="mathml:para"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="div">
+    <xs:sequence>
+      <xs:element name="div">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:footnote"/>
+              <xs:group ref="mathml:link_2"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="definition">
+    <xs:sequence>
+      <xs:element name="definition">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:choice>
+              <xs:group ref="mathml:seealso"/>
+              <xs:sequence>
+                <xs:sequence maxOccurs="unbounded">
+                  <xs:group ref="mathml:meaning"/>
+                  <xs:group minOccurs="0" maxOccurs="unbounded" ref="mathml:example"/>
+                </xs:sequence>
+                <xs:group minOccurs="0" ref="mathml:seealso"/>
+              </xs:sequence>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="example">
+    <xs:sequence>
+      <xs:element name="example">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+              <xs:group ref="mathml:para"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="figure">
+    <xs:sequence>
+      <xs:element name="figure">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:code"/>
+              <xs:sequence>
+                <xs:group ref="mathml:subfigure"/>
+                <xs:group maxOccurs="unbounded" ref="mathml:subfigure"/>
+              </xs:sequence>
+            </xs:choice>
+            <xs:group minOccurs="0" ref="mathml:caption"/>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="orient">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="horizontal"/>
+                <xs:enumeration value="vertical"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="code">
     <xs:sequence>
       <xs:element name="code">
         <xs:complexType mixed="true">
           <xs:choice>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-              <xs:element ref="mathml:math"/>
-              <xs:group ref="mathml:span_2"/>
-              <xs:group ref="mathml:term_2"/>
-              <xs:group ref="mathml:cite_2"/>
-              <xs:element ref="cnxml:cite-title"/>
-              <xs:group ref="mathml:foreign_2"/>
-              <xs:group ref="mathml:emphasis_2"/>
-              <xs:group ref="mathml:sub_2"/>
-              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
               <xs:group ref="mathml:code"/>
               <xs:group ref="mathml:preformat"/>
               <xs:group ref="mathml:quote"/>
-              <xs:element ref="cnxml:note"/>
+              <xs:group ref="mathml:note"/>
               <xs:group ref="mathml:list"/>
-              <xs:element ref="cnxml:media"/>
-              <xs:element ref="cnxml:footnote"/>
-              <xs:element ref="cnxml:link"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:footnote"/>
+              <xs:group ref="mathml:link_2"/>
               <xs:element ref="cnxml:newline"/>
               <xs:element ref="cnxml:space"/>
             </xs:choice>
             <xs:sequence>
-              <xs:element minOccurs="0" ref="cnxml:label"/>
-              <xs:group minOccurs="0" ref="mathml:title_3"/>
+              <xs:group minOccurs="0" ref="mathml:label_2"/>
+              <xs:group minOccurs="0" ref="mathml:title_5"/>
               <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element ref="mathml:math"/>
-                <xs:group ref="mathml:span_2"/>
-                <xs:group ref="mathml:term_2"/>
-                <xs:group ref="mathml:cite_2"/>
-                <xs:element ref="cnxml:cite-title"/>
-                <xs:group ref="mathml:foreign_2"/>
-                <xs:group ref="mathml:emphasis_2"/>
-                <xs:group ref="mathml:sub_2"/>
-                <xs:group ref="mathml:sup_2"/>
+                <xs:group ref="mathml:math_2"/>
+                <xs:group ref="mathml:span_3"/>
+                <xs:group ref="mathml:term_3"/>
+                <xs:group ref="mathml:cite_3"/>
+                <xs:group ref="mathml:cite-title"/>
+                <xs:group ref="mathml:foreign_3"/>
+                <xs:group ref="mathml:emphasis_3"/>
+                <xs:group ref="mathml:sub_3"/>
+                <xs:group ref="mathml:sup_3"/>
                 <xs:group ref="mathml:code"/>
                 <xs:group ref="mathml:preformat"/>
                 <xs:group ref="mathml:quote"/>
-                <xs:element ref="cnxml:note"/>
+                <xs:group ref="mathml:note"/>
                 <xs:group ref="mathml:list"/>
-                <xs:element ref="cnxml:media"/>
-                <xs:element ref="cnxml:footnote"/>
-                <xs:element ref="cnxml:link"/>
+                <xs:group ref="mathml:media"/>
+                <xs:group ref="mathml:footnote"/>
+                <xs:group ref="mathml:link_2"/>
                 <xs:element ref="cnxml:newline"/>
                 <xs:element ref="cnxml:space"/>
               </xs:choice>
-              <xs:element minOccurs="0" ref="cnxml:caption"/>
+              <xs:group minOccurs="0" ref="mathml:caption"/>
             </xs:sequence>
           </xs:choice>
           <xs:attribute name="display">
@@ -500,62 +546,62 @@
         <xs:complexType mixed="true">
           <xs:choice>
             <xs:sequence>
-              <xs:group minOccurs="0" ref="mathml:title_3"/>
+              <xs:group minOccurs="0" ref="mathml:title_5"/>
               <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:group ref="mathml:para"/>
-                <xs:element ref="mathml:math"/>
-                <xs:group ref="mathml:span_2"/>
-                <xs:group ref="mathml:term_2"/>
-                <xs:group ref="mathml:cite_2"/>
-                <xs:element ref="cnxml:cite-title"/>
-                <xs:group ref="mathml:foreign_2"/>
-                <xs:group ref="mathml:emphasis_2"/>
-                <xs:group ref="mathml:sub_2"/>
-                <xs:group ref="mathml:sup_2"/>
+                <xs:group ref="mathml:math_2"/>
+                <xs:group ref="mathml:span_3"/>
+                <xs:group ref="mathml:term_3"/>
+                <xs:group ref="mathml:cite_3"/>
+                <xs:group ref="mathml:cite-title"/>
+                <xs:group ref="mathml:foreign_3"/>
+                <xs:group ref="mathml:emphasis_3"/>
+                <xs:group ref="mathml:sub_3"/>
+                <xs:group ref="mathml:sup_3"/>
                 <xs:group ref="mathml:code"/>
                 <xs:group ref="mathml:preformat"/>
                 <xs:group ref="mathml:quote"/>
-                <xs:element ref="cnxml:note"/>
+                <xs:group ref="mathml:note"/>
                 <xs:group ref="mathml:list"/>
-                <xs:element ref="cnxml:media"/>
-                <xs:element ref="cnxml:footnote"/>
-                <xs:element ref="cnxml:link"/>
+                <xs:group ref="mathml:media"/>
+                <xs:group ref="mathml:footnote"/>
+                <xs:group ref="mathml:link_2"/>
                 <xs:element ref="cnxml:newline"/>
                 <xs:element ref="cnxml:space"/>
-                <xs:element ref="cnxml:div"/>
-                <xs:element ref="cnxml:definition"/>
-                <xs:element ref="cnxml:example"/>
-                <xs:element ref="cnxml:figure"/>
+                <xs:group ref="mathml:div"/>
+                <xs:group ref="mathml:definition"/>
+                <xs:group ref="mathml:example"/>
+                <xs:group ref="mathml:figure"/>
                 <xs:group ref="mathml:code"/>
                 <xs:group ref="mathml:preformat"/>
                 <xs:group ref="mathml:quote"/>
-                <xs:element ref="cnxml:note"/>
-                <xs:element ref="cnxml:media"/>
+                <xs:group ref="mathml:note"/>
+                <xs:group ref="mathml:media"/>
                 <xs:group ref="mathml:list"/>
-                <xs:element ref="cnxml:table"/>
-                <xs:element ref="cnxml:rule"/>
-                <xs:element ref="cnxml:equation"/>
-                <xs:element ref="cnxml:exercise"/>
+                <xs:group ref="mathml:table"/>
+                <xs:group ref="mathml:rule"/>
+                <xs:group ref="mathml:equation"/>
+                <xs:group ref="mathml:exercise"/>
               </xs:choice>
             </xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-              <xs:element ref="mathml:math"/>
-              <xs:group ref="mathml:span_2"/>
-              <xs:group ref="mathml:term_2"/>
-              <xs:group ref="mathml:cite_2"/>
-              <xs:element ref="cnxml:cite-title"/>
-              <xs:group ref="mathml:foreign_2"/>
-              <xs:group ref="mathml:emphasis_2"/>
-              <xs:group ref="mathml:sub_2"/>
-              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
               <xs:group ref="mathml:code"/>
               <xs:group ref="mathml:preformat"/>
               <xs:group ref="mathml:quote"/>
-              <xs:element ref="cnxml:note"/>
+              <xs:group ref="mathml:note"/>
               <xs:group ref="mathml:list"/>
-              <xs:element ref="cnxml:media"/>
-              <xs:element ref="cnxml:footnote"/>
-              <xs:element ref="cnxml:link"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:footnote"/>
+              <xs:group ref="mathml:link_2"/>
               <xs:element ref="cnxml:newline"/>
               <xs:element ref="cnxml:space"/>
             </xs:choice>
@@ -592,65 +638,65 @@
         <xs:complexType mixed="true">
           <xs:choice>
             <xs:sequence>
-              <xs:element minOccurs="0" ref="cnxml:label"/>
-              <xs:group minOccurs="0" ref="mathml:title_3"/>
+              <xs:group minOccurs="0" ref="mathml:label_2"/>
+              <xs:group minOccurs="0" ref="mathml:title_5"/>
               <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:group ref="mathml:para"/>
-                <xs:element ref="mathml:math"/>
-                <xs:group ref="mathml:span_2"/>
-                <xs:group ref="mathml:term_2"/>
-                <xs:group ref="mathml:cite_2"/>
-                <xs:element ref="cnxml:cite-title"/>
-                <xs:group ref="mathml:foreign_2"/>
-                <xs:group ref="mathml:emphasis_2"/>
-                <xs:group ref="mathml:sub_2"/>
-                <xs:group ref="mathml:sup_2"/>
+                <xs:group ref="mathml:math_2"/>
+                <xs:group ref="mathml:span_3"/>
+                <xs:group ref="mathml:term_3"/>
+                <xs:group ref="mathml:cite_3"/>
+                <xs:group ref="mathml:cite-title"/>
+                <xs:group ref="mathml:foreign_3"/>
+                <xs:group ref="mathml:emphasis_3"/>
+                <xs:group ref="mathml:sub_3"/>
+                <xs:group ref="mathml:sup_3"/>
                 <xs:group ref="mathml:code"/>
                 <xs:group ref="mathml:preformat"/>
                 <xs:group ref="mathml:quote"/>
-                <xs:element ref="cnxml:note"/>
+                <xs:group ref="mathml:note"/>
                 <xs:group ref="mathml:list"/>
-                <xs:element ref="cnxml:media"/>
-                <xs:element ref="cnxml:footnote"/>
-                <xs:element ref="cnxml:link"/>
+                <xs:group ref="mathml:media"/>
+                <xs:group ref="mathml:footnote"/>
+                <xs:group ref="mathml:link_2"/>
                 <xs:element ref="cnxml:newline"/>
                 <xs:element ref="cnxml:space"/>
-                <xs:element ref="cnxml:div"/>
-                <xs:element ref="cnxml:definition"/>
-                <xs:element ref="cnxml:example"/>
-                <xs:element ref="cnxml:figure"/>
+                <xs:group ref="mathml:div"/>
+                <xs:group ref="mathml:definition"/>
+                <xs:group ref="mathml:example"/>
+                <xs:group ref="mathml:figure"/>
                 <xs:group ref="mathml:code"/>
                 <xs:group ref="mathml:preformat"/>
                 <xs:group ref="mathml:quote"/>
-                <xs:element ref="cnxml:note"/>
-                <xs:element ref="cnxml:media"/>
+                <xs:group ref="mathml:note"/>
+                <xs:group ref="mathml:media"/>
                 <xs:group ref="mathml:list"/>
-                <xs:element ref="cnxml:table"/>
-                <xs:element ref="cnxml:rule"/>
-                <xs:element ref="cnxml:equation"/>
-                <xs:element ref="cnxml:exercise"/>
+                <xs:group ref="mathml:table"/>
+                <xs:group ref="mathml:rule"/>
+                <xs:group ref="mathml:equation"/>
+                <xs:group ref="mathml:exercise"/>
               </xs:choice>
             </xs:sequence>
             <xs:sequence>
-              <xs:element minOccurs="0" ref="cnxml:label"/>
+              <xs:group minOccurs="0" ref="mathml:label_2"/>
               <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element ref="mathml:math"/>
-                <xs:group ref="mathml:span_2"/>
-                <xs:group ref="mathml:term_2"/>
-                <xs:group ref="mathml:cite_2"/>
-                <xs:element ref="cnxml:cite-title"/>
-                <xs:group ref="mathml:foreign_2"/>
-                <xs:group ref="mathml:emphasis_2"/>
-                <xs:group ref="mathml:sub_2"/>
-                <xs:group ref="mathml:sup_2"/>
+                <xs:group ref="mathml:math_2"/>
+                <xs:group ref="mathml:span_3"/>
+                <xs:group ref="mathml:term_3"/>
+                <xs:group ref="mathml:cite_3"/>
+                <xs:group ref="mathml:cite-title"/>
+                <xs:group ref="mathml:foreign_3"/>
+                <xs:group ref="mathml:emphasis_3"/>
+                <xs:group ref="mathml:sub_3"/>
+                <xs:group ref="mathml:sup_3"/>
                 <xs:group ref="mathml:code"/>
                 <xs:group ref="mathml:preformat"/>
                 <xs:group ref="mathml:quote"/>
-                <xs:element ref="cnxml:note"/>
+                <xs:group ref="mathml:note"/>
                 <xs:group ref="mathml:list"/>
-                <xs:element ref="cnxml:media"/>
-                <xs:element ref="cnxml:footnote"/>
-                <xs:element ref="cnxml:link"/>
+                <xs:group ref="mathml:media"/>
+                <xs:group ref="mathml:footnote"/>
+                <xs:group ref="mathml:link_2"/>
                 <xs:element ref="cnxml:newline"/>
                 <xs:element ref="cnxml:space"/>
               </xs:choice>
@@ -696,192 +742,200 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:element name="note">
-    <xs:complexType mixed="true">
-      <xs:choice>
-        <xs:sequence>
-          <xs:element minOccurs="0" ref="cnxml:label"/>
-          <xs:group minOccurs="0" ref="mathml:title_3"/>
-          <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:group ref="mathml:para"/>
-            <xs:element ref="mathml:math"/>
-            <xs:group ref="mathml:span_2"/>
-            <xs:group ref="mathml:term_2"/>
-            <xs:group ref="mathml:cite_2"/>
-            <xs:element ref="cnxml:cite-title"/>
-            <xs:group ref="mathml:foreign_2"/>
-            <xs:group ref="mathml:emphasis_2"/>
-            <xs:group ref="mathml:sub_2"/>
-            <xs:group ref="mathml:sup_2"/>
-            <xs:group ref="mathml:code"/>
-            <xs:group ref="mathml:preformat"/>
-            <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
-            <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:element ref="cnxml:footnote"/>
-            <xs:element ref="cnxml:link"/>
-            <xs:element ref="cnxml:newline"/>
-            <xs:element ref="cnxml:space"/>
-            <xs:element ref="cnxml:div"/>
-            <xs:element ref="cnxml:definition"/>
-            <xs:element ref="cnxml:example"/>
-            <xs:element ref="cnxml:figure"/>
-            <xs:group ref="mathml:code"/>
-            <xs:group ref="mathml:preformat"/>
-            <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:table"/>
-            <xs:element ref="cnxml:rule"/>
-            <xs:element ref="cnxml:equation"/>
-            <xs:element ref="cnxml:exercise"/>
+  <xs:group name="note">
+    <xs:sequence>
+      <xs:element name="note">
+        <xs:complexType mixed="true">
+          <xs:choice>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="mathml:label_2"/>
+              <xs:group minOccurs="0" ref="mathml:title_5"/>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="mathml:para"/>
+                <xs:group ref="mathml:math_2"/>
+                <xs:group ref="mathml:span_3"/>
+                <xs:group ref="mathml:term_3"/>
+                <xs:group ref="mathml:cite_3"/>
+                <xs:group ref="mathml:cite-title"/>
+                <xs:group ref="mathml:foreign_3"/>
+                <xs:group ref="mathml:emphasis_3"/>
+                <xs:group ref="mathml:sub_3"/>
+                <xs:group ref="mathml:sup_3"/>
+                <xs:group ref="mathml:code"/>
+                <xs:group ref="mathml:preformat"/>
+                <xs:group ref="mathml:quote"/>
+                <xs:group ref="mathml:note"/>
+                <xs:group ref="mathml:list"/>
+                <xs:group ref="mathml:media"/>
+                <xs:group ref="mathml:footnote"/>
+                <xs:group ref="mathml:link_2"/>
+                <xs:element ref="cnxml:newline"/>
+                <xs:element ref="cnxml:space"/>
+                <xs:group ref="mathml:div"/>
+                <xs:group ref="mathml:definition"/>
+                <xs:group ref="mathml:example"/>
+                <xs:group ref="mathml:figure"/>
+                <xs:group ref="mathml:code"/>
+                <xs:group ref="mathml:preformat"/>
+                <xs:group ref="mathml:quote"/>
+                <xs:group ref="mathml:note"/>
+                <xs:group ref="mathml:media"/>
+                <xs:group ref="mathml:list"/>
+                <xs:group ref="mathml:table"/>
+                <xs:group ref="mathml:rule"/>
+                <xs:group ref="mathml:equation"/>
+                <xs:group ref="mathml:exercise"/>
+              </xs:choice>
+            </xs:sequence>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="mathml:label_2"/>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="mathml:math_2"/>
+                <xs:group ref="mathml:span_3"/>
+                <xs:group ref="mathml:term_3"/>
+                <xs:group ref="mathml:cite_3"/>
+                <xs:group ref="mathml:cite-title"/>
+                <xs:group ref="mathml:foreign_3"/>
+                <xs:group ref="mathml:emphasis_3"/>
+                <xs:group ref="mathml:sub_3"/>
+                <xs:group ref="mathml:sup_3"/>
+                <xs:group ref="mathml:code"/>
+                <xs:group ref="mathml:preformat"/>
+                <xs:group ref="mathml:quote"/>
+                <xs:group ref="mathml:note"/>
+                <xs:group ref="mathml:list"/>
+                <xs:group ref="mathml:media"/>
+                <xs:group ref="mathml:footnote"/>
+                <xs:group ref="mathml:link_2"/>
+                <xs:element ref="cnxml:newline"/>
+                <xs:element ref="cnxml:space"/>
+              </xs:choice>
+            </xs:sequence>
           </xs:choice>
-        </xs:sequence>
-        <xs:sequence>
-          <xs:element minOccurs="0" ref="cnxml:label"/>
-          <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="mathml:math"/>
-            <xs:group ref="mathml:span_2"/>
-            <xs:group ref="mathml:term_2"/>
-            <xs:group ref="mathml:cite_2"/>
-            <xs:element ref="cnxml:cite-title"/>
-            <xs:group ref="mathml:foreign_2"/>
-            <xs:group ref="mathml:emphasis_2"/>
-            <xs:group ref="mathml:sub_2"/>
-            <xs:group ref="mathml:sup_2"/>
-            <xs:group ref="mathml:code"/>
-            <xs:group ref="mathml:preformat"/>
-            <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
-            <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:element ref="cnxml:footnote"/>
-            <xs:element ref="cnxml:link"/>
-            <xs:element ref="cnxml:newline"/>
-            <xs:element ref="cnxml:space"/>
-          </xs:choice>
-        </xs:sequence>
-      </xs:choice>
-      <xs:attribute name="display">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="block"/>
-            <xs:enumeration value="none"/>
-            <xs:enumeration value="inline"/>
-            <xs:enumeration value="none"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="type">
-        <xs:simpleType>
-          <xs:union memberTypes="xs:token">
+          <xs:attribute name="display">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="note"/>
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
               </xs:restriction>
             </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="type">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:token">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="note"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="aside"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="warning"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="tip"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="important"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="media">
+    <xs:sequence>
+      <xs:element name="media">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc"/>
+            <xs:choice>
+              <xs:group ref="mathml:object"/>
+              <xs:group ref="mathml:image"/>
+              <xs:group ref="mathml:audio"/>
+              <xs:group ref="mathml:video"/>
+              <xs:group ref="mathml:java-applet"/>
+              <xs:group ref="mathml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview"/>
+              <xs:group ref="mathml:text"/>
+              <xs:group ref="mathml:download"/>
+            </xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:object"/>
+              <xs:group ref="mathml:image"/>
+              <xs:group ref="mathml:audio"/>
+              <xs:group ref="mathml:video"/>
+              <xs:group ref="mathml:java-applet"/>
+              <xs:group ref="mathml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview"/>
+              <xs:group ref="mathml:text"/>
+              <xs:group ref="mathml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="display">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="aside"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
               </xs:restriction>
             </xs:simpleType>
-            <xs:simpleType>
-              <xs:restriction base="xs:token">
-                <xs:enumeration value="warning"/>
-              </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-              <xs:restriction base="xs:token">
-                <xs:enumeration value="tip"/>
-              </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-              <xs:restriction base="xs:token">
-                <xs:enumeration value="important"/>
-              </xs:restriction>
-            </xs:simpleType>
-          </xs:union>
-        </xs:simpleType>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="media">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
-        <xs:choice>
-          <xs:element ref="cnxml:object"/>
-          <xs:element ref="cnxml:image"/>
-          <xs:element ref="cnxml:audio"/>
-          <xs:element ref="cnxml:video"/>
-          <xs:element ref="cnxml:java-applet"/>
-          <xs:element ref="cnxml:flash"/>
-          <xs:element ref="cnxml:iframe"/>
-          <xs:element ref="cnxml:labview"/>
-          <xs:element ref="cnxml:text"/>
-          <xs:element ref="cnxml:download"/>
-        </xs:choice>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="cnxml:object"/>
-          <xs:element ref="cnxml:image"/>
-          <xs:element ref="cnxml:audio"/>
-          <xs:element ref="cnxml:video"/>
-          <xs:element ref="cnxml:java-applet"/>
-          <xs:element ref="cnxml:flash"/>
-          <xs:element ref="cnxml:iframe"/>
-          <xs:element ref="cnxml:labview"/>
-          <xs:element ref="cnxml:text"/>
-          <xs:element ref="cnxml:download"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute name="display">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="inline"/>
-            <xs:enumeration value="none"/>
-            <xs:enumeration value="block"/>
-            <xs:enumeration value="inline"/>
-            <xs:enumeration value="none"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="alt" use="required"/>
-      <xs:attribute name="longdesc"/>
-    </xs:complexType>
-  </xs:element>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="alt" use="required"/>
+          <xs:attribute name="longdesc"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="list">
     <xs:sequence>
       <xs:element name="list">
         <xs:complexType>
           <xs:sequence>
-            <xs:element minOccurs="0" ref="cnxml:label"/>
-            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
             <xs:group maxOccurs="unbounded" ref="mathml:item"/>
           </xs:sequence>
           <xs:attribute name="list-type">
@@ -942,212 +996,228 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:element name="table">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:element maxOccurs="unbounded" ref="cnxml:tgroup"/>
-        <xs:element minOccurs="0" ref="cnxml:caption"/>
-      </xs:sequence>
-      <xs:attribute name="frame">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="top"/>
-            <xs:enumeration value="bottom"/>
-            <xs:enumeration value="topbot"/>
-            <xs:enumeration value="all"/>
-            <xs:enumeration value="sides"/>
-            <xs:enumeration value="none"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="summary" use="required"/>
-      <xs:attribute name="colsep">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="rowsep">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="tabstyle"/>
-      <xs:attribute name="tocentry">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="shortentry">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="orient">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="port"/>
-            <xs:enumeration value="land"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="pgwide">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="type"/>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="rule">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:element maxOccurs="unbounded" ref="cnxml:statement"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="cnxml:proof"/>
-          <xs:element ref="cnxml:example"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="equation">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice minOccurs="0">
-          <xs:element ref="cnxml:media"/>
-          <xs:element ref="mathml:math"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="exercise">
-    <xs:complexType>
-      <xs:choice>
-        <xs:sequence>
-          <xs:element minOccurs="0" ref="cnxml:label"/>
-          <xs:group minOccurs="0" ref="mathml:title_3"/>
-          <xs:element ref="cnxml:problem"/>
-          <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:solution"/>
-          <xs:element minOccurs="0" ref="cnxml:commentary"/>
-        </xs:sequence>
-        <xs:element ref="qml:item"/>
-      </xs:choice>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="print-placement">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="here"/>
-            <xs:enumeration value="end"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="table">
+    <xs:sequence>
+      <xs:element name="table">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:tgroup"/>
+            <xs:group minOccurs="0" ref="mathml:caption"/>
+          </xs:sequence>
+          <xs:attribute name="frame">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="bottom"/>
+                <xs:enumeration value="topbot"/>
+                <xs:enumeration value="all"/>
+                <xs:enumeration value="sides"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="summary" use="required"/>
+          <xs:attribute name="colsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="tabstyle"/>
+          <xs:attribute name="tocentry">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="shortentry">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="orient">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="port"/>
+                <xs:enumeration value="land"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="pgwide">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="type"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="rule">
+    <xs:sequence>
+      <xs:element name="rule">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:statement"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:proof"/>
+              <xs:group ref="mathml:example"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="equation">
+    <xs:sequence>
+      <xs:element name="equation">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice minOccurs="0">
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:math_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="exercise">
+    <xs:sequence>
+      <xs:element name="exercise">
+        <xs:complexType>
+          <xs:choice>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="mathml:label_2"/>
+              <xs:group minOccurs="0" ref="mathml:title_5"/>
+              <xs:group ref="mathml:problem"/>
+              <xs:group minOccurs="0" maxOccurs="unbounded" ref="mathml:solution"/>
+              <xs:group minOccurs="0" ref="mathml:commentary"/>
+            </xs:sequence>
+            <xs:element ref="qml:item"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="print-placement">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="here"/>
+                <xs:enumeration value="end"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="para">
     <xs:sequence>
       <xs:element name="para">
         <xs:complexType mixed="true">
           <xs:sequence>
-            <xs:group minOccurs="0" ref="mathml:title_3"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-              <xs:element ref="mathml:math"/>
-              <xs:group ref="mathml:span_2"/>
-              <xs:group ref="mathml:term_2"/>
-              <xs:group ref="mathml:cite_2"/>
-              <xs:element ref="cnxml:cite-title"/>
-              <xs:group ref="mathml:foreign_2"/>
-              <xs:group ref="mathml:emphasis_2"/>
-              <xs:group ref="mathml:sub_2"/>
-              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
               <xs:group ref="mathml:code"/>
               <xs:group ref="mathml:preformat"/>
               <xs:group ref="mathml:quote"/>
-              <xs:element ref="cnxml:note"/>
+              <xs:group ref="mathml:note"/>
               <xs:group ref="mathml:list"/>
-              <xs:element ref="cnxml:media"/>
-              <xs:element ref="cnxml:footnote"/>
-              <xs:element ref="cnxml:link"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:footnote"/>
+              <xs:group ref="mathml:link_2"/>
               <xs:element ref="cnxml:newline"/>
               <xs:element ref="cnxml:space"/>
-              <xs:element ref="cnxml:div"/>
-              <xs:element ref="cnxml:definition"/>
-              <xs:element ref="cnxml:example"/>
-              <xs:element ref="cnxml:figure"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
               <xs:group ref="mathml:code"/>
               <xs:group ref="mathml:preformat"/>
               <xs:group ref="mathml:quote"/>
-              <xs:element ref="cnxml:note"/>
-              <xs:element ref="cnxml:media"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
               <xs:group ref="mathml:list"/>
-              <xs:element ref="cnxml:table"/>
-              <xs:element ref="cnxml:rule"/>
-              <xs:element ref="cnxml:equation"/>
-              <xs:element ref="cnxml:exercise"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
             </xs:choice>
           </xs:sequence>
           <xs:attribute ref="cmlnle:case"/>
@@ -1179,21 +1249,14 @@
             <xs:group ref="mathml:sup"/>
             <xs:group ref="mathml:sub"/>
             <xs:group ref="mathml:code_2"/>
-            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:math"/>
             <xs:group ref="mathml:quote_2"/>
             <xs:group ref="mathml:preformat_2"/>
             <xs:group ref="mathml:list_2"/>
           </xs:choice>
-          <xs:attribute ref="cmlnle:case"/>
-          <xs:attribute ref="cmlnle:reference"/>
-          <xs:attribute ref="cxlxt:born"/>
-          <xs:attribute ref="cxlxt:died"/>
-          <xs:attribute ref="cxlxt:index"/>
-          <xs:attribute ref="cxlxt:name"/>
-          <xs:attribute ref="ns1:color"/>
-          <xs:attribute ref="ns1:font-style"/>
-          <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -1211,18 +1274,11 @@
             <xs:group ref="mathml:sup"/>
             <xs:group ref="mathml:sub"/>
             <xs:group ref="mathml:code_2"/>
-            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:math"/>
           </xs:choice>
-          <xs:attribute ref="cmlnle:case"/>
-          <xs:attribute ref="cmlnle:reference"/>
-          <xs:attribute ref="cxlxt:born"/>
-          <xs:attribute ref="cxlxt:died"/>
-          <xs:attribute ref="cxlxt:index"/>
-          <xs:attribute ref="cxlxt:name"/>
-          <xs:attribute ref="ns1:color"/>
-          <xs:attribute ref="ns1:font-style"/>
-          <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -1240,18 +1296,11 @@
             <xs:group ref="mathml:sup"/>
             <xs:group ref="mathml:sub"/>
             <xs:group ref="mathml:code_2"/>
-            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:math"/>
           </xs:choice>
-          <xs:attribute ref="cmlnle:case"/>
-          <xs:attribute ref="cmlnle:reference"/>
-          <xs:attribute ref="cxlxt:born"/>
-          <xs:attribute ref="cxlxt:died"/>
-          <xs:attribute ref="cxlxt:index"/>
-          <xs:attribute ref="cxlxt:name"/>
-          <xs:attribute ref="ns1:color"/>
-          <xs:attribute ref="ns1:font-style"/>
-          <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -1269,18 +1318,11 @@
             <xs:group ref="mathml:sup"/>
             <xs:group ref="mathml:sub"/>
             <xs:group ref="mathml:code_2"/>
-            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:math"/>
           </xs:choice>
-          <xs:attribute ref="cmlnle:case"/>
-          <xs:attribute ref="cmlnle:reference"/>
-          <xs:attribute ref="cxlxt:born"/>
-          <xs:attribute ref="cxlxt:died"/>
-          <xs:attribute ref="cxlxt:index"/>
-          <xs:attribute ref="cxlxt:name"/>
-          <xs:attribute ref="ns1:color"/>
-          <xs:attribute ref="ns1:font-style"/>
-          <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -1298,18 +1340,11 @@
             <xs:group ref="mathml:sup"/>
             <xs:group ref="mathml:sub"/>
             <xs:group ref="mathml:code_2"/>
-            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:math"/>
           </xs:choice>
-          <xs:attribute ref="cmlnle:case"/>
-          <xs:attribute ref="cmlnle:reference"/>
-          <xs:attribute ref="cxlxt:born"/>
-          <xs:attribute ref="cxlxt:died"/>
-          <xs:attribute ref="cxlxt:index"/>
-          <xs:attribute ref="cxlxt:name"/>
-          <xs:attribute ref="ns1:color"/>
-          <xs:attribute ref="ns1:font-style"/>
-          <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -1327,18 +1362,11 @@
             <xs:group ref="mathml:sup"/>
             <xs:group ref="mathml:sub"/>
             <xs:group ref="mathml:code_2"/>
-            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:math"/>
           </xs:choice>
-          <xs:attribute ref="cmlnle:case"/>
-          <xs:attribute ref="cmlnle:reference"/>
-          <xs:attribute ref="cxlxt:born"/>
-          <xs:attribute ref="cxlxt:died"/>
-          <xs:attribute ref="cxlxt:index"/>
-          <xs:attribute ref="cxlxt:name"/>
-          <xs:attribute ref="ns1:color"/>
-          <xs:attribute ref="ns1:font-style"/>
-          <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -1356,18 +1384,11 @@
             <xs:group ref="mathml:sup"/>
             <xs:group ref="mathml:sub"/>
             <xs:group ref="mathml:code_2"/>
-            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:math"/>
           </xs:choice>
-          <xs:attribute ref="cmlnle:case"/>
-          <xs:attribute ref="cmlnle:reference"/>
-          <xs:attribute ref="cxlxt:born"/>
-          <xs:attribute ref="cxlxt:died"/>
-          <xs:attribute ref="cxlxt:index"/>
-          <xs:attribute ref="cxlxt:name"/>
-          <xs:attribute ref="ns1:color"/>
-          <xs:attribute ref="ns1:font-style"/>
-          <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -1385,18 +1406,11 @@
             <xs:group ref="mathml:sup"/>
             <xs:group ref="mathml:sub"/>
             <xs:group ref="mathml:code_2"/>
-            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:math"/>
           </xs:choice>
-          <xs:attribute ref="cmlnle:case"/>
-          <xs:attribute ref="cmlnle:reference"/>
-          <xs:attribute ref="cxlxt:born"/>
-          <xs:attribute ref="cxlxt:died"/>
-          <xs:attribute ref="cxlxt:index"/>
-          <xs:attribute ref="cxlxt:name"/>
-          <xs:attribute ref="ns1:color"/>
-          <xs:attribute ref="ns1:font-style"/>
-          <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -1414,18 +1428,10 @@
             <xs:group ref="mathml:sup"/>
             <xs:group ref="mathml:sub"/>
             <xs:group ref="mathml:code_2"/>
-            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:math"/>
           </xs:choice>
-          <xs:attribute ref="cmlnle:case"/>
-          <xs:attribute ref="cmlnle:reference"/>
-          <xs:attribute ref="cxlxt:born"/>
-          <xs:attribute ref="cxlxt:died"/>
-          <xs:attribute ref="cxlxt:index"/>
-          <xs:attribute ref="cxlxt:name"/>
-          <xs:attribute ref="ns1:color"/>
-          <xs:attribute ref="ns1:font-style"/>
-          <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
           <xs:attribute name="display">
             <xs:simpleType>
               <xs:restriction base="xs:token">
@@ -1437,6 +1443,7 @@
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>
+          <xs:anyAttribute processContents="skip"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -1456,22 +1463,14 @@
               <xs:group ref="mathml:sup"/>
               <xs:group ref="mathml:sub"/>
               <xs:group ref="mathml:code_2"/>
-              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:math"/>
               <xs:group ref="mathml:quote_2"/>
               <xs:group ref="mathml:preformat_2"/>
               <xs:group ref="mathml:list_2"/>
             </xs:choice>
           </xs:choice>
-          <xs:attribute ref="cmlnle:case"/>
-          <xs:attribute ref="cmlnle:reference"/>
-          <xs:attribute ref="cxlxt:born"/>
-          <xs:attribute ref="cxlxt:died"/>
-          <xs:attribute ref="cxlxt:index"/>
-          <xs:attribute ref="cxlxt:name"/>
-          <xs:attribute ref="ns1:color"/>
-          <xs:attribute ref="ns1:font-style"/>
-          <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
           <xs:attribute name="display">
             <xs:simpleType>
               <xs:restriction base="xs:token">
@@ -1483,6 +1482,7 @@
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>
+          <xs:anyAttribute processContents="skip"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -1502,10 +1502,457 @@
               <xs:group ref="mathml:sup"/>
               <xs:group ref="mathml:sub"/>
               <xs:group ref="mathml:code_2"/>
-              <xs:element ref="mathml:math"/>
+              <xs:group ref="mathml:math"/>
               <xs:group ref="mathml:quote_2"/>
               <xs:group ref="mathml:preformat_2"/>
               <xs:group ref="mathml:list_2"/>
+            </xs:choice>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list1">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:item_3"/>
+          <xs:attribute name="list-type">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="bulleted"/>
+                <xs:enumeration value="enumerated"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="label">
+    <xs:sequence>
+      <xs:element name="label">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="link">
+    <xs:sequence>
+      <xs:element name="link">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="strength">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="1"/>
+                <xs:enumeration value="2"/>
+                <xs:enumeration value="3"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="para2">
+    <xs:sequence>
+      <xs:element name="para">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:list_3"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="emphasis1">
+    <xs:sequence>
+      <xs:element name="emphasis">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:math_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="term1">
+    <xs:sequence>
+      <xs:element name="term">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:math_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="foreign1">
+    <xs:sequence>
+      <xs:element name="foreign">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:math_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite1">
+    <xs:sequence>
+      <xs:element name="cite">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:math_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="span1">
+    <xs:sequence>
+      <xs:element name="span">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:math_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sup1">
+    <xs:sequence>
+      <xs:element name="sup">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:math_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sub1">
+    <xs:sequence>
+      <xs:element name="sub">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:math_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="code2">
+    <xs:sequence>
+      <xs:element name="code">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:math_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="quote2">
+    <xs:sequence>
+      <xs:element name="quote">
+        <xs:complexType mixed="true">
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="mathml:para_3"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:list_3"/>
             </xs:choice>
           </xs:choice>
           <xs:attribute ref="cmlnle:case"/>
@@ -1533,11 +1980,57 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:group name="list1">
+  <xs:group name="preformat2">
+    <xs:sequence>
+      <xs:element name="preformat">
+        <xs:complexType mixed="true">
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="mathml:para_3"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:list_3"/>
+            </xs:choice>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list2">
     <xs:sequence>
       <xs:element name="list">
         <xs:complexType>
-          <xs:group maxOccurs="unbounded" ref="mathml:item_3"/>
+          <xs:group maxOccurs="unbounded" ref="mathml:item_4"/>
           <xs:attribute name="list-type">
             <xs:simpleType>
               <xs:restriction base="xs:token">
@@ -1571,124 +2064,132 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:element name="label">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:math"/>
-        <xs:group ref="mathml:span_2"/>
-        <xs:group ref="mathml:term_2"/>
-        <xs:group ref="mathml:cite_2"/>
-        <xs:element ref="cnxml:cite-title"/>
-        <xs:group ref="mathml:foreign_2"/>
-        <xs:group ref="mathml:emphasis_2"/>
-        <xs:group ref="mathml:sub_2"/>
-        <xs:group ref="mathml:sup_2"/>
-        <xs:group ref="mathml:code"/>
-        <xs:group ref="mathml:preformat"/>
-        <xs:group ref="mathml:quote"/>
-        <xs:element ref="cnxml:note"/>
-        <xs:group ref="mathml:list"/>
-        <xs:element ref="cnxml:media"/>
-        <xs:element ref="cnxml:footnote"/>
-        <xs:element ref="cnxml:link"/>
-        <xs:element ref="cnxml:newline"/>
-        <xs:element ref="cnxml:space"/>
-      </xs:choice>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="link">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:math"/>
-        <xs:group ref="mathml:span_2"/>
-        <xs:group ref="mathml:term_2"/>
-        <xs:group ref="mathml:cite_2"/>
-        <xs:element ref="cnxml:cite-title"/>
-        <xs:group ref="mathml:foreign_2"/>
-        <xs:group ref="mathml:emphasis_2"/>
-        <xs:group ref="mathml:sub_2"/>
-        <xs:group ref="mathml:sup_2"/>
-        <xs:group ref="mathml:code"/>
-        <xs:group ref="mathml:preformat"/>
-        <xs:group ref="mathml:quote"/>
-        <xs:element ref="cnxml:note"/>
-        <xs:group ref="mathml:list"/>
-        <xs:element ref="cnxml:media"/>
-        <xs:element ref="cnxml:footnote"/>
-        <xs:element ref="cnxml:link"/>
-        <xs:element ref="cnxml:newline"/>
-        <xs:element ref="cnxml:space"/>
-      </xs:choice>
-      <xs:attribute name="strength">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="1"/>
-            <xs:enumeration value="2"/>
-            <xs:enumeration value="3"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="window">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="replace"/>
-            <xs:enumeration value="new"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="url"/>
-      <xs:attribute name="document"/>
-      <xs:attribute name="version"/>
-      <xs:attribute name="target-id"/>
-      <xs:attribute name="resource"/>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="label1">
+    <xs:sequence>
+      <xs:element name="label">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
+            <xs:group ref="mathml:code"/>
+            <xs:group ref="mathml:preformat"/>
+            <xs:group ref="mathml:quote"/>
+            <xs:group ref="mathml:note"/>
+            <xs:group ref="mathml:list"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="link1">
+    <xs:sequence>
+      <xs:element name="link">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
+            <xs:group ref="mathml:code"/>
+            <xs:group ref="mathml:preformat"/>
+            <xs:group ref="mathml:quote"/>
+            <xs:group ref="mathml:note"/>
+            <xs:group ref="mathml:list"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="strength">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="1"/>
+                <xs:enumeration value="2"/>
+                <xs:enumeration value="3"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="title1">
     <xs:sequence>
       <xs:element name="title">
         <xs:complexType mixed="true">
           <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="mathml:math"/>
-            <xs:group ref="mathml:span_2"/>
-            <xs:group ref="mathml:term_2"/>
-            <xs:group ref="mathml:cite_2"/>
-            <xs:element ref="cnxml:cite-title"/>
-            <xs:group ref="mathml:foreign_2"/>
-            <xs:group ref="mathml:emphasis_2"/>
-            <xs:group ref="mathml:sub_2"/>
-            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
             <xs:group ref="mathml:code"/>
             <xs:group ref="mathml:preformat"/>
             <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
+            <xs:group ref="mathml:note"/>
             <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:element ref="cnxml:footnote"/>
-            <xs:element ref="cnxml:link"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
             <xs:element ref="cnxml:newline"/>
             <xs:element ref="cnxml:space"/>
           </xs:choice>
@@ -1708,28 +2209,28 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:group name="span1">
+  <xs:group name="span2">
     <xs:sequence>
       <xs:element name="span">
         <xs:complexType mixed="true">
           <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="mathml:math"/>
-            <xs:group ref="mathml:span_2"/>
-            <xs:group ref="mathml:term_2"/>
-            <xs:group ref="mathml:cite_2"/>
-            <xs:element ref="cnxml:cite-title"/>
-            <xs:group ref="mathml:foreign_2"/>
-            <xs:group ref="mathml:emphasis_2"/>
-            <xs:group ref="mathml:sub_2"/>
-            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
             <xs:group ref="mathml:code"/>
             <xs:group ref="mathml:preformat"/>
             <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
+            <xs:group ref="mathml:note"/>
             <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:element ref="cnxml:footnote"/>
-            <xs:element ref="cnxml:link"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
             <xs:element ref="cnxml:newline"/>
             <xs:element ref="cnxml:space"/>
           </xs:choice>
@@ -1780,28 +2281,28 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:group name="term1">
+  <xs:group name="term2">
     <xs:sequence>
       <xs:element name="term">
         <xs:complexType mixed="true">
           <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="mathml:math"/>
-            <xs:group ref="mathml:span_2"/>
-            <xs:group ref="mathml:term_2"/>
-            <xs:group ref="mathml:cite_2"/>
-            <xs:element ref="cnxml:cite-title"/>
-            <xs:group ref="mathml:foreign_2"/>
-            <xs:group ref="mathml:emphasis_2"/>
-            <xs:group ref="mathml:sub_2"/>
-            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
             <xs:group ref="mathml:code"/>
             <xs:group ref="mathml:preformat"/>
             <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
+            <xs:group ref="mathml:note"/>
             <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:element ref="cnxml:footnote"/>
-            <xs:element ref="cnxml:link"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
             <xs:element ref="cnxml:newline"/>
             <xs:element ref="cnxml:space"/>
           </xs:choice>
@@ -1834,28 +2335,28 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:group name="cite1">
+  <xs:group name="cite2">
     <xs:sequence>
       <xs:element name="cite">
         <xs:complexType mixed="true">
           <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="mathml:math"/>
-            <xs:group ref="mathml:span_2"/>
-            <xs:group ref="mathml:term_2"/>
-            <xs:group ref="mathml:cite_2"/>
-            <xs:element ref="cnxml:cite-title"/>
-            <xs:group ref="mathml:foreign_2"/>
-            <xs:group ref="mathml:emphasis_2"/>
-            <xs:group ref="mathml:sub_2"/>
-            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
             <xs:group ref="mathml:code"/>
             <xs:group ref="mathml:preformat"/>
             <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
+            <xs:group ref="mathml:note"/>
             <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:element ref="cnxml:footnote"/>
-            <xs:element ref="cnxml:link"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
             <xs:element ref="cnxml:newline"/>
             <xs:element ref="cnxml:space"/>
           </xs:choice>
@@ -1888,85 +2389,89 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:element name="cite-title">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:math"/>
-        <xs:group ref="mathml:span_2"/>
-        <xs:group ref="mathml:term_2"/>
-        <xs:group ref="mathml:cite_2"/>
-        <xs:element ref="cnxml:cite-title"/>
-        <xs:group ref="mathml:foreign_2"/>
-        <xs:group ref="mathml:emphasis_2"/>
-        <xs:group ref="mathml:sub_2"/>
-        <xs:group ref="mathml:sup_2"/>
-        <xs:group ref="mathml:code"/>
-        <xs:group ref="mathml:preformat"/>
-        <xs:group ref="mathml:quote"/>
-        <xs:element ref="cnxml:note"/>
-        <xs:group ref="mathml:list"/>
-        <xs:element ref="cnxml:media"/>
-        <xs:element ref="cnxml:footnote"/>
-        <xs:element ref="cnxml:link"/>
-        <xs:element ref="cnxml:newline"/>
-        <xs:element ref="cnxml:space"/>
-      </xs:choice>
-      <xs:attribute name="pub-type">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="article"/>
-            <xs:enumeration value="book"/>
-            <xs:enumeration value="booklet"/>
-            <xs:enumeration value="conference"/>
-            <xs:enumeration value="inbook"/>
-            <xs:enumeration value="incollection"/>
-            <xs:enumeration value="inproceedings"/>
-            <xs:enumeration value="manual"/>
-            <xs:enumeration value="mastersthesis"/>
-            <xs:enumeration value="misc"/>
-            <xs:enumeration value="phdthesis"/>
-            <xs:enumeration value="proceedings"/>
-            <xs:enumeration value="techreport"/>
-            <xs:enumeration value="unpublished"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:group name="foreign1">
+  <xs:group name="cite-title">
+    <xs:sequence>
+      <xs:element name="cite-title">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
+            <xs:group ref="mathml:code"/>
+            <xs:group ref="mathml:preformat"/>
+            <xs:group ref="mathml:quote"/>
+            <xs:group ref="mathml:note"/>
+            <xs:group ref="mathml:list"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="pub-type">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="article"/>
+                <xs:enumeration value="book"/>
+                <xs:enumeration value="booklet"/>
+                <xs:enumeration value="conference"/>
+                <xs:enumeration value="inbook"/>
+                <xs:enumeration value="incollection"/>
+                <xs:enumeration value="inproceedings"/>
+                <xs:enumeration value="manual"/>
+                <xs:enumeration value="mastersthesis"/>
+                <xs:enumeration value="misc"/>
+                <xs:enumeration value="phdthesis"/>
+                <xs:enumeration value="proceedings"/>
+                <xs:enumeration value="techreport"/>
+                <xs:enumeration value="unpublished"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="foreign2">
     <xs:sequence>
       <xs:element name="foreign">
         <xs:complexType mixed="true">
           <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="mathml:math"/>
-            <xs:group ref="mathml:span_2"/>
-            <xs:group ref="mathml:term_2"/>
-            <xs:group ref="mathml:cite_2"/>
-            <xs:element ref="cnxml:cite-title"/>
-            <xs:group ref="mathml:foreign_2"/>
-            <xs:group ref="mathml:emphasis_2"/>
-            <xs:group ref="mathml:sub_2"/>
-            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
             <xs:group ref="mathml:code"/>
             <xs:group ref="mathml:preformat"/>
             <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
+            <xs:group ref="mathml:note"/>
             <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:element ref="cnxml:footnote"/>
-            <xs:element ref="cnxml:link"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
             <xs:element ref="cnxml:newline"/>
             <xs:element ref="cnxml:space"/>
           </xs:choice>
@@ -1999,28 +2504,28 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:group name="emphasis1">
+  <xs:group name="emphasis2">
     <xs:sequence>
       <xs:element name="emphasis">
         <xs:complexType mixed="true">
           <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="mathml:math"/>
-            <xs:group ref="mathml:span_2"/>
-            <xs:group ref="mathml:term_2"/>
-            <xs:group ref="mathml:cite_2"/>
-            <xs:element ref="cnxml:cite-title"/>
-            <xs:group ref="mathml:foreign_2"/>
-            <xs:group ref="mathml:emphasis_2"/>
-            <xs:group ref="mathml:sub_2"/>
-            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
             <xs:group ref="mathml:code"/>
             <xs:group ref="mathml:preformat"/>
             <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
+            <xs:group ref="mathml:note"/>
             <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:element ref="cnxml:footnote"/>
-            <xs:element ref="cnxml:link"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
             <xs:element ref="cnxml:newline"/>
             <xs:element ref="cnxml:space"/>
           </xs:choice>
@@ -2071,28 +2576,28 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:group name="sub1">
+  <xs:group name="sub2">
     <xs:sequence>
       <xs:element name="sub">
         <xs:complexType mixed="true">
           <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="mathml:math"/>
-            <xs:group ref="mathml:span_2"/>
-            <xs:group ref="mathml:term_2"/>
-            <xs:group ref="mathml:cite_2"/>
-            <xs:element ref="cnxml:cite-title"/>
-            <xs:group ref="mathml:foreign_2"/>
-            <xs:group ref="mathml:emphasis_2"/>
-            <xs:group ref="mathml:sub_2"/>
-            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
             <xs:group ref="mathml:code"/>
             <xs:group ref="mathml:preformat"/>
             <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
+            <xs:group ref="mathml:note"/>
             <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:element ref="cnxml:footnote"/>
-            <xs:element ref="cnxml:link"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
             <xs:element ref="cnxml:newline"/>
             <xs:element ref="cnxml:space"/>
           </xs:choice>
@@ -2112,28 +2617,28 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:group name="sup1">
+  <xs:group name="sup2">
     <xs:sequence>
       <xs:element name="sup">
         <xs:complexType mixed="true">
           <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="mathml:math"/>
-            <xs:group ref="mathml:span_2"/>
-            <xs:group ref="mathml:term_2"/>
-            <xs:group ref="mathml:cite_2"/>
-            <xs:element ref="cnxml:cite-title"/>
-            <xs:group ref="mathml:foreign_2"/>
-            <xs:group ref="mathml:emphasis_2"/>
-            <xs:group ref="mathml:sub_2"/>
-            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
             <xs:group ref="mathml:code"/>
             <xs:group ref="mathml:preformat"/>
             <xs:group ref="mathml:quote"/>
-            <xs:element ref="cnxml:note"/>
+            <xs:group ref="mathml:note"/>
             <xs:group ref="mathml:list"/>
-            <xs:element ref="cnxml:media"/>
-            <xs:element ref="cnxml:footnote"/>
-            <xs:element ref="cnxml:link"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
             <xs:element ref="cnxml:newline"/>
             <xs:element ref="cnxml:space"/>
           </xs:choice>
@@ -2153,61 +2658,65 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:element name="footnote">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:group ref="mathml:para"/>
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:element ref="cnxml:footnote"/>
-          <xs:element ref="cnxml:link"/>
-          <xs:element ref="cnxml:newline"/>
-          <xs:element ref="cnxml:space"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="footnote">
+    <xs:sequence>
+      <xs:element name="footnote">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:footnote"/>
+              <xs:group ref="mathml:link_2"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:element name="newline">
     <xs:complexType>
       <xs:attribute ref="cmlnle:case"/>
@@ -2316,720 +2825,764 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-  <xs:element name="seealso">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group maxOccurs="unbounded" ref="mathml:term_2"/>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="meaning">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:group ref="mathml:para"/>
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:element ref="cnxml:footnote"/>
-          <xs:element ref="cnxml:link"/>
-          <xs:element ref="cnxml:newline"/>
-          <xs:element ref="cnxml:space"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="subfigure">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice>
-          <xs:element ref="cnxml:media"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:group ref="mathml:code"/>
-        </xs:choice>
-        <xs:element minOccurs="0" ref="cnxml:caption"/>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="caption">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:math"/>
-        <xs:group ref="mathml:span_2"/>
-        <xs:group ref="mathml:term_2"/>
-        <xs:group ref="mathml:cite_2"/>
-        <xs:element ref="cnxml:cite-title"/>
-        <xs:group ref="mathml:foreign_2"/>
-        <xs:group ref="mathml:emphasis_2"/>
-        <xs:group ref="mathml:sub_2"/>
-        <xs:group ref="mathml:sup_2"/>
-        <xs:group ref="mathml:code"/>
-        <xs:group ref="mathml:preformat"/>
-        <xs:group ref="mathml:quote"/>
-        <xs:element ref="cnxml:note"/>
-        <xs:group ref="mathml:list"/>
-        <xs:element ref="cnxml:media"/>
-        <xs:element ref="cnxml:footnote"/>
-        <xs:element ref="cnxml:link"/>
-        <xs:element ref="cnxml:newline"/>
-        <xs:element ref="cnxml:space"/>
-      </xs:choice>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="longdesc">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:group ref="mathml:para"/>
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:element ref="cnxml:footnote"/>
-          <xs:element ref="cnxml:link"/>
-          <xs:element ref="cnxml:newline"/>
-          <xs:element ref="cnxml:space"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="object">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:object"/>
-          <xs:element ref="cnxml:image"/>
-          <xs:element ref="cnxml:audio"/>
-          <xs:element ref="cnxml:video"/>
-          <xs:element ref="cnxml:java-applet"/>
-          <xs:element ref="cnxml:flash"/>
-          <xs:element ref="cnxml:iframe"/>
-          <xs:element ref="cnxml:labview"/>
-          <xs:element ref="cnxml:text"/>
-          <xs:element ref="cnxml:download"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="mime-type" use="required"/>
-      <xs:attribute name="for">
-        <xs:simpleType>
-          <xs:union memberTypes="xs:NMTOKEN">
+  <xs:group name="seealso">
+    <xs:sequence>
+      <xs:element name="seealso">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:term_3"/>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="meaning">
+    <xs:sequence>
+      <xs:element name="meaning">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:footnote"/>
+              <xs:group ref="mathml:link_2"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subfigure">
+    <xs:sequence>
+      <xs:element name="subfigure">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:code"/>
+            </xs:choice>
+            <xs:group minOccurs="0" ref="mathml:caption"/>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="caption">
+    <xs:sequence>
+      <xs:element name="caption">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
+            <xs:group ref="mathml:code"/>
+            <xs:group ref="mathml:preformat"/>
+            <xs:group ref="mathml:quote"/>
+            <xs:group ref="mathml:note"/>
+            <xs:group ref="mathml:list"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="longdesc">
+    <xs:sequence>
+      <xs:element name="longdesc">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:footnote"/>
+              <xs:group ref="mathml:link_2"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="object">
+    <xs:sequence>
+      <xs:element name="object">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:object"/>
+              <xs:group ref="mathml:image"/>
+              <xs:group ref="mathml:audio"/>
+              <xs:group ref="mathml:video"/>
+              <xs:group ref="mathml:java-applet"/>
+              <xs:group ref="mathml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview"/>
+              <xs:group ref="mathml:text"/>
+              <xs:group ref="mathml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="image">
+    <xs:sequence>
+      <xs:element name="image">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:object"/>
+              <xs:group ref="mathml:image"/>
+              <xs:group ref="mathml:audio"/>
+              <xs:group ref="mathml:video"/>
+              <xs:group ref="mathml:java-applet"/>
+              <xs:group ref="mathml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview"/>
+              <xs:group ref="mathml:text"/>
+              <xs:group ref="mathml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+          <xs:attribute name="print-width"/>
+          <xs:attribute name="thumbnail"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="audio">
+    <xs:sequence>
+      <xs:element name="audio">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:object"/>
+              <xs:group ref="mathml:image"/>
+              <xs:group ref="mathml:audio"/>
+              <xs:group ref="mathml:video"/>
+              <xs:group ref="mathml:java-applet"/>
+              <xs:group ref="mathml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview"/>
+              <xs:group ref="mathml:text"/>
+              <xs:group ref="mathml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+          <xs:attribute name="standby"/>
+          <xs:attribute name="autoplay">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="online"/>
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
               </xs:restriction>
             </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="loop">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="pdf"/>
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
               </xs:restriction>
             </xs:simpleType>
-          </xs:union>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="longdesc"/>
-      <xs:attribute name="src" use="required"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="image">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:object"/>
-          <xs:element ref="cnxml:image"/>
-          <xs:element ref="cnxml:audio"/>
-          <xs:element ref="cnxml:video"/>
-          <xs:element ref="cnxml:java-applet"/>
-          <xs:element ref="cnxml:flash"/>
-          <xs:element ref="cnxml:iframe"/>
-          <xs:element ref="cnxml:labview"/>
-          <xs:element ref="cnxml:text"/>
-          <xs:element ref="cnxml:download"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="mime-type" use="required"/>
-      <xs:attribute name="for">
-        <xs:simpleType>
-          <xs:union memberTypes="xs:NMTOKEN">
+          </xs:attribute>
+          <xs:attribute name="controller">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="online"/>
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
               </xs:restriction>
             </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="volume">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="1"/>
+                <xs:maxInclusive value="100"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="video">
+    <xs:sequence>
+      <xs:element name="video">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:object"/>
+              <xs:group ref="mathml:image"/>
+              <xs:group ref="mathml:audio"/>
+              <xs:group ref="mathml:video"/>
+              <xs:group ref="mathml:java-applet"/>
+              <xs:group ref="mathml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview"/>
+              <xs:group ref="mathml:text"/>
+              <xs:group ref="mathml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+          <xs:attribute name="standby"/>
+          <xs:attribute name="autoplay">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="pdf"/>
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
               </xs:restriction>
             </xs:simpleType>
-          </xs:union>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="longdesc"/>
-      <xs:attribute name="src" use="required"/>
-      <xs:attribute name="print-width"/>
-      <xs:attribute name="thumbnail"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="audio">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:object"/>
-          <xs:element ref="cnxml:image"/>
-          <xs:element ref="cnxml:audio"/>
-          <xs:element ref="cnxml:video"/>
-          <xs:element ref="cnxml:java-applet"/>
-          <xs:element ref="cnxml:flash"/>
-          <xs:element ref="cnxml:iframe"/>
-          <xs:element ref="cnxml:labview"/>
-          <xs:element ref="cnxml:text"/>
-          <xs:element ref="cnxml:download"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="mime-type" use="required"/>
-      <xs:attribute name="for">
-        <xs:simpleType>
-          <xs:union memberTypes="xs:NMTOKEN">
+          </xs:attribute>
+          <xs:attribute name="loop">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="online"/>
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
               </xs:restriction>
             </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="controller">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="pdf"/>
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
               </xs:restriction>
             </xs:simpleType>
-          </xs:union>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="longdesc"/>
-      <xs:attribute name="src" use="required"/>
-      <xs:attribute name="standby"/>
-      <xs:attribute name="autoplay">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="loop">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="controller">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="volume">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="1"/>
-            <xs:maxInclusive value="100"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="video">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:object"/>
-          <xs:element ref="cnxml:image"/>
-          <xs:element ref="cnxml:audio"/>
-          <xs:element ref="cnxml:video"/>
-          <xs:element ref="cnxml:java-applet"/>
-          <xs:element ref="cnxml:flash"/>
-          <xs:element ref="cnxml:iframe"/>
-          <xs:element ref="cnxml:labview"/>
-          <xs:element ref="cnxml:text"/>
-          <xs:element ref="cnxml:download"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="mime-type" use="required"/>
-      <xs:attribute name="for">
-        <xs:simpleType>
-          <xs:union memberTypes="xs:NMTOKEN">
+          </xs:attribute>
+          <xs:attribute name="volume">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="1"/>
+                <xs:maxInclusive value="100"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="java-applet">
+    <xs:sequence>
+      <xs:element name="java-applet">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:object"/>
+              <xs:group ref="mathml:image"/>
+              <xs:group ref="mathml:audio"/>
+              <xs:group ref="mathml:video"/>
+              <xs:group ref="mathml:java-applet"/>
+              <xs:group ref="mathml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview"/>
+              <xs:group ref="mathml:text"/>
+              <xs:group ref="mathml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src"/>
+          <xs:attribute name="codebase"/>
+          <xs:attribute name="code" use="required"/>
+          <xs:attribute name="archive"/>
+          <xs:attribute name="name"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="flash">
+    <xs:sequence>
+      <xs:element name="flash">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:object"/>
+              <xs:group ref="mathml:image"/>
+              <xs:group ref="mathml:audio"/>
+              <xs:group ref="mathml:video"/>
+              <xs:group ref="mathml:java-applet"/>
+              <xs:group ref="mathml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview"/>
+              <xs:group ref="mathml:text"/>
+              <xs:group ref="mathml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+          <xs:attribute name="wmode">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="online"/>
+                <xs:enumeration value="window"/>
+                <xs:enumeration value="opaque"/>
+                <xs:enumeration value="transparent"/>
               </xs:restriction>
             </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="loop">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="pdf"/>
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
               </xs:restriction>
             </xs:simpleType>
-          </xs:union>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="longdesc"/>
-      <xs:attribute name="src" use="required"/>
-      <xs:attribute name="standby"/>
-      <xs:attribute name="autoplay">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="loop">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="controller">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="volume">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="1"/>
-            <xs:maxInclusive value="100"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="java-applet">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:object"/>
-          <xs:element ref="cnxml:image"/>
-          <xs:element ref="cnxml:audio"/>
-          <xs:element ref="cnxml:video"/>
-          <xs:element ref="cnxml:java-applet"/>
-          <xs:element ref="cnxml:flash"/>
-          <xs:element ref="cnxml:iframe"/>
-          <xs:element ref="cnxml:labview"/>
-          <xs:element ref="cnxml:text"/>
-          <xs:element ref="cnxml:download"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="mime-type" use="required"/>
-      <xs:attribute name="for">
-        <xs:simpleType>
-          <xs:union memberTypes="xs:NMTOKEN">
+          </xs:attribute>
+          <xs:attribute name="quality">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="online"/>
+                <xs:enumeration value="low"/>
+                <xs:enumeration value="autolow"/>
+                <xs:enumeration value="autohigh"/>
+                <xs:enumeration value="medium"/>
+                <xs:enumeration value="high"/>
               </xs:restriction>
             </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="scale">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="pdf"/>
+                <xs:enumeration value="default"/>
+                <xs:enumeration value="noorder"/>
+                <xs:enumeration value="exactfit"/>
               </xs:restriction>
             </xs:simpleType>
-          </xs:union>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="longdesc"/>
-      <xs:attribute name="src"/>
-      <xs:attribute name="codebase"/>
-      <xs:attribute name="code" use="required"/>
-      <xs:attribute name="archive"/>
-      <xs:attribute name="name"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="flash">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:object"/>
-          <xs:element ref="cnxml:image"/>
-          <xs:element ref="cnxml:audio"/>
-          <xs:element ref="cnxml:video"/>
-          <xs:element ref="cnxml:java-applet"/>
-          <xs:element ref="cnxml:flash"/>
-          <xs:element ref="cnxml:iframe"/>
-          <xs:element ref="cnxml:labview"/>
-          <xs:element ref="cnxml:text"/>
-          <xs:element ref="cnxml:download"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="mime-type" use="required"/>
-      <xs:attribute name="for">
-        <xs:simpleType>
-          <xs:union memberTypes="xs:NMTOKEN">
+          </xs:attribute>
+          <xs:attribute name="bgcolor">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="online"/>
+                <xs:pattern value="#[a-fA-F0-9]{6}"/>
               </xs:restriction>
             </xs:simpleType>
-            <xs:simpleType>
-              <xs:restriction base="xs:token">
-                <xs:enumeration value="pdf"/>
-              </xs:restriction>
-            </xs:simpleType>
-          </xs:union>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="longdesc"/>
-      <xs:attribute name="src" use="required"/>
-      <xs:attribute name="wmode">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="window"/>
-            <xs:enumeration value="opaque"/>
-            <xs:enumeration value="transparent"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="loop">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="quality">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="low"/>
-            <xs:enumeration value="autolow"/>
-            <xs:enumeration value="autohigh"/>
-            <xs:enumeration value="medium"/>
-            <xs:enumeration value="high"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="scale">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="default"/>
-            <xs:enumeration value="noorder"/>
-            <xs:enumeration value="exactfit"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="bgcolor">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:pattern value="#[a-fA-F0-9]{6}"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="flash-vars"/>
-    </xs:complexType>
-  </xs:element>
+          </xs:attribute>
+          <xs:attribute name="flash-vars"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:element name="iframe">
     <xs:complexType>
       <xs:attribute name="src" use="required"/>
@@ -3038,288 +3591,300 @@
       <xs:attribute name="width"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="labview">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:object"/>
-          <xs:element ref="cnxml:image"/>
-          <xs:element ref="cnxml:audio"/>
-          <xs:element ref="cnxml:video"/>
-          <xs:element ref="cnxml:java-applet"/>
-          <xs:element ref="cnxml:flash"/>
-          <xs:element ref="cnxml:iframe"/>
-          <xs:element ref="cnxml:labview"/>
-          <xs:element ref="cnxml:text"/>
-          <xs:element ref="cnxml:download"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="mime-type" use="required"/>
-      <xs:attribute name="for">
-        <xs:simpleType>
-          <xs:union memberTypes="xs:NMTOKEN">
+  <xs:group name="labview">
+    <xs:sequence>
+      <xs:element name="labview">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:object"/>
+              <xs:group ref="mathml:image"/>
+              <xs:group ref="mathml:audio"/>
+              <xs:group ref="mathml:video"/>
+              <xs:group ref="mathml:java-applet"/>
+              <xs:group ref="mathml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview"/>
+              <xs:group ref="mathml:text"/>
+              <xs:group ref="mathml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+          <xs:attribute name="viname" use="required"/>
+          <xs:attribute name="version" use="required">
             <xs:simpleType>
               <xs:restriction base="xs:token">
-                <xs:enumeration value="online"/>
+                <xs:enumeration value="7.0"/>
+                <xs:enumeration value="8.0"/>
+                <xs:enumeration value="8.2"/>
               </xs:restriction>
             </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="text">
+    <xs:sequence>
+      <xs:element name="text">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:footnote"/>
+              <xs:group ref="mathml:link_2"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type"/>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src"/>
+          <xs:attribute name="for">
             <xs:simpleType>
-              <xs:restriction base="xs:token">
-                <xs:enumeration value="pdf"/>
-              </xs:restriction>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
             </xs:simpleType>
-          </xs:union>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="longdesc"/>
-      <xs:attribute name="src" use="required"/>
-      <xs:attribute name="viname" use="required"/>
-      <xs:attribute name="version" use="required">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="7.0"/>
-            <xs:enumeration value="8.0"/>
-            <xs:enumeration value="8.2"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="text">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:group ref="mathml:para"/>
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:element ref="cnxml:footnote"/>
-          <xs:element ref="cnxml:link"/>
-          <xs:element ref="cnxml:newline"/>
-          <xs:element ref="cnxml:space"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="mime-type"/>
-      <xs:attribute name="longdesc"/>
-      <xs:attribute name="src"/>
-      <xs:attribute name="for">
-        <xs:simpleType>
-          <xs:union memberTypes="xs:NMTOKEN">
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="download">
+    <xs:sequence>
+      <xs:element name="download">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:object"/>
+              <xs:group ref="mathml:image"/>
+              <xs:group ref="mathml:audio"/>
+              <xs:group ref="mathml:video"/>
+              <xs:group ref="mathml:java-applet"/>
+              <xs:group ref="mathml:flash"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview"/>
+              <xs:group ref="mathml:text"/>
+              <xs:group ref="mathml:download"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
             <xs:simpleType>
-              <xs:restriction base="xs:token">
-                <xs:enumeration value="online"/>
-              </xs:restriction>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
             </xs:simpleType>
-            <xs:simpleType>
-              <xs:restriction base="xs:token">
-                <xs:enumeration value="pdf"/>
-              </xs:restriction>
-            </xs:simpleType>
-          </xs:union>
-        </xs:simpleType>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="download">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:longdesc"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:object"/>
-          <xs:element ref="cnxml:image"/>
-          <xs:element ref="cnxml:audio"/>
-          <xs:element ref="cnxml:video"/>
-          <xs:element ref="cnxml:java-applet"/>
-          <xs:element ref="cnxml:flash"/>
-          <xs:element ref="cnxml:iframe"/>
-          <xs:element ref="cnxml:labview"/>
-          <xs:element ref="cnxml:text"/>
-          <xs:element ref="cnxml:download"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="mime-type" use="required"/>
-      <xs:attribute name="for">
-        <xs:simpleType>
-          <xs:union memberTypes="xs:NMTOKEN">
-            <xs:simpleType>
-              <xs:restriction base="xs:token">
-                <xs:enumeration value="online"/>
-              </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-              <xs:restriction base="xs:token">
-                <xs:enumeration value="pdf"/>
-              </xs:restriction>
-            </xs:simpleType>
-          </xs:union>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="longdesc"/>
-      <xs:attribute name="src" use="required"/>
-    </xs:complexType>
-  </xs:element>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="item">
     <xs:sequence>
       <xs:element name="item">
         <xs:complexType mixed="true">
           <xs:sequence>
-            <xs:element minOccurs="0" ref="cnxml:label"/>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
             <xs:choice>
               <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:group ref="mathml:para"/>
-                <xs:element ref="mathml:math"/>
-                <xs:group ref="mathml:span_2"/>
-                <xs:group ref="mathml:term_2"/>
-                <xs:group ref="mathml:cite_2"/>
-                <xs:element ref="cnxml:cite-title"/>
-                <xs:group ref="mathml:foreign_2"/>
-                <xs:group ref="mathml:emphasis_2"/>
-                <xs:group ref="mathml:sub_2"/>
-                <xs:group ref="mathml:sup_2"/>
+                <xs:group ref="mathml:math_2"/>
+                <xs:group ref="mathml:span_3"/>
+                <xs:group ref="mathml:term_3"/>
+                <xs:group ref="mathml:cite_3"/>
+                <xs:group ref="mathml:cite-title"/>
+                <xs:group ref="mathml:foreign_3"/>
+                <xs:group ref="mathml:emphasis_3"/>
+                <xs:group ref="mathml:sub_3"/>
+                <xs:group ref="mathml:sup_3"/>
                 <xs:group ref="mathml:code"/>
                 <xs:group ref="mathml:preformat"/>
                 <xs:group ref="mathml:quote"/>
-                <xs:element ref="cnxml:note"/>
+                <xs:group ref="mathml:note"/>
                 <xs:group ref="mathml:list"/>
-                <xs:element ref="cnxml:media"/>
-                <xs:element ref="cnxml:footnote"/>
-                <xs:element ref="cnxml:link"/>
+                <xs:group ref="mathml:media"/>
+                <xs:group ref="mathml:footnote"/>
+                <xs:group ref="mathml:link_2"/>
                 <xs:element ref="cnxml:newline"/>
                 <xs:element ref="cnxml:space"/>
-                <xs:element ref="cnxml:div"/>
-                <xs:element ref="cnxml:definition"/>
-                <xs:element ref="cnxml:example"/>
-                <xs:element ref="cnxml:figure"/>
+                <xs:group ref="mathml:div"/>
+                <xs:group ref="mathml:definition"/>
+                <xs:group ref="mathml:example"/>
+                <xs:group ref="mathml:figure"/>
                 <xs:group ref="mathml:code"/>
                 <xs:group ref="mathml:preformat"/>
                 <xs:group ref="mathml:quote"/>
-                <xs:element ref="cnxml:note"/>
-                <xs:element ref="cnxml:media"/>
+                <xs:group ref="mathml:note"/>
+                <xs:group ref="mathml:media"/>
                 <xs:group ref="mathml:list"/>
-                <xs:element ref="cnxml:table"/>
-                <xs:element ref="cnxml:rule"/>
-                <xs:element ref="cnxml:equation"/>
-                <xs:element ref="cnxml:exercise"/>
+                <xs:group ref="mathml:table"/>
+                <xs:group ref="mathml:rule"/>
+                <xs:group ref="mathml:equation"/>
+                <xs:group ref="mathml:exercise"/>
               </xs:choice>
               <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element ref="mathml:math"/>
-                <xs:group ref="mathml:span_2"/>
-                <xs:group ref="mathml:term_2"/>
-                <xs:group ref="mathml:cite_2"/>
-                <xs:element ref="cnxml:cite-title"/>
-                <xs:group ref="mathml:foreign_2"/>
-                <xs:group ref="mathml:emphasis_2"/>
-                <xs:group ref="mathml:sub_2"/>
-                <xs:group ref="mathml:sup_2"/>
+                <xs:group ref="mathml:math_2"/>
+                <xs:group ref="mathml:span_3"/>
+                <xs:group ref="mathml:term_3"/>
+                <xs:group ref="mathml:cite_3"/>
+                <xs:group ref="mathml:cite-title"/>
+                <xs:group ref="mathml:foreign_3"/>
+                <xs:group ref="mathml:emphasis_3"/>
+                <xs:group ref="mathml:sub_3"/>
+                <xs:group ref="mathml:sup_3"/>
                 <xs:group ref="mathml:code"/>
                 <xs:group ref="mathml:preformat"/>
                 <xs:group ref="mathml:quote"/>
-                <xs:element ref="cnxml:note"/>
+                <xs:group ref="mathml:note"/>
                 <xs:group ref="mathml:list"/>
-                <xs:element ref="cnxml:media"/>
-                <xs:element ref="cnxml:footnote"/>
-                <xs:element ref="cnxml:link"/>
+                <xs:group ref="mathml:media"/>
+                <xs:group ref="mathml:footnote"/>
+                <xs:group ref="mathml:link_2"/>
                 <xs:element ref="cnxml:newline"/>
                 <xs:element ref="cnxml:space"/>
               </xs:choice>
@@ -3341,279 +3906,303 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:element name="tgroup">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:spanspec"/>
-        <xs:element minOccurs="0" ref="cnxml:thead"/>
-        <xs:element minOccurs="0" ref="cnxml:tfoot"/>
-        <xs:element ref="cnxml:tbody"/>
-      </xs:sequence>
-      <xs:attribute name="cols" use="required"/>
-      <xs:attribute name="tgroupstyle"/>
-      <xs:attribute name="colsep">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="rowsep">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="align">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="left"/>
-            <xs:enumeration value="right"/>
-            <xs:enumeration value="center"/>
-            <xs:enumeration value="justify"/>
-            <xs:enumeration value="char"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="char"/>
-      <xs:attribute name="charoff"/>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="statement">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice maxOccurs="unbounded">
-          <xs:element ref="cnxml:section"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-          <xs:group ref="mathml:para"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="proof">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice maxOccurs="unbounded">
-          <xs:element ref="cnxml:section"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-          <xs:group ref="mathml:para"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="problem">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice maxOccurs="unbounded">
-          <xs:element ref="cnxml:section"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-          <xs:group ref="mathml:para"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="solution">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice maxOccurs="unbounded">
-          <xs:element ref="cnxml:section"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-          <xs:group ref="mathml:para"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute name="print-placement">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="here"/>
-            <xs:enumeration value="end"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="commentary">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="cnxml:label"/>
-        <xs:group minOccurs="0" ref="mathml:title_3"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:group ref="mathml:para"/>
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:span_2"/>
-          <xs:group ref="mathml:term_2"/>
-          <xs:group ref="mathml:cite_2"/>
-          <xs:element ref="cnxml:cite-title"/>
-          <xs:group ref="mathml:foreign_2"/>
-          <xs:group ref="mathml:emphasis_2"/>
-          <xs:group ref="mathml:sub_2"/>
-          <xs:group ref="mathml:sup_2"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:element ref="cnxml:footnote"/>
-          <xs:element ref="cnxml:link"/>
-          <xs:element ref="cnxml:newline"/>
-          <xs:element ref="cnxml:space"/>
-          <xs:element ref="cnxml:div"/>
-          <xs:element ref="cnxml:definition"/>
-          <xs:element ref="cnxml:example"/>
-          <xs:element ref="cnxml:figure"/>
-          <xs:group ref="mathml:code"/>
-          <xs:group ref="mathml:preformat"/>
-          <xs:group ref="mathml:quote"/>
-          <xs:element ref="cnxml:note"/>
-          <xs:element ref="cnxml:media"/>
-          <xs:group ref="mathml:list"/>
-          <xs:element ref="cnxml:table"/>
-          <xs:element ref="cnxml:rule"/>
-          <xs:element ref="cnxml:equation"/>
-          <xs:element ref="cnxml:exercise"/>
-        </xs:choice>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="tgroup">
+    <xs:sequence>
+      <xs:element name="tgroup">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:spanspec"/>
+            <xs:group minOccurs="0" ref="mathml:thead"/>
+            <xs:group minOccurs="0" ref="mathml:tfoot"/>
+            <xs:group ref="mathml:tbody"/>
+          </xs:sequence>
+          <xs:attribute name="cols" use="required"/>
+          <xs:attribute name="tgroupstyle"/>
+          <xs:attribute name="colsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="align">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+                <xs:enumeration value="center"/>
+                <xs:enumeration value="justify"/>
+                <xs:enumeration value="char"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="char"/>
+          <xs:attribute name="charoff"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="statement">
+    <xs:sequence>
+      <xs:element name="statement">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+              <xs:group ref="mathml:para"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="proof">
+    <xs:sequence>
+      <xs:element name="proof">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+              <xs:group ref="mathml:para"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="problem">
+    <xs:sequence>
+      <xs:element name="problem">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+              <xs:group ref="mathml:para"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="solution">
+    <xs:sequence>
+      <xs:element name="solution">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+              <xs:group ref="mathml:para"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="print-placement">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="here"/>
+                <xs:enumeration value="end"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="commentary">
+    <xs:sequence>
+      <xs:element name="commentary">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label_2"/>
+            <xs:group minOccurs="0" ref="mathml:title_5"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:span_3"/>
+              <xs:group ref="mathml:term_3"/>
+              <xs:group ref="mathml:cite_3"/>
+              <xs:group ref="mathml:cite-title"/>
+              <xs:group ref="mathml:foreign_3"/>
+              <xs:group ref="mathml:emphasis_3"/>
+              <xs:group ref="mathml:sub_3"/>
+              <xs:group ref="mathml:sup_3"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:footnote"/>
+              <xs:group ref="mathml:link_2"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div"/>
+              <xs:group ref="mathml:definition"/>
+              <xs:group ref="mathml:example"/>
+              <xs:group ref="mathml:figure"/>
+              <xs:group ref="mathml:code"/>
+              <xs:group ref="mathml:preformat"/>
+              <xs:group ref="mathml:quote"/>
+              <xs:group ref="mathml:note"/>
+              <xs:group ref="mathml:media"/>
+              <xs:group ref="mathml:list"/>
+              <xs:group ref="mathml:table"/>
+              <xs:group ref="mathml:rule"/>
+              <xs:group ref="mathml:equation"/>
+              <xs:group ref="mathml:exercise"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="item1">
     <xs:sequence>
       <xs:element name="item">
@@ -3627,10 +4216,1063 @@
             <xs:group ref="mathml:sup"/>
             <xs:group ref="mathml:sub"/>
             <xs:group ref="mathml:code_2"/>
-            <xs:element ref="mathml:math"/>
+            <xs:group ref="mathml:math"/>
             <xs:group ref="mathml:quote_2"/>
             <xs:group ref="mathml:preformat_2"/>
             <xs:group ref="mathml:list_2"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="span3">
+    <xs:sequence>
+      <xs:element name="span">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="effect">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="bold"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="italics"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="underline"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="normal"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="smallcaps"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="term3">
+    <xs:sequence>
+      <xs:element name="term">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite3">
+    <xs:sequence>
+      <xs:element name="cite">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite-title1">
+    <xs:sequence>
+      <xs:element name="cite-title">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="pub-type">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="article"/>
+                <xs:enumeration value="book"/>
+                <xs:enumeration value="booklet"/>
+                <xs:enumeration value="conference"/>
+                <xs:enumeration value="inbook"/>
+                <xs:enumeration value="incollection"/>
+                <xs:enumeration value="inproceedings"/>
+                <xs:enumeration value="manual"/>
+                <xs:enumeration value="mastersthesis"/>
+                <xs:enumeration value="misc"/>
+                <xs:enumeration value="phdthesis"/>
+                <xs:enumeration value="proceedings"/>
+                <xs:enumeration value="techreport"/>
+                <xs:enumeration value="unpublished"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="foreign3">
+    <xs:sequence>
+      <xs:element name="foreign">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="emphasis3">
+    <xs:sequence>
+      <xs:element name="emphasis">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute name="effect">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="bold"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="italics"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="underline"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="normal"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="smallcaps"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sub3">
+    <xs:sequence>
+      <xs:element name="sub">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sup3">
+    <xs:sequence>
+      <xs:element name="sup">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="code3">
+    <xs:sequence>
+      <xs:element name="code">
+        <xs:complexType mixed="true">
+          <xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:footnote_2"/>
+              <xs:group ref="mathml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+            </xs:choice>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="mathml:label"/>
+              <xs:group minOccurs="0" ref="mathml:title_7"/>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="mathml:span_4"/>
+                <xs:group ref="mathml:term_4"/>
+                <xs:group ref="mathml:cite_4"/>
+                <xs:group ref="mathml:cite-title_2"/>
+                <xs:group ref="mathml:foreign_4"/>
+                <xs:group ref="mathml:emphasis_4"/>
+                <xs:group ref="mathml:sub_4"/>
+                <xs:group ref="mathml:sup_4"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:footnote_2"/>
+                <xs:group ref="mathml:link"/>
+                <xs:element ref="cnxml:newline"/>
+                <xs:element ref="cnxml:space"/>
+              </xs:choice>
+              <xs:group minOccurs="0" ref="mathml:caption_2"/>
+            </xs:sequence>
+          </xs:choice>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="lang"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="preformat3">
+    <xs:sequence>
+      <xs:element name="preformat">
+        <xs:complexType mixed="true">
+          <xs:choice>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="mathml:title_7"/>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="mathml:para_4"/>
+                <xs:group ref="mathml:span_4"/>
+                <xs:group ref="mathml:term_4"/>
+                <xs:group ref="mathml:cite_4"/>
+                <xs:group ref="mathml:cite-title_2"/>
+                <xs:group ref="mathml:foreign_4"/>
+                <xs:group ref="mathml:emphasis_4"/>
+                <xs:group ref="mathml:sub_4"/>
+                <xs:group ref="mathml:sup_4"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:footnote_2"/>
+                <xs:group ref="mathml:link"/>
+                <xs:element ref="cnxml:newline"/>
+                <xs:element ref="cnxml:space"/>
+                <xs:group ref="mathml:div_2"/>
+                <xs:group ref="mathml:definition_2"/>
+                <xs:group ref="mathml:example_2"/>
+                <xs:group ref="mathml:figure_2"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:table_2"/>
+                <xs:group ref="mathml:rule_2"/>
+                <xs:group ref="mathml:equation_2"/>
+                <xs:group ref="mathml:exercise_2"/>
+              </xs:choice>
+            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:footnote_2"/>
+              <xs:group ref="mathml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+            </xs:choice>
+          </xs:choice>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="quote3">
+    <xs:sequence>
+      <xs:element name="quote">
+        <xs:complexType mixed="true">
+          <xs:choice>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="mathml:label"/>
+              <xs:group minOccurs="0" ref="mathml:title_7"/>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="mathml:para_4"/>
+                <xs:group ref="mathml:span_4"/>
+                <xs:group ref="mathml:term_4"/>
+                <xs:group ref="mathml:cite_4"/>
+                <xs:group ref="mathml:cite-title_2"/>
+                <xs:group ref="mathml:foreign_4"/>
+                <xs:group ref="mathml:emphasis_4"/>
+                <xs:group ref="mathml:sub_4"/>
+                <xs:group ref="mathml:sup_4"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:footnote_2"/>
+                <xs:group ref="mathml:link"/>
+                <xs:element ref="cnxml:newline"/>
+                <xs:element ref="cnxml:space"/>
+                <xs:group ref="mathml:div_2"/>
+                <xs:group ref="mathml:definition_2"/>
+                <xs:group ref="mathml:example_2"/>
+                <xs:group ref="mathml:figure_2"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:table_2"/>
+                <xs:group ref="mathml:rule_2"/>
+                <xs:group ref="mathml:equation_2"/>
+                <xs:group ref="mathml:exercise_2"/>
+              </xs:choice>
+            </xs:sequence>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="mathml:label"/>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="mathml:span_4"/>
+                <xs:group ref="mathml:term_4"/>
+                <xs:group ref="mathml:cite_4"/>
+                <xs:group ref="mathml:cite-title_2"/>
+                <xs:group ref="mathml:foreign_4"/>
+                <xs:group ref="mathml:emphasis_4"/>
+                <xs:group ref="mathml:sub_4"/>
+                <xs:group ref="mathml:sup_4"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:footnote_2"/>
+                <xs:group ref="mathml:link"/>
+                <xs:element ref="cnxml:newline"/>
+                <xs:element ref="cnxml:space"/>
+              </xs:choice>
+            </xs:sequence>
+          </xs:choice>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="window">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="new"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="target-id"/>
+          <xs:attribute name="resource"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="note1">
+    <xs:sequence>
+      <xs:element name="note">
+        <xs:complexType mixed="true">
+          <xs:choice>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="mathml:label"/>
+              <xs:group minOccurs="0" ref="mathml:title_7"/>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="mathml:para_4"/>
+                <xs:group ref="mathml:span_4"/>
+                <xs:group ref="mathml:term_4"/>
+                <xs:group ref="mathml:cite_4"/>
+                <xs:group ref="mathml:cite-title_2"/>
+                <xs:group ref="mathml:foreign_4"/>
+                <xs:group ref="mathml:emphasis_4"/>
+                <xs:group ref="mathml:sub_4"/>
+                <xs:group ref="mathml:sup_4"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:footnote_2"/>
+                <xs:group ref="mathml:link"/>
+                <xs:element ref="cnxml:newline"/>
+                <xs:element ref="cnxml:space"/>
+                <xs:group ref="mathml:div_2"/>
+                <xs:group ref="mathml:definition_2"/>
+                <xs:group ref="mathml:example_2"/>
+                <xs:group ref="mathml:figure_2"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:table_2"/>
+                <xs:group ref="mathml:rule_2"/>
+                <xs:group ref="mathml:equation_2"/>
+                <xs:group ref="mathml:exercise_2"/>
+              </xs:choice>
+            </xs:sequence>
+            <xs:sequence>
+              <xs:group minOccurs="0" ref="mathml:label"/>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="mathml:span_4"/>
+                <xs:group ref="mathml:term_4"/>
+                <xs:group ref="mathml:cite_4"/>
+                <xs:group ref="mathml:cite-title_2"/>
+                <xs:group ref="mathml:foreign_4"/>
+                <xs:group ref="mathml:emphasis_4"/>
+                <xs:group ref="mathml:sub_4"/>
+                <xs:group ref="mathml:sup_4"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:footnote_2"/>
+                <xs:group ref="mathml:link"/>
+                <xs:element ref="cnxml:newline"/>
+                <xs:element ref="cnxml:space"/>
+              </xs:choice>
+            </xs:sequence>
+          </xs:choice>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="type">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:token">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="note"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="aside"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="warning"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="tip"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="important"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list3">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:item_5"/>
+          </xs:sequence>
+          <xs:attribute name="list-type">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="bulleted"/>
+                <xs:enumeration value="enumerated"/>
+                <xs:enumeration value="labeled-item"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="mark-suffix"/>
+          <xs:attribute name="bullet-style"/>
+          <xs:attribute name="number-style">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="arabic"/>
+                <xs:enumeration value="upper-alpha"/>
+                <xs:enumeration value="lower-alpha"/>
+                <xs:enumeration value="upper-roman"/>
+                <xs:enumeration value="lower-roman"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="start-value">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="1"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="mark-prefix"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="item-sep"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="media1">
+    <xs:sequence>
+      <xs:element name="media">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc_2"/>
+            <xs:choice>
+              <xs:group ref="mathml:object_2"/>
+              <xs:group ref="mathml:image_3"/>
+              <xs:group ref="mathml:audio_2"/>
+              <xs:group ref="mathml:video_2"/>
+              <xs:group ref="mathml:java-applet_2"/>
+              <xs:group ref="mathml:flash_2"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview_2"/>
+              <xs:group ref="mathml:text_2"/>
+              <xs:group ref="mathml:download_2"/>
+            </xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:object_2"/>
+              <xs:group ref="mathml:image_3"/>
+              <xs:group ref="mathml:audio_2"/>
+              <xs:group ref="mathml:video_2"/>
+              <xs:group ref="mathml:java-applet_2"/>
+              <xs:group ref="mathml:flash_2"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview_2"/>
+              <xs:group ref="mathml:text_2"/>
+              <xs:group ref="mathml:download_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="display">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="block"/>
+                <xs:enumeration value="inline"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="alt" use="required"/>
+          <xs:attribute name="longdesc"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="footnote1">
+    <xs:sequence>
+      <xs:element name="footnote">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para_4"/>
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:footnote_2"/>
+              <xs:group ref="mathml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="item2">
+    <xs:sequence>
+      <xs:element name="item">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis_2"/>
+            <xs:group ref="mathml:term_2"/>
+            <xs:group ref="mathml:foreign_2"/>
+            <xs:group ref="mathml:cite_2"/>
+            <xs:group ref="mathml:span_2"/>
+            <xs:group ref="mathml:sup_2"/>
+            <xs:group ref="mathml:sub_2"/>
+            <xs:group ref="mathml:code_3"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:quote_3"/>
+            <xs:group ref="mathml:preformat_3"/>
+            <xs:group ref="mathml:list_3"/>
           </xs:choice>
           <xs:attribute ref="cmlnle:case"/>
           <xs:attribute ref="cmlnle:reference"/>
@@ -3757,281 +5399,2451 @@
       <xs:attribute name="id" type="xs:ID"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="thead">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
-        <xs:element maxOccurs="unbounded" ref="cnxml:row"/>
-      </xs:sequence>
-      <xs:attribute name="valign">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="top"/>
-            <xs:enumeration value="middle"/>
-            <xs:enumeration value="bottom"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="tfoot">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
-        <xs:element maxOccurs="unbounded" ref="cnxml:row"/>
-      </xs:sequence>
-      <xs:attribute name="valign">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="top"/>
-            <xs:enumeration value="middle"/>
-            <xs:enumeration value="bottom"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="tbody">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="cnxml:row"/>
-      </xs:sequence>
-      <xs:attribute name="valign">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="top"/>
-            <xs:enumeration value="middle"/>
-            <xs:enumeration value="bottom"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="row">
-    <xs:complexType>
-      <xs:choice maxOccurs="unbounded">
-        <xs:element ref="cnxml:entry"/>
-        <xs:element ref="cnxml:entrytbl"/>
-      </xs:choice>
-      <xs:attribute name="rowsep">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="valign">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="top"/>
-            <xs:enumeration value="middle"/>
-            <xs:enumeration value="bottom"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="entry">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="mathml:para"/>
-        <xs:element ref="mathml:math"/>
-        <xs:group ref="mathml:span_2"/>
-        <xs:group ref="mathml:term_2"/>
-        <xs:group ref="mathml:cite_2"/>
-        <xs:element ref="cnxml:cite-title"/>
-        <xs:group ref="mathml:foreign_2"/>
-        <xs:group ref="mathml:emphasis_2"/>
-        <xs:group ref="mathml:sub_2"/>
-        <xs:group ref="mathml:sup_2"/>
-        <xs:group ref="mathml:code"/>
-        <xs:group ref="mathml:preformat"/>
-        <xs:group ref="mathml:quote"/>
-        <xs:element ref="cnxml:note"/>
-        <xs:group ref="mathml:list"/>
-        <xs:element ref="cnxml:media"/>
-        <xs:element ref="cnxml:footnote"/>
-        <xs:element ref="cnxml:link"/>
-        <xs:element ref="cnxml:newline"/>
-        <xs:element ref="cnxml:space"/>
-        <xs:element ref="cnxml:div"/>
-        <xs:element ref="cnxml:definition"/>
-        <xs:element ref="cnxml:example"/>
-        <xs:element ref="cnxml:figure"/>
-        <xs:group ref="mathml:code"/>
-        <xs:group ref="mathml:preformat"/>
-        <xs:group ref="mathml:quote"/>
-        <xs:element ref="cnxml:note"/>
-        <xs:element ref="cnxml:media"/>
-        <xs:group ref="mathml:list"/>
-        <xs:element ref="cnxml:table"/>
-        <xs:element ref="cnxml:rule"/>
-        <xs:element ref="cnxml:equation"/>
-        <xs:element ref="cnxml:exercise"/>
-      </xs:choice>
-      <xs:attribute name="colname"/>
-      <xs:attribute name="namest"/>
-      <xs:attribute name="nameend"/>
-      <xs:attribute name="spanname"/>
-      <xs:attribute name="morerows"/>
-      <xs:attribute name="colsep">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="rowsep">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="align">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="left"/>
-            <xs:enumeration value="right"/>
-            <xs:enumeration value="center"/>
-            <xs:enumeration value="justify"/>
-            <xs:enumeration value="char"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="char"/>
-      <xs:attribute name="charoff"/>
-      <xs:attribute name="rotate">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="valign">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="top"/>
-            <xs:enumeration value="middle"/>
-            <xs:enumeration value="bottom"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="entrytbl">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:spanspec"/>
-        <xs:element minOccurs="0" ref="cnxml:thead"/>
-        <xs:element ref="cnxml:tbody"/>
-      </xs:sequence>
-      <xs:attribute name="cols" use="required"/>
-      <xs:attribute name="tgroupstyle"/>
-      <xs:attribute name="colname"/>
-      <xs:attribute name="spanname"/>
-      <xs:attribute name="namest"/>
-      <xs:attribute name="nameend"/>
-      <xs:attribute name="colsep">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="rowsep">
-        <xs:simpleType>
-          <xs:restriction base="xs:integer">
-            <xs:minInclusive value="0"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="align">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="left"/>
-            <xs:enumeration value="right"/>
-            <xs:enumeration value="center"/>
-            <xs:enumeration value="justify"/>
-            <xs:enumeration value="char"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="char"/>
-      <xs:attribute name="charoff"/>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="id" type="xs:ID"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="thead">
+    <xs:sequence>
+      <xs:element name="thead">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:row"/>
+          </xs:sequence>
+          <xs:attribute name="valign">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="middle"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="tfoot">
+    <xs:sequence>
+      <xs:element name="tfoot">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:row"/>
+          </xs:sequence>
+          <xs:attribute name="valign">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="middle"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="tbody">
+    <xs:sequence>
+      <xs:element name="tbody">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:row"/>
+          <xs:attribute name="valign">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="middle"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="title2">
+    <xs:sequence>
+      <xs:element name="title">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="caption1">
+    <xs:sequence>
+      <xs:element name="caption">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="para3">
+    <xs:sequence>
+      <xs:element name="para">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:footnote_2"/>
+              <xs:group ref="mathml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="div1">
+    <xs:sequence>
+      <xs:element name="div">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para_4"/>
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:footnote_2"/>
+              <xs:group ref="mathml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="definition1">
+    <xs:sequence>
+      <xs:element name="definition">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:choice>
+              <xs:group ref="mathml:seealso_2"/>
+              <xs:sequence>
+                <xs:sequence maxOccurs="unbounded">
+                  <xs:group ref="mathml:meaning_2"/>
+                  <xs:group minOccurs="0" maxOccurs="unbounded" ref="mathml:example_2"/>
+                </xs:sequence>
+                <xs:group minOccurs="0" ref="mathml:seealso_2"/>
+              </xs:sequence>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="example1">
+    <xs:sequence>
+      <xs:element name="example">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section_2"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+              <xs:group ref="mathml:para_4"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="figure1">
+    <xs:sequence>
+      <xs:element name="figure">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:sequence>
+                <xs:group ref="mathml:subfigure_2"/>
+                <xs:group maxOccurs="unbounded" ref="mathml:subfigure_2"/>
+              </xs:sequence>
+            </xs:choice>
+            <xs:group minOccurs="0" ref="mathml:caption_2"/>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="orient">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="horizontal"/>
+                <xs:enumeration value="vertical"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="table1">
+    <xs:sequence>
+      <xs:element name="table">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:tgroup_2"/>
+            <xs:group minOccurs="0" ref="mathml:caption_2"/>
+          </xs:sequence>
+          <xs:attribute name="frame">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="bottom"/>
+                <xs:enumeration value="topbot"/>
+                <xs:enumeration value="all"/>
+                <xs:enumeration value="sides"/>
+                <xs:enumeration value="none"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="summary" use="required"/>
+          <xs:attribute name="colsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="tabstyle"/>
+          <xs:attribute name="tocentry">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="shortentry">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="orient">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="port"/>
+                <xs:enumeration value="land"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="pgwide">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="type"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="rule1">
+    <xs:sequence>
+      <xs:element name="rule">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:statement_2"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:proof_2"/>
+              <xs:group ref="mathml:example_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="equation1">
+    <xs:sequence>
+      <xs:element name="equation">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:group minOccurs="0" ref="mathml:media_2"/>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="exercise1">
+    <xs:sequence>
+      <xs:element name="exercise">
+        <xs:complexType>
+          <xs:sequence minOccurs="0">
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:group ref="mathml:problem_2"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="mathml:solution_2"/>
+            <xs:group minOccurs="0" ref="mathml:commentary_2"/>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="print-placement">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="here"/>
+                <xs:enumeration value="end"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="item3">
+    <xs:sequence>
+      <xs:element name="item">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:choice>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="mathml:para_4"/>
+                <xs:group ref="mathml:span_4"/>
+                <xs:group ref="mathml:term_4"/>
+                <xs:group ref="mathml:cite_4"/>
+                <xs:group ref="mathml:cite-title_2"/>
+                <xs:group ref="mathml:foreign_4"/>
+                <xs:group ref="mathml:emphasis_4"/>
+                <xs:group ref="mathml:sub_4"/>
+                <xs:group ref="mathml:sup_4"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:footnote_2"/>
+                <xs:group ref="mathml:link"/>
+                <xs:element ref="cnxml:newline"/>
+                <xs:element ref="cnxml:space"/>
+                <xs:group ref="mathml:div_2"/>
+                <xs:group ref="mathml:definition_2"/>
+                <xs:group ref="mathml:example_2"/>
+                <xs:group ref="mathml:figure_2"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:table_2"/>
+                <xs:group ref="mathml:rule_2"/>
+                <xs:group ref="mathml:equation_2"/>
+                <xs:group ref="mathml:exercise_2"/>
+              </xs:choice>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="mathml:span_4"/>
+                <xs:group ref="mathml:term_4"/>
+                <xs:group ref="mathml:cite_4"/>
+                <xs:group ref="mathml:cite-title_2"/>
+                <xs:group ref="mathml:foreign_4"/>
+                <xs:group ref="mathml:emphasis_4"/>
+                <xs:group ref="mathml:sub_4"/>
+                <xs:group ref="mathml:sup_4"/>
+                <xs:group ref="mathml:code_4"/>
+                <xs:group ref="mathml:preformat_4"/>
+                <xs:group ref="mathml:quote_4"/>
+                <xs:group ref="mathml:note_2"/>
+                <xs:group ref="mathml:list_5"/>
+                <xs:group ref="mathml:media_2"/>
+                <xs:group ref="mathml:footnote_2"/>
+                <xs:group ref="mathml:link"/>
+                <xs:element ref="cnxml:newline"/>
+                <xs:element ref="cnxml:space"/>
+              </xs:choice>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="longdesc1">
+    <xs:sequence>
+      <xs:element name="longdesc">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para_4"/>
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:footnote_2"/>
+              <xs:group ref="mathml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="object1">
+    <xs:sequence>
+      <xs:element name="object">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc_2"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:object_2"/>
+              <xs:group ref="mathml:image_3"/>
+              <xs:group ref="mathml:audio_2"/>
+              <xs:group ref="mathml:video_2"/>
+              <xs:group ref="mathml:java-applet_2"/>
+              <xs:group ref="mathml:flash_2"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview_2"/>
+              <xs:group ref="mathml:text_2"/>
+              <xs:group ref="mathml:download_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="image1">
+    <xs:sequence>
+      <xs:element name="image">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc_2"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:object_2"/>
+              <xs:group ref="mathml:image_3"/>
+              <xs:group ref="mathml:audio_2"/>
+              <xs:group ref="mathml:video_2"/>
+              <xs:group ref="mathml:java-applet_2"/>
+              <xs:group ref="mathml:flash_2"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview_2"/>
+              <xs:group ref="mathml:text_2"/>
+              <xs:group ref="mathml:download_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+          <xs:attribute name="print-width"/>
+          <xs:attribute name="thumbnail"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="audio1">
+    <xs:sequence>
+      <xs:element name="audio">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc_2"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:object_2"/>
+              <xs:group ref="mathml:image_3"/>
+              <xs:group ref="mathml:audio_2"/>
+              <xs:group ref="mathml:video_2"/>
+              <xs:group ref="mathml:java-applet_2"/>
+              <xs:group ref="mathml:flash_2"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview_2"/>
+              <xs:group ref="mathml:text_2"/>
+              <xs:group ref="mathml:download_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+          <xs:attribute name="standby"/>
+          <xs:attribute name="autoplay">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="loop">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="controller">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="volume">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="1"/>
+                <xs:maxInclusive value="100"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="video1">
+    <xs:sequence>
+      <xs:element name="video">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc_2"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:object_2"/>
+              <xs:group ref="mathml:image_3"/>
+              <xs:group ref="mathml:audio_2"/>
+              <xs:group ref="mathml:video_2"/>
+              <xs:group ref="mathml:java-applet_2"/>
+              <xs:group ref="mathml:flash_2"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview_2"/>
+              <xs:group ref="mathml:text_2"/>
+              <xs:group ref="mathml:download_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+          <xs:attribute name="standby"/>
+          <xs:attribute name="autoplay">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="loop">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="controller">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="volume">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="1"/>
+                <xs:maxInclusive value="100"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="java-applet1">
+    <xs:sequence>
+      <xs:element name="java-applet">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc_2"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:object_2"/>
+              <xs:group ref="mathml:image_3"/>
+              <xs:group ref="mathml:audio_2"/>
+              <xs:group ref="mathml:video_2"/>
+              <xs:group ref="mathml:java-applet_2"/>
+              <xs:group ref="mathml:flash_2"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview_2"/>
+              <xs:group ref="mathml:text_2"/>
+              <xs:group ref="mathml:download_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src"/>
+          <xs:attribute name="codebase"/>
+          <xs:attribute name="code" use="required"/>
+          <xs:attribute name="archive"/>
+          <xs:attribute name="name"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="flash1">
+    <xs:sequence>
+      <xs:element name="flash">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc_2"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:object_2"/>
+              <xs:group ref="mathml:image_3"/>
+              <xs:group ref="mathml:audio_2"/>
+              <xs:group ref="mathml:video_2"/>
+              <xs:group ref="mathml:java-applet_2"/>
+              <xs:group ref="mathml:flash_2"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview_2"/>
+              <xs:group ref="mathml:text_2"/>
+              <xs:group ref="mathml:download_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+          <xs:attribute name="wmode">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="window"/>
+                <xs:enumeration value="opaque"/>
+                <xs:enumeration value="transparent"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="loop">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="quality">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="low"/>
+                <xs:enumeration value="autolow"/>
+                <xs:enumeration value="autohigh"/>
+                <xs:enumeration value="medium"/>
+                <xs:enumeration value="high"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="scale">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="default"/>
+                <xs:enumeration value="noorder"/>
+                <xs:enumeration value="exactfit"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="bgcolor">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:pattern value="#[a-fA-F0-9]{6}"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="flash-vars"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="labview1">
+    <xs:sequence>
+      <xs:element name="labview">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc_2"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:object_2"/>
+              <xs:group ref="mathml:image_3"/>
+              <xs:group ref="mathml:audio_2"/>
+              <xs:group ref="mathml:video_2"/>
+              <xs:group ref="mathml:java-applet_2"/>
+              <xs:group ref="mathml:flash_2"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview_2"/>
+              <xs:group ref="mathml:text_2"/>
+              <xs:group ref="mathml:download_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+          <xs:attribute name="viname" use="required"/>
+          <xs:attribute name="version" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="7.0"/>
+                <xs:enumeration value="8.0"/>
+                <xs:enumeration value="8.2"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="text1">
+    <xs:sequence>
+      <xs:element name="text">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc_2"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para_4"/>
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:footnote_2"/>
+              <xs:group ref="mathml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type"/>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="download1">
+    <xs:sequence>
+      <xs:element name="download">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:longdesc_2"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:param"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:object_2"/>
+              <xs:group ref="mathml:image_3"/>
+              <xs:group ref="mathml:audio_2"/>
+              <xs:group ref="mathml:video_2"/>
+              <xs:group ref="mathml:java-applet_2"/>
+              <xs:group ref="mathml:flash_2"/>
+              <xs:element ref="cnxml:iframe"/>
+              <xs:group ref="mathml:labview_2"/>
+              <xs:group ref="mathml:text_2"/>
+              <xs:group ref="mathml:download_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="mime-type" use="required"/>
+          <xs:attribute name="for">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:NMTOKEN">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="online"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="pdf"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="longdesc"/>
+          <xs:attribute name="src" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="row">
+    <xs:sequence>
+      <xs:element name="row">
+        <xs:complexType>
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="mathml:entry_2"/>
+            <xs:group ref="mathml:entrytbl"/>
+          </xs:choice>
+          <xs:attribute name="rowsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="valign">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="middle"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="seealso1">
+    <xs:sequence>
+      <xs:element name="seealso">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:term_4"/>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="meaning1">
+    <xs:sequence>
+      <xs:element name="meaning">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para_4"/>
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:footnote_2"/>
+              <xs:group ref="mathml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="section1">
+    <xs:sequence>
+      <xs:element name="section">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section_2"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+              <xs:group ref="mathml:para_4"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subfigure1">
+    <xs:sequence>
+      <xs:element name="subfigure">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:code_4"/>
+            </xs:choice>
+            <xs:group minOccurs="0" ref="mathml:caption_2"/>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="tgroup1">
+    <xs:sequence>
+      <xs:element name="tgroup">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:spanspec"/>
+            <xs:group minOccurs="0" ref="mathml:thead_2"/>
+            <xs:group minOccurs="0" ref="mathml:tfoot_2"/>
+            <xs:group ref="mathml:tbody_2"/>
+          </xs:sequence>
+          <xs:attribute name="cols" use="required"/>
+          <xs:attribute name="tgroupstyle"/>
+          <xs:attribute name="colsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="align">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+                <xs:enumeration value="center"/>
+                <xs:enumeration value="justify"/>
+                <xs:enumeration value="char"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="char"/>
+          <xs:attribute name="charoff"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="statement1">
+    <xs:sequence>
+      <xs:element name="statement">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section_2"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+              <xs:group ref="mathml:para_4"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="proof1">
+    <xs:sequence>
+      <xs:element name="proof">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section_2"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+              <xs:group ref="mathml:para_4"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="problem1">
+    <xs:sequence>
+      <xs:element name="problem">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section_2"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+              <xs:group ref="mathml:para_4"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="solution1">
+    <xs:sequence>
+      <xs:element name="solution">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="mathml:section_2"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+              <xs:group ref="mathml:para_4"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="print-placement">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="here"/>
+                <xs:enumeration value="end"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="commentary1">
+    <xs:sequence>
+      <xs:element name="commentary">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="mathml:label"/>
+            <xs:group minOccurs="0" ref="mathml:title_7"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:para_4"/>
+              <xs:group ref="mathml:span_4"/>
+              <xs:group ref="mathml:term_4"/>
+              <xs:group ref="mathml:cite_4"/>
+              <xs:group ref="mathml:cite-title_2"/>
+              <xs:group ref="mathml:foreign_4"/>
+              <xs:group ref="mathml:emphasis_4"/>
+              <xs:group ref="mathml:sub_4"/>
+              <xs:group ref="mathml:sup_4"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:footnote_2"/>
+              <xs:group ref="mathml:link"/>
+              <xs:element ref="cnxml:newline"/>
+              <xs:element ref="cnxml:space"/>
+              <xs:group ref="mathml:div_2"/>
+              <xs:group ref="mathml:definition_2"/>
+              <xs:group ref="mathml:example_2"/>
+              <xs:group ref="mathml:figure_2"/>
+              <xs:group ref="mathml:code_4"/>
+              <xs:group ref="mathml:preformat_4"/>
+              <xs:group ref="mathml:quote_4"/>
+              <xs:group ref="mathml:note_2"/>
+              <xs:group ref="mathml:media_2"/>
+              <xs:group ref="mathml:list_5"/>
+              <xs:group ref="mathml:table_2"/>
+              <xs:group ref="mathml:rule_2"/>
+              <xs:group ref="mathml:equation_2"/>
+              <xs:group ref="mathml:exercise_2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" use="required" type="xs:ID"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="entry">
+    <xs:sequence>
+      <xs:element name="entry">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:para"/>
+            <xs:group ref="mathml:math_2"/>
+            <xs:group ref="mathml:span_3"/>
+            <xs:group ref="mathml:term_3"/>
+            <xs:group ref="mathml:cite_3"/>
+            <xs:group ref="mathml:cite-title"/>
+            <xs:group ref="mathml:foreign_3"/>
+            <xs:group ref="mathml:emphasis_3"/>
+            <xs:group ref="mathml:sub_3"/>
+            <xs:group ref="mathml:sup_3"/>
+            <xs:group ref="mathml:code"/>
+            <xs:group ref="mathml:preformat"/>
+            <xs:group ref="mathml:quote"/>
+            <xs:group ref="mathml:note"/>
+            <xs:group ref="mathml:list"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:footnote"/>
+            <xs:group ref="mathml:link_2"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+            <xs:group ref="mathml:div"/>
+            <xs:group ref="mathml:definition"/>
+            <xs:group ref="mathml:example"/>
+            <xs:group ref="mathml:figure"/>
+            <xs:group ref="mathml:code"/>
+            <xs:group ref="mathml:preformat"/>
+            <xs:group ref="mathml:quote"/>
+            <xs:group ref="mathml:note"/>
+            <xs:group ref="mathml:media"/>
+            <xs:group ref="mathml:list"/>
+            <xs:group ref="mathml:table"/>
+            <xs:group ref="mathml:rule"/>
+            <xs:group ref="mathml:equation"/>
+            <xs:group ref="mathml:exercise"/>
+          </xs:choice>
+          <xs:attribute name="colname"/>
+          <xs:attribute name="namest"/>
+          <xs:attribute name="nameend"/>
+          <xs:attribute name="spanname"/>
+          <xs:attribute name="morerows"/>
+          <xs:attribute name="colsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="align">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+                <xs:enumeration value="center"/>
+                <xs:enumeration value="justify"/>
+                <xs:enumeration value="char"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="char"/>
+          <xs:attribute name="charoff"/>
+          <xs:attribute name="rotate">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="valign">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="middle"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="entrytbl">
+    <xs:sequence>
+      <xs:element name="entrytbl">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:spanspec"/>
+            <xs:group minOccurs="0" ref="mathml:thead"/>
+            <xs:group ref="mathml:tbody"/>
+          </xs:sequence>
+          <xs:attribute name="cols" use="required"/>
+          <xs:attribute name="tgroupstyle"/>
+          <xs:attribute name="colname"/>
+          <xs:attribute name="spanname"/>
+          <xs:attribute name="namest"/>
+          <xs:attribute name="nameend"/>
+          <xs:attribute name="colsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="align">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+                <xs:enumeration value="center"/>
+                <xs:enumeration value="justify"/>
+                <xs:enumeration value="char"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="char"/>
+          <xs:attribute name="charoff"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="thead1">
+    <xs:sequence>
+      <xs:element name="thead">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:row_2"/>
+          </xs:sequence>
+          <xs:attribute name="valign">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="middle"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="tfoot1">
+    <xs:sequence>
+      <xs:element name="tfoot">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+            <xs:group maxOccurs="unbounded" ref="mathml:row_2"/>
+          </xs:sequence>
+          <xs:attribute name="valign">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="middle"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="tbody1">
+    <xs:sequence>
+      <xs:element name="tbody">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:row_2"/>
+          <xs:attribute name="valign">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="middle"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="row1">
+    <xs:sequence>
+      <xs:element name="row">
+        <xs:complexType>
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="mathml:entry_3"/>
+            <xs:group ref="mathml:entrytbl_2"/>
+          </xs:choice>
+          <xs:attribute name="rowsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="valign">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="middle"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="entry1">
+    <xs:sequence>
+      <xs:element name="entry">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:para_4"/>
+            <xs:group ref="mathml:span_4"/>
+            <xs:group ref="mathml:term_4"/>
+            <xs:group ref="mathml:cite_4"/>
+            <xs:group ref="mathml:cite-title_2"/>
+            <xs:group ref="mathml:foreign_4"/>
+            <xs:group ref="mathml:emphasis_4"/>
+            <xs:group ref="mathml:sub_4"/>
+            <xs:group ref="mathml:sup_4"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:footnote_2"/>
+            <xs:group ref="mathml:link"/>
+            <xs:element ref="cnxml:newline"/>
+            <xs:element ref="cnxml:space"/>
+            <xs:group ref="mathml:div_2"/>
+            <xs:group ref="mathml:definition_2"/>
+            <xs:group ref="mathml:example_2"/>
+            <xs:group ref="mathml:figure_2"/>
+            <xs:group ref="mathml:code_4"/>
+            <xs:group ref="mathml:preformat_4"/>
+            <xs:group ref="mathml:quote_4"/>
+            <xs:group ref="mathml:note_2"/>
+            <xs:group ref="mathml:media_2"/>
+            <xs:group ref="mathml:list_5"/>
+            <xs:group ref="mathml:table_2"/>
+            <xs:group ref="mathml:rule_2"/>
+            <xs:group ref="mathml:equation_2"/>
+            <xs:group ref="mathml:exercise_2"/>
+          </xs:choice>
+          <xs:attribute name="colname"/>
+          <xs:attribute name="namest"/>
+          <xs:attribute name="nameend"/>
+          <xs:attribute name="spanname"/>
+          <xs:attribute name="morerows"/>
+          <xs:attribute name="colsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="align">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+                <xs:enumeration value="center"/>
+                <xs:enumeration value="justify"/>
+                <xs:enumeration value="char"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="char"/>
+          <xs:attribute name="charoff"/>
+          <xs:attribute name="rotate">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="valign">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="middle"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="entrytbl1">
+    <xs:sequence>
+      <xs:element name="entrytbl">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:colspec"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cnxml:spanspec"/>
+            <xs:group minOccurs="0" ref="mathml:thead_2"/>
+            <xs:group ref="mathml:tbody_2"/>
+          </xs:sequence>
+          <xs:attribute name="cols" use="required"/>
+          <xs:attribute name="tgroupstyle"/>
+          <xs:attribute name="colname"/>
+          <xs:attribute name="spanname"/>
+          <xs:attribute name="namest"/>
+          <xs:attribute name="nameend"/>
+          <xs:attribute name="colsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowsep">
+            <xs:simpleType>
+              <xs:restriction base="xs:integer">
+                <xs:minInclusive value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="align">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+                <xs:enumeration value="center"/>
+                <xs:enumeration value="justify"/>
+                <xs:enumeration value="char"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="char"/>
+          <xs:attribute name="charoff"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
 </xs:schema>

--- a/client/static/xsd/collxml.xsd
+++ b/client/static/xsd/collxml.xsd
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/collxml" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+  <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
+  <xs:import namespace="http://katalysteducation.org/cmlnle/1.0" schemaLocation="cmlnle.xsd"/>
+  <xs:import namespace="http://katalysteducation.org/cxlxt/1.0" schemaLocation="cxlxt.xsd"/>
+  <xs:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="mathml.xsd"/>
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:import namespace="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" schemaLocation="ns1.xsd"/>
+  <xs:element name="collection">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="collxml:metadata"/>
+        <xs:group ref="mathml:parameters"/>
+        <xs:element ref="collxml:featured-links"/>
+        <xs:element ref="collxml:content"/>
+        <xs:element ref="collxml:declarations"/>
+        <xs:element ref="collxml:extensions"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="metadata">
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="mdml:content-id"/>
+        <xs:element ref="mdml:title"/>
+        <xs:element ref="mdml:license"/>
+        <xs:element ref="mdml:uuid"/>
+        <xs:element ref="mdml:slug"/>
+        <xs:element ref="mdml:language"/>
+      </xs:all>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:attribute name="mdml-version">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0.5"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="parameters">
+    <xs:sequence>
+      <xs:element name="parameters">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="collxml:param"/>
+          </xs:sequence>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="featured-links">
+    <xs:complexType>
+      <xs:group maxOccurs="unbounded" ref="mathml:link-group"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:attribute name="display-on-children">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="content">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="collxml:subcollection"/>
+        <xs:element ref="collxml:module"/>
+        <xs:element ref="collxml:segue"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="declarations">
+    <xs:complexType>
+      <xs:group maxOccurs="unbounded" ref="mathml:parameters_2"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="extensions">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="param">
+    <xs:complexType>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:attribute name="name" use="required"/>
+      <xs:attribute name="value" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subcollection">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="mathml:title_2"/>
+        <xs:group ref="mathml:short-title"/>
+        <xs:group ref="mathml:subtitle"/>
+        <xs:group ref="mathml:parameters_3"/>
+        <xs:element ref="collxml:featured-links"/>
+        <xs:element ref="collxml:content"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="module">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="mathml:title_4"/>
+        <xs:group ref="mathml:short-title"/>
+        <xs:group ref="mathml:subtitle"/>
+        <xs:group ref="mathml:parameters_3"/>
+        <xs:element ref="collxml:featured-links"/>
+        <xs:element ref="collxml:module-featured-link-overrides"/>
+      </xs:choice>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:attribute name="url"/>
+      <xs:attribute name="document"/>
+      <xs:attribute name="version"/>
+      <xs:attribute name="repository"/>
+      <xs:attribute ref="s:local-path"/>
+      <xs:attribute ref="s:version-at-this-collection-version"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="segue">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:group minOccurs="0" ref="mathml:parameters_3"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:group ref="mathml:para_2"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:emphasis"/>
+            <xs:group ref="mathml:term"/>
+            <xs:group ref="mathml:foreign"/>
+            <xs:group ref="mathml:cite"/>
+            <xs:group ref="mathml:span"/>
+            <xs:group ref="mathml:sup"/>
+            <xs:group ref="mathml:sub"/>
+            <xs:group ref="mathml:code_2"/>
+            <xs:group ref="mathml:math"/>
+            <xs:group ref="mathml:quote_2"/>
+            <xs:group ref="mathml:preformat_2"/>
+            <xs:group ref="mathml:list_2"/>
+          </xs:choice>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="parameter-set"/>
+      <xs:attribute name="goes-with">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="next"/>
+            <xs:enumeration value="previous"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="type"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="parameters1">
+    <xs:sequence>
+      <xs:element name="parameters">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="collxml:param"/>
+          </xs:sequence>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:attribute name="defines" use="required"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="parameters2">
+    <xs:sequence>
+      <xs:element name="parameters">
+        <xs:complexType>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:attribute name="uses" use="required"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="module-featured-link-overrides">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="collxml:hide-link"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="hide-all-links">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="hide-link">
+    <xs:complexType>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:attribute name="url" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/client/static/xsd/cxlxt.xsd
+++ b/client/static/xsd/cxlxt.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://katalysteducation.org/cxlxt/1.0" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://katalysteducation.org/cxlxt/1.0" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>

--- a/client/static/xsd/mathml.xsd
+++ b/client/static/xsd/mathml.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/1998/Math/MathML" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/1998/Math/MathML" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
@@ -10,9 +11,324 @@
   <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
   <xs:import namespace="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" schemaLocation="ns1.xsd"/>
+  <xs:group name="parameters">
+    <xs:sequence>
+      <xs:group ref="collxml:parameters"/>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="title">
     <xs:sequence>
       <xs:group ref="cnxml:title"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="content-id">
+    <xs:sequence>
+      <xs:group ref="mdml:content-id"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="repository">
+    <xs:sequence>
+      <xs:group ref="mdml:repository"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="content-url">
+    <xs:sequence>
+      <xs:group ref="mdml:content-url"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="title_2">
+    <xs:sequence>
+      <xs:group ref="mdml:title"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="short-title">
+    <xs:sequence>
+      <xs:group ref="mdml:short-title"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subtitle">
+    <xs:sequence>
+      <xs:group ref="mdml:subtitle"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="version">
+    <xs:sequence>
+      <xs:group ref="mdml:version"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="created">
+    <xs:sequence>
+      <xs:group ref="mdml:created"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="revised">
+    <xs:sequence>
+      <xs:group ref="mdml:revised"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="actors">
+    <xs:sequence>
+      <xs:group ref="mdml:actors"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="roles">
+    <xs:sequence>
+      <xs:group ref="mdml:roles"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="license">
+    <xs:sequence>
+      <xs:group ref="mdml:license"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="extended-attribution">
+    <xs:sequence>
+      <xs:group ref="mdml:extended-attribution"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="derived-from">
+    <xs:sequence>
+      <xs:group ref="mdml:derived-from"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="keywordlist">
+    <xs:sequence>
+      <xs:group ref="mdml:keywordlist"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subjectlist">
+    <xs:sequence>
+      <xs:group ref="mdml:subjectlist"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="education-levellist">
+    <xs:sequence>
+      <xs:group ref="mdml:education-levellist"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="abstract">
+    <xs:sequence>
+      <xs:group ref="mdml:abstract"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="objectives">
+    <xs:sequence>
+      <xs:group ref="mdml:objectives"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="homepage">
+    <xs:sequence>
+      <xs:group ref="mdml:homepage"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="institution">
+    <xs:sequence>
+      <xs:group ref="mdml:institution"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="course-code">
+    <xs:sequence>
+      <xs:group ref="mdml:course-code"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="instructor">
+    <xs:sequence>
+      <xs:group ref="mdml:instructor"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="uuid">
+    <xs:sequence>
+      <xs:group ref="mdml:uuid"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="canonical-book-uuid">
+    <xs:sequence>
+      <xs:group ref="mdml:canonical-book-uuid"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="slug">
+    <xs:sequence>
+      <xs:group ref="mdml:slug"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="language">
+    <xs:sequence>
+      <xs:group ref="mdml:language"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="link-group">
+    <xs:sequence>
+      <xs:group ref="cnxml:link-group"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="parameters_2">
+    <xs:sequence>
+      <xs:group ref="collxml:parameters1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="content-id_2">
+    <xs:sequence>
+      <xs:group ref="mdml:content-id1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="repository_2">
+    <xs:sequence>
+      <xs:group ref="mdml:repository1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="content-url_2">
+    <xs:sequence>
+      <xs:group ref="mdml:content-url1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="title_3">
+    <xs:sequence>
+      <xs:group ref="mdml:title1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="short-title_2">
+    <xs:sequence>
+      <xs:group ref="mdml:short-title1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subtitle_2">
+    <xs:sequence>
+      <xs:group ref="mdml:subtitle1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="version_2">
+    <xs:sequence>
+      <xs:group ref="mdml:version1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="created_2">
+    <xs:sequence>
+      <xs:group ref="mdml:created1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="revised_2">
+    <xs:sequence>
+      <xs:group ref="mdml:revised1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="actors_2">
+    <xs:sequence>
+      <xs:group ref="mdml:actors1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="roles_2">
+    <xs:sequence>
+      <xs:group ref="mdml:roles1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="license_2">
+    <xs:sequence>
+      <xs:group ref="mdml:license1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="extended-attribution_2">
+    <xs:sequence>
+      <xs:group ref="mdml:extended-attribution1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="derived-from_2">
+    <xs:sequence>
+      <xs:group ref="mdml:derived-from1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="keywordlist_2">
+    <xs:sequence>
+      <xs:group ref="mdml:keywordlist1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subjectlist_2">
+    <xs:sequence>
+      <xs:group ref="mdml:subjectlist1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="education-levellist_2">
+    <xs:sequence>
+      <xs:group ref="mdml:education-levellist1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="abstract_2">
+    <xs:sequence>
+      <xs:group ref="mdml:abstract1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="objectives_2">
+    <xs:sequence>
+      <xs:group ref="mdml:objectives1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="homepage_2">
+    <xs:sequence>
+      <xs:group ref="mdml:homepage1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="institution_2">
+    <xs:sequence>
+      <xs:group ref="mdml:institution1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="course-code_2">
+    <xs:sequence>
+      <xs:group ref="mdml:course-code1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="instructor_2">
+    <xs:sequence>
+      <xs:group ref="mdml:instructor1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="uuid_2">
+    <xs:sequence>
+      <xs:group ref="mdml:uuid1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="canonical-book-uuid_2">
+    <xs:sequence>
+      <xs:group ref="mdml:canonical-book-uuid1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="slug_2">
+    <xs:sequence>
+      <xs:group ref="mdml:slug1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="language_2">
+    <xs:sequence>
+      <xs:group ref="mdml:language1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="link-group_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:link-group1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="section">
+    <xs:sequence>
+      <xs:group ref="cnxml:section"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="div">
+    <xs:sequence>
+      <xs:group ref="cnxml:div"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="definition">
+    <xs:sequence>
+      <xs:group ref="cnxml:definition"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="example">
+    <xs:sequence>
+      <xs:group ref="cnxml:example"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="figure">
+    <xs:sequence>
+      <xs:group ref="cnxml:figure"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="code">
@@ -30,14 +346,74 @@
       <xs:group ref="cnxml:quote"/>
     </xs:sequence>
   </xs:group>
+  <xs:group name="note">
+    <xs:sequence>
+      <xs:group ref="cnxml:note"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="media">
+    <xs:sequence>
+      <xs:group ref="cnxml:media"/>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="list">
     <xs:sequence>
       <xs:group ref="cnxml:list"/>
     </xs:sequence>
   </xs:group>
+  <xs:group name="table">
+    <xs:sequence>
+      <xs:group ref="cnxml:table"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="rule">
+    <xs:sequence>
+      <xs:group ref="cnxml:rule"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="equation">
+    <xs:sequence>
+      <xs:group ref="cnxml:equation"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="exercise">
+    <xs:sequence>
+      <xs:group ref="cnxml:exercise"/>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="para">
     <xs:sequence>
       <xs:group ref="cnxml:para"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="person">
+    <xs:sequence>
+      <xs:group ref="mdml:person"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="organization">
+    <xs:sequence>
+      <xs:group ref="mdml:organization"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="role">
+    <xs:sequence>
+      <xs:group ref="mdml:role"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="keyword">
+    <xs:sequence>
+      <xs:group ref="mdml:keyword"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subject">
+    <xs:sequence>
+      <xs:group ref="mdml:subject"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="education-level">
+    <xs:sequence>
+      <xs:group ref="mdml:education-level"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="para_2">
@@ -85,100 +461,104 @@
       <xs:group ref="cnxml:code1"/>
     </xs:sequence>
   </xs:group>
-  <xs:element name="math">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="macros"/>
-      <xs:attribute name="mode"/>
-      <xs:attribute name="display"/>
-      <xs:attribute name="type"/>
-      <xs:attribute name="name"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="baseline"/>
-      <xs:attribute name="overflow">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="scroll"/>
-            <xs:enumeration value="elide"/>
-            <xs:enumeration value="truncate"/>
-            <xs:enumeration value="scale"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="altimg"/>
-      <xs:attribute name="alttext"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="math">
+    <xs:sequence>
+      <xs:element name="math">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="macros"/>
+          <xs:attribute name="mode"/>
+          <xs:attribute name="display"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="name"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="baseline"/>
+          <xs:attribute name="overflow">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="scroll"/>
+                <xs:enumeration value="elide"/>
+                <xs:enumeration value="truncate"/>
+                <xs:enumeration value="scale"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="altimg"/>
+          <xs:attribute name="alttext"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="quote_2">
     <xs:sequence>
       <xs:group ref="cnxml:quote1"/>
@@ -194,29 +574,59 @@
       <xs:group ref="cnxml:list1"/>
     </xs:sequence>
   </xs:group>
-  <xs:group name="title_3">
+  <xs:group name="label">
     <xs:sequence>
-      <xs:group ref="cnxml:title1"/>
+      <xs:group ref="cnxml:label"/>
     </xs:sequence>
   </xs:group>
-  <xs:group name="span_2">
+  <xs:group name="link">
     <xs:sequence>
-      <xs:group ref="cnxml:span1"/>
+      <xs:group ref="cnxml:link"/>
     </xs:sequence>
   </xs:group>
-  <xs:group name="term_2">
+  <xs:group name="parameters_3">
     <xs:sequence>
-      <xs:group ref="cnxml:term1"/>
+      <xs:group ref="collxml:parameters2"/>
     </xs:sequence>
   </xs:group>
-  <xs:group name="cite_2">
+  <xs:group name="title_4">
     <xs:sequence>
-      <xs:group ref="cnxml:cite1"/>
+      <xs:group ref="mdml:title"/>
     </xs:sequence>
   </xs:group>
-  <xs:group name="foreign_2">
+  <xs:group name="person_2">
     <xs:sequence>
-      <xs:group ref="cnxml:foreign1"/>
+      <xs:group ref="mdml:person1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="organization_2">
+    <xs:sequence>
+      <xs:group ref="mdml:organization1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="role_2">
+    <xs:sequence>
+      <xs:group ref="mdml:role1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="keyword_2">
+    <xs:sequence>
+      <xs:group ref="mdml:keyword1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subject_2">
+    <xs:sequence>
+      <xs:group ref="mdml:subject1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="education-level_2">
+    <xs:sequence>
+      <xs:group ref="mdml:education-level1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="para_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:para2"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="emphasis_2">
@@ -224,9 +634,24 @@
       <xs:group ref="cnxml:emphasis1"/>
     </xs:sequence>
   </xs:group>
-  <xs:group name="sub_2">
+  <xs:group name="term_2">
     <xs:sequence>
-      <xs:group ref="cnxml:sub1"/>
+      <xs:group ref="cnxml:term1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="foreign_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:foreign1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:cite1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="span_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:span1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="sup_2">
@@ -234,272 +659,615 @@
       <xs:group ref="cnxml:sup1"/>
     </xs:sequence>
   </xs:group>
+  <xs:group name="sub_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:sub1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="code_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:code2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="math_2">
+    <xs:sequence>
+      <xs:element name="math">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="macros"/>
+          <xs:attribute name="mode"/>
+          <xs:attribute name="display"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="name"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="baseline"/>
+          <xs:attribute name="overflow">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="scroll"/>
+                <xs:enumeration value="elide"/>
+                <xs:enumeration value="truncate"/>
+                <xs:enumeration value="scale"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="altimg"/>
+          <xs:attribute name="alttext"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="quote_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:quote2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="preformat_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:preformat2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:list2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="label_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:label1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="link_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:link1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="title_5">
+    <xs:sequence>
+      <xs:group ref="cnxml:title1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="span_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:span2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="term_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:term2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:cite2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite-title">
+    <xs:sequence>
+      <xs:group ref="cnxml:cite-title"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="foreign_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:foreign2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="emphasis_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:emphasis2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sub_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:sub2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sup_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:sup2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="footnote">
+    <xs:sequence>
+      <xs:group ref="cnxml:footnote"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="seealso">
+    <xs:sequence>
+      <xs:group ref="cnxml:seealso"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="meaning">
+    <xs:sequence>
+      <xs:group ref="cnxml:meaning"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subfigure">
+    <xs:sequence>
+      <xs:group ref="cnxml:subfigure"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="caption">
+    <xs:sequence>
+      <xs:group ref="cnxml:caption"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="longdesc">
+    <xs:sequence>
+      <xs:group ref="cnxml:longdesc"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="object">
+    <xs:sequence>
+      <xs:group ref="cnxml:object"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="image">
+    <xs:sequence>
+      <xs:group ref="cnxml:image"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="audio">
+    <xs:sequence>
+      <xs:group ref="cnxml:audio"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="video">
+    <xs:sequence>
+      <xs:group ref="cnxml:video"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="java-applet">
+    <xs:sequence>
+      <xs:group ref="cnxml:java-applet"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="flash">
+    <xs:sequence>
+      <xs:group ref="cnxml:flash"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="labview">
+    <xs:sequence>
+      <xs:group ref="cnxml:labview"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="text">
+    <xs:sequence>
+      <xs:group ref="cnxml:text"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="download">
+    <xs:sequence>
+      <xs:group ref="cnxml:download"/>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="item">
     <xs:sequence>
       <xs:group ref="cnxml:item"/>
     </xs:sequence>
   </xs:group>
-  <xs:element name="mi">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mglyph"/>
-        <xs:element ref="mathml:malignmark"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="fontsize"/>
-      <xs:attribute name="fontweight">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="bold"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontstyle">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="italic"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontfamily"/>
-      <xs:attribute name="color"/>
-      <xs:attribute name="mathvariant"/>
-      <xs:attribute name="mathsize"/>
-      <xs:attribute name="mathcolor"/>
-      <xs:attribute name="mathbackground"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mn">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mglyph"/>
-        <xs:element ref="mathml:malignmark"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="fontsize"/>
-      <xs:attribute name="fontweight">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="bold"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontstyle">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="italic"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontfamily"/>
-      <xs:attribute name="color"/>
-      <xs:attribute name="mathvariant"/>
-      <xs:attribute name="mathsize"/>
-      <xs:attribute name="mathcolor"/>
-      <xs:attribute name="mathbackground"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mo">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mglyph"/>
-        <xs:element ref="mathml:malignmark"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="fontsize"/>
-      <xs:attribute name="fontweight">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="bold"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontstyle">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="italic"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontfamily"/>
-      <xs:attribute name="color"/>
-      <xs:attribute name="mathvariant"/>
-      <xs:attribute name="mathsize"/>
-      <xs:attribute name="mathcolor"/>
-      <xs:attribute name="mathbackground"/>
-      <xs:attribute name="form">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="prefix"/>
-            <xs:enumeration value="infix"/>
-            <xs:enumeration value="postfix"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fence">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="separator">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="lspace"/>
-      <xs:attribute name="rspace"/>
-      <xs:attribute name="stretchy">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="symmetric">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="maxsize"/>
-      <xs:attribute name="minsize"/>
-      <xs:attribute name="largeop">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="movablelimits">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="accent">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mtext">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mglyph"/>
-        <xs:element ref="mathml:malignmark"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="fontsize"/>
-      <xs:attribute name="fontweight">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="bold"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontstyle">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="italic"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontfamily"/>
-      <xs:attribute name="color"/>
-      <xs:attribute name="mathvariant"/>
-      <xs:attribute name="mathsize"/>
-      <xs:attribute name="mathcolor"/>
-      <xs:attribute name="mathbackground"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="ms">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mglyph"/>
-        <xs:element ref="mathml:malignmark"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="fontsize"/>
-      <xs:attribute name="fontweight">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="bold"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontstyle">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="italic"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontfamily"/>
-      <xs:attribute name="color"/>
-      <xs:attribute name="mathvariant"/>
-      <xs:attribute name="mathsize"/>
-      <xs:attribute name="mathcolor"/>
-      <xs:attribute name="mathbackground"/>
-      <xs:attribute name="lquote"/>
-      <xs:attribute name="rquote"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="tgroup">
+    <xs:sequence>
+      <xs:group ref="cnxml:tgroup"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="statement">
+    <xs:sequence>
+      <xs:group ref="cnxml:statement"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="proof">
+    <xs:sequence>
+      <xs:group ref="cnxml:proof"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="problem">
+    <xs:sequence>
+      <xs:group ref="cnxml:problem"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="solution">
+    <xs:sequence>
+      <xs:group ref="cnxml:solution"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="commentary">
+    <xs:sequence>
+      <xs:group ref="cnxml:commentary"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="honorific">
+    <xs:sequence>
+      <xs:group ref="mdml:honorific"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="firstname">
+    <xs:sequence>
+      <xs:group ref="mdml:firstname"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="othername">
+    <xs:sequence>
+      <xs:group ref="mdml:othername"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="surname">
+    <xs:sequence>
+      <xs:group ref="mdml:surname"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="lineage">
+    <xs:sequence>
+      <xs:group ref="mdml:lineage"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="fullname">
+    <xs:sequence>
+      <xs:group ref="mdml:fullname"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="email">
+    <xs:sequence>
+      <xs:group ref="mdml:email"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="shortname">
+    <xs:sequence>
+      <xs:group ref="mdml:shortname"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mi">
+    <xs:sequence>
+      <xs:element name="mi">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:malignmark"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mn">
+    <xs:sequence>
+      <xs:element name="mn">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:malignmark"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mo">
+    <xs:sequence>
+      <xs:element name="mo">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:malignmark"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+          <xs:attribute name="form">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="prefix"/>
+                <xs:enumeration value="infix"/>
+                <xs:enumeration value="postfix"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fence">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="separator">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="lspace"/>
+          <xs:attribute name="rspace"/>
+          <xs:attribute name="stretchy">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="symmetric">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="maxsize"/>
+          <xs:attribute name="minsize"/>
+          <xs:attribute name="largeop">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="movablelimits">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="accent">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mtext">
+    <xs:sequence>
+      <xs:element name="mtext">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:malignmark"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ms">
+    <xs:sequence>
+      <xs:element name="ms">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:malignmark"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+          <xs:attribute name="lquote"/>
+          <xs:attribute name="rquote"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:element name="mspace">
     <xs:complexType>
       <xs:attribute name="width"/>
@@ -515,1876 +1283,1960 @@
       <xs:attribute name="other"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="mrow">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mfrac">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="bevelled"/>
-      <xs:attribute name="numalign"/>
-      <xs:attribute name="denomalign"/>
-      <xs:attribute name="linethickness"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="msqrt">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mroot">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="menclose">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="notation"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mstyle">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="fontsize"/>
-      <xs:attribute name="fontweight">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="bold"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontstyle">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="normal"/>
-            <xs:enumeration value="italic"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fontfamily"/>
-      <xs:attribute name="color"/>
-      <xs:attribute name="mathvariant"/>
-      <xs:attribute name="mathsize"/>
-      <xs:attribute name="mathcolor"/>
-      <xs:attribute name="mathbackground"/>
-      <xs:attribute name="form">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="prefix"/>
-            <xs:enumeration value="infix"/>
-            <xs:enumeration value="postfix"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="fence">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="separator">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="lspace"/>
-      <xs:attribute name="rspace"/>
-      <xs:attribute name="stretchy">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="symmetric">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="maxsize"/>
-      <xs:attribute name="minsize"/>
-      <xs:attribute name="largeop">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="movablelimits">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="accent">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="lquote"/>
-      <xs:attribute name="rquote"/>
-      <xs:attribute name="linethickness"/>
-      <xs:attribute name="scriptlevel"/>
-      <xs:attribute name="scriptsizemultiplier"/>
-      <xs:attribute name="scriptminsize"/>
-      <xs:attribute name="background"/>
-      <xs:attribute name="veryverythinmathspace"/>
-      <xs:attribute name="verythinmathspace"/>
-      <xs:attribute name="thinmathspace"/>
-      <xs:attribute name="mediummathspace"/>
-      <xs:attribute name="thickmathspace"/>
-      <xs:attribute name="verythickmathspace"/>
-      <xs:attribute name="veryverythickmathspace"/>
-      <xs:attribute name="open"/>
-      <xs:attribute name="close"/>
-      <xs:attribute name="separators"/>
-      <xs:attribute name="subscriptshift"/>
-      <xs:attribute name="superscriptshift"/>
-      <xs:attribute name="accentunder">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="align"/>
-      <xs:attribute name="rowalign"/>
-      <xs:attribute name="columnalign"/>
-      <xs:attribute name="columnwidth"/>
-      <xs:attribute name="groupalign"/>
-      <xs:attribute name="alignmentscope"/>
-      <xs:attribute name="side">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="left"/>
-            <xs:enumeration value="right"/>
-            <xs:enumeration value="leftoverlap"/>
-            <xs:enumeration value="rightoverlap"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="rowspacing"/>
-      <xs:attribute name="columnspacing"/>
-      <xs:attribute name="rowlines"/>
-      <xs:attribute name="columnlines"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="frame">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="none"/>
-            <xs:enumeration value="solid"/>
-            <xs:enumeration value="dashed"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="framespacing"/>
-      <xs:attribute name="equalrows"/>
-      <xs:attribute name="equalcolumns"/>
-      <xs:attribute name="displaystyle">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="rowspan"/>
-      <xs:attribute name="columnspan"/>
-      <xs:attribute name="edge">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="left"/>
-            <xs:enumeration value="right"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="actiontype"/>
-      <xs:attribute name="selection"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="merror">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mpadded">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="height"/>
-      <xs:attribute name="depth"/>
-      <xs:attribute name="lspace"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mphantom">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mfenced">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="open"/>
-      <xs:attribute name="close"/>
-      <xs:attribute name="separators"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="msub">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="subscriptshift"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="msup">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="superscriptshift"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="msubsup">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="subscriptshift"/>
-      <xs:attribute name="superscriptshift"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="munder">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="accentunder">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mover">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="accent">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="munderover">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="accent">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="accentunder">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mmultiscripts">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="subscriptshift"/>
-      <xs:attribute name="superscriptshift"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mtable">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="align"/>
-      <xs:attribute name="rowalign"/>
-      <xs:attribute name="columnalign"/>
-      <xs:attribute name="columnwidth"/>
-      <xs:attribute name="groupalign"/>
-      <xs:attribute name="alignmentscope"/>
-      <xs:attribute name="side">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="left"/>
-            <xs:enumeration value="right"/>
-            <xs:enumeration value="leftoverlap"/>
-            <xs:enumeration value="rightoverlap"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="rowspacing"/>
-      <xs:attribute name="columnspacing"/>
-      <xs:attribute name="rowlines"/>
-      <xs:attribute name="columnlines"/>
-      <xs:attribute name="width"/>
-      <xs:attribute name="frame">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="none"/>
-            <xs:enumeration value="solid"/>
-            <xs:enumeration value="dashed"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="framespacing"/>
-      <xs:attribute name="equalrows"/>
-      <xs:attribute name="equalcolumns"/>
-      <xs:attribute name="displaystyle">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mtr">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="rowalign"/>
-      <xs:attribute name="columnalign"/>
-      <xs:attribute name="groupalign"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mlabeledtr">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="rowalign"/>
-      <xs:attribute name="columnalign"/>
-      <xs:attribute name="groupalign"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="mtd">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="rowalign"/>
-      <xs:attribute name="columnalign"/>
-      <xs:attribute name="groupalign"/>
-      <xs:attribute name="rowspan"/>
-      <xs:attribute name="columnspan"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="mrow">
+    <xs:sequence>
+      <xs:element name="mrow">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mfrac">
+    <xs:sequence>
+      <xs:element name="mfrac">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="bevelled"/>
+          <xs:attribute name="numalign"/>
+          <xs:attribute name="denomalign"/>
+          <xs:attribute name="linethickness"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="msqrt">
+    <xs:sequence>
+      <xs:element name="msqrt">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mroot">
+    <xs:sequence>
+      <xs:element name="mroot">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="menclose">
+    <xs:sequence>
+      <xs:element name="menclose">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="notation"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mstyle">
+    <xs:sequence>
+      <xs:element name="mstyle">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+          <xs:attribute name="form">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="prefix"/>
+                <xs:enumeration value="infix"/>
+                <xs:enumeration value="postfix"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fence">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="separator">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="lspace"/>
+          <xs:attribute name="rspace"/>
+          <xs:attribute name="stretchy">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="symmetric">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="maxsize"/>
+          <xs:attribute name="minsize"/>
+          <xs:attribute name="largeop">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="movablelimits">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="accent">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="lquote"/>
+          <xs:attribute name="rquote"/>
+          <xs:attribute name="linethickness"/>
+          <xs:attribute name="scriptlevel"/>
+          <xs:attribute name="scriptsizemultiplier"/>
+          <xs:attribute name="scriptminsize"/>
+          <xs:attribute name="background"/>
+          <xs:attribute name="veryverythinmathspace"/>
+          <xs:attribute name="verythinmathspace"/>
+          <xs:attribute name="thinmathspace"/>
+          <xs:attribute name="mediummathspace"/>
+          <xs:attribute name="thickmathspace"/>
+          <xs:attribute name="verythickmathspace"/>
+          <xs:attribute name="veryverythickmathspace"/>
+          <xs:attribute name="open"/>
+          <xs:attribute name="close"/>
+          <xs:attribute name="separators"/>
+          <xs:attribute name="subscriptshift"/>
+          <xs:attribute name="superscriptshift"/>
+          <xs:attribute name="accentunder">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="align"/>
+          <xs:attribute name="rowalign"/>
+          <xs:attribute name="columnalign"/>
+          <xs:attribute name="columnwidth"/>
+          <xs:attribute name="groupalign"/>
+          <xs:attribute name="alignmentscope"/>
+          <xs:attribute name="side">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+                <xs:enumeration value="leftoverlap"/>
+                <xs:enumeration value="rightoverlap"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowspacing"/>
+          <xs:attribute name="columnspacing"/>
+          <xs:attribute name="rowlines"/>
+          <xs:attribute name="columnlines"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="frame">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="solid"/>
+                <xs:enumeration value="dashed"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="framespacing"/>
+          <xs:attribute name="equalrows"/>
+          <xs:attribute name="equalcolumns"/>
+          <xs:attribute name="displaystyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowspan"/>
+          <xs:attribute name="columnspan"/>
+          <xs:attribute name="edge">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="actiontype"/>
+          <xs:attribute name="selection"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="merror">
+    <xs:sequence>
+      <xs:element name="merror">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mpadded">
+    <xs:sequence>
+      <xs:element name="mpadded">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="depth"/>
+          <xs:attribute name="lspace"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mphantom">
+    <xs:sequence>
+      <xs:element name="mphantom">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mfenced">
+    <xs:sequence>
+      <xs:element name="mfenced">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="open"/>
+          <xs:attribute name="close"/>
+          <xs:attribute name="separators"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="msub">
+    <xs:sequence>
+      <xs:element name="msub">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="subscriptshift"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="msup">
+    <xs:sequence>
+      <xs:element name="msup">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="superscriptshift"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="msubsup">
+    <xs:sequence>
+      <xs:element name="msubsup">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="subscriptshift"/>
+          <xs:attribute name="superscriptshift"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="munder">
+    <xs:sequence>
+      <xs:element name="munder">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="accentunder">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mover">
+    <xs:sequence>
+      <xs:element name="mover">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="accent">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="munderover">
+    <xs:sequence>
+      <xs:element name="munderover">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="accent">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="accentunder">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mmultiscripts">
+    <xs:sequence>
+      <xs:element name="mmultiscripts">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="subscriptshift"/>
+          <xs:attribute name="superscriptshift"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mtable">
+    <xs:sequence>
+      <xs:element name="mtable">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="align"/>
+          <xs:attribute name="rowalign"/>
+          <xs:attribute name="columnalign"/>
+          <xs:attribute name="columnwidth"/>
+          <xs:attribute name="groupalign"/>
+          <xs:attribute name="alignmentscope"/>
+          <xs:attribute name="side">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+                <xs:enumeration value="leftoverlap"/>
+                <xs:enumeration value="rightoverlap"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowspacing"/>
+          <xs:attribute name="columnspacing"/>
+          <xs:attribute name="rowlines"/>
+          <xs:attribute name="columnlines"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="frame">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="solid"/>
+                <xs:enumeration value="dashed"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="framespacing"/>
+          <xs:attribute name="equalrows"/>
+          <xs:attribute name="equalcolumns"/>
+          <xs:attribute name="displaystyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mtr">
+    <xs:sequence>
+      <xs:element name="mtr">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="rowalign"/>
+          <xs:attribute name="columnalign"/>
+          <xs:attribute name="groupalign"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mlabeledtr">
+    <xs:sequence>
+      <xs:element name="mlabeledtr">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="rowalign"/>
+          <xs:attribute name="columnalign"/>
+          <xs:attribute name="groupalign"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mtd">
+    <xs:sequence>
+      <xs:element name="mtd">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="rowalign"/>
+          <xs:attribute name="columnalign"/>
+          <xs:attribute name="groupalign"/>
+          <xs:attribute name="rowspan"/>
+          <xs:attribute name="columnspan"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:element name="maligngroup">
     <xs:complexType>
       <xs:attribute ref="xlink:href"/>
@@ -2409,227 +3261,243 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-  <xs:element name="maction">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:declare"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="actiontype"/>
-      <xs:attribute name="selection"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="ci">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mglyph"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="type"/>
-      <xs:attribute name="definitionURL"/>
-      <xs:attribute name="encoding"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="csymbol">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mglyph"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="encoding"/>
-      <xs:attribute name="type"/>
-      <xs:attribute name="definitionURL"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="cn">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mglyph"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="type"/>
-      <xs:attribute name="base"/>
-      <xs:attribute name="definitionURL"/>
-      <xs:attribute name="encoding"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="maction">
+    <xs:sequence>
+      <xs:element name="maction">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:group ref="mathml:declare"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="actiontype"/>
+          <xs:attribute name="selection"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ci">
+    <xs:sequence>
+      <xs:element name="ci">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="definitionURL"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="csymbol">
+    <xs:sequence>
+      <xs:element name="csymbol">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="encoding"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="definitionURL"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cn">
+    <xs:sequence>
+      <xs:element name="cn">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="base"/>
+          <xs:attribute name="definitionURL"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:element name="integers">
     <xs:complexType>
       <xs:attribute ref="xlink:href"/>
@@ -2825,2293 +3693,7288 @@
       <xs:attribute name="encoding"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="apply">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="fn">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="definitionURL"/>
-      <xs:attribute name="encoding"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="lambda">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="reln">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="interval">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="closure"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="list">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="order"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="matrix">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="matrixrow">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="set">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="type"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="vector">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="piecewise">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="mathml:piece"/>
-        <xs:element minOccurs="0" ref="mathml:otherwise"/>
-      </xs:sequence>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="semantics">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="definitionURL"/>
-      <xs:attribute name="encoding"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="declare">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="type"/>
-      <xs:attribute name="scope"/>
-      <xs:attribute name="nargs"/>
-      <xs:attribute name="occurrence"/>
-      <xs:attribute name="definitionURL"/>
-      <xs:attribute name="encoding"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="apply">
+    <xs:sequence>
+      <xs:element name="apply">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="fn">
+    <xs:sequence>
+      <xs:element name="fn">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="definitionURL"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="lambda">
+    <xs:sequence>
+      <xs:element name="lambda">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="reln">
+    <xs:sequence>
+      <xs:element name="reln">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="interval">
+    <xs:sequence>
+      <xs:element name="interval">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="closure"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list_4">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="order"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="matrix">
+    <xs:sequence>
+      <xs:element name="matrix">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="matrixrow">
+    <xs:sequence>
+      <xs:element name="matrixrow">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="set">
+    <xs:sequence>
+      <xs:element name="set">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="vector">
+    <xs:sequence>
+      <xs:element name="vector">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="piecewise">
+    <xs:sequence>
+      <xs:element name="piecewise">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="mathml:piece"/>
+            <xs:group minOccurs="0" ref="mathml:otherwise"/>
+          </xs:sequence>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="semantics">
+    <xs:sequence>
+      <xs:element name="semantics">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="definitionURL"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="declare">
+    <xs:sequence>
+      <xs:element name="declare">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="scope"/>
+          <xs:attribute name="nargs"/>
+          <xs:attribute name="occurrence"/>
+          <xs:attribute name="definitionURL"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="item_3">
     <xs:sequence>
       <xs:group ref="cnxml:item1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="span_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:span3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="term_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:term3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:cite3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cite-title_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:cite-title1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="foreign_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:foreign3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="emphasis_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:emphasis3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sub_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:sub3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="sup_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:sup3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="code_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:code3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="preformat_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:preformat3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="quote_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:quote3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="note_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:note1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list_5">
+    <xs:sequence>
+      <xs:group ref="cnxml:list3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="media_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:media1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="footnote_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:footnote1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="honorific_2">
+    <xs:sequence>
+      <xs:group ref="mdml:honorific1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="firstname_2">
+    <xs:sequence>
+      <xs:group ref="mdml:firstname1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="othername_2">
+    <xs:sequence>
+      <xs:group ref="mdml:othername1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="surname_2">
+    <xs:sequence>
+      <xs:group ref="mdml:surname1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="lineage_2">
+    <xs:sequence>
+      <xs:group ref="mdml:lineage1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="fullname_2">
+    <xs:sequence>
+      <xs:group ref="mdml:fullname1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="email_2">
+    <xs:sequence>
+      <xs:group ref="mdml:email1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="shortname_2">
+    <xs:sequence>
+      <xs:group ref="mdml:shortname1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mi_2">
+    <xs:sequence>
+      <xs:element name="mi">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:malignmark"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mn_2">
+    <xs:sequence>
+      <xs:element name="mn">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:malignmark"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mo_2">
+    <xs:sequence>
+      <xs:element name="mo">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:malignmark"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+          <xs:attribute name="form">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="prefix"/>
+                <xs:enumeration value="infix"/>
+                <xs:enumeration value="postfix"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fence">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="separator">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="lspace"/>
+          <xs:attribute name="rspace"/>
+          <xs:attribute name="stretchy">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="symmetric">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="maxsize"/>
+          <xs:attribute name="minsize"/>
+          <xs:attribute name="largeop">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="movablelimits">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="accent">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mtext_2">
+    <xs:sequence>
+      <xs:element name="mtext">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:malignmark"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ms_2">
+    <xs:sequence>
+      <xs:element name="ms">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:malignmark"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+          <xs:attribute name="lquote"/>
+          <xs:attribute name="rquote"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mrow_2">
+    <xs:sequence>
+      <xs:element name="mrow">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mfrac_2">
+    <xs:sequence>
+      <xs:element name="mfrac">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="bevelled"/>
+          <xs:attribute name="numalign"/>
+          <xs:attribute name="denomalign"/>
+          <xs:attribute name="linethickness"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="msqrt_2">
+    <xs:sequence>
+      <xs:element name="msqrt">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mroot_2">
+    <xs:sequence>
+      <xs:element name="mroot">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="menclose_2">
+    <xs:sequence>
+      <xs:element name="menclose">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="notation"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mstyle_2">
+    <xs:sequence>
+      <xs:element name="mstyle">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="fontsize"/>
+          <xs:attribute name="fontweight">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="bold"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontstyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="normal"/>
+                <xs:enumeration value="italic"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fontfamily"/>
+          <xs:attribute name="color"/>
+          <xs:attribute name="mathvariant"/>
+          <xs:attribute name="mathsize"/>
+          <xs:attribute name="mathcolor"/>
+          <xs:attribute name="mathbackground"/>
+          <xs:attribute name="form">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="prefix"/>
+                <xs:enumeration value="infix"/>
+                <xs:enumeration value="postfix"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="fence">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="separator">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="lspace"/>
+          <xs:attribute name="rspace"/>
+          <xs:attribute name="stretchy">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="symmetric">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="maxsize"/>
+          <xs:attribute name="minsize"/>
+          <xs:attribute name="largeop">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="movablelimits">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="accent">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="lquote"/>
+          <xs:attribute name="rquote"/>
+          <xs:attribute name="linethickness"/>
+          <xs:attribute name="scriptlevel"/>
+          <xs:attribute name="scriptsizemultiplier"/>
+          <xs:attribute name="scriptminsize"/>
+          <xs:attribute name="background"/>
+          <xs:attribute name="veryverythinmathspace"/>
+          <xs:attribute name="verythinmathspace"/>
+          <xs:attribute name="thinmathspace"/>
+          <xs:attribute name="mediummathspace"/>
+          <xs:attribute name="thickmathspace"/>
+          <xs:attribute name="verythickmathspace"/>
+          <xs:attribute name="veryverythickmathspace"/>
+          <xs:attribute name="open"/>
+          <xs:attribute name="close"/>
+          <xs:attribute name="separators"/>
+          <xs:attribute name="subscriptshift"/>
+          <xs:attribute name="superscriptshift"/>
+          <xs:attribute name="accentunder">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="align"/>
+          <xs:attribute name="rowalign"/>
+          <xs:attribute name="columnalign"/>
+          <xs:attribute name="columnwidth"/>
+          <xs:attribute name="groupalign"/>
+          <xs:attribute name="alignmentscope"/>
+          <xs:attribute name="side">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+                <xs:enumeration value="leftoverlap"/>
+                <xs:enumeration value="rightoverlap"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowspacing"/>
+          <xs:attribute name="columnspacing"/>
+          <xs:attribute name="rowlines"/>
+          <xs:attribute name="columnlines"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="frame">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="solid"/>
+                <xs:enumeration value="dashed"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="framespacing"/>
+          <xs:attribute name="equalrows"/>
+          <xs:attribute name="equalcolumns"/>
+          <xs:attribute name="displaystyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowspan"/>
+          <xs:attribute name="columnspan"/>
+          <xs:attribute name="edge">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="actiontype"/>
+          <xs:attribute name="selection"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="merror_2">
+    <xs:sequence>
+      <xs:element name="merror">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mpadded_2">
+    <xs:sequence>
+      <xs:element name="mpadded">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="height"/>
+          <xs:attribute name="depth"/>
+          <xs:attribute name="lspace"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mphantom_2">
+    <xs:sequence>
+      <xs:element name="mphantom">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mfenced_2">
+    <xs:sequence>
+      <xs:element name="mfenced">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="open"/>
+          <xs:attribute name="close"/>
+          <xs:attribute name="separators"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="msub_2">
+    <xs:sequence>
+      <xs:element name="msub">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="subscriptshift"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="msup_2">
+    <xs:sequence>
+      <xs:element name="msup">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="superscriptshift"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="msubsup_2">
+    <xs:sequence>
+      <xs:element name="msubsup">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="subscriptshift"/>
+          <xs:attribute name="superscriptshift"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="munder_2">
+    <xs:sequence>
+      <xs:element name="munder">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="accentunder">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mover_2">
+    <xs:sequence>
+      <xs:element name="mover">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="accent">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="munderover_2">
+    <xs:sequence>
+      <xs:element name="munderover">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="accent">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="accentunder">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mmultiscripts_2">
+    <xs:sequence>
+      <xs:element name="mmultiscripts">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="subscriptshift"/>
+          <xs:attribute name="superscriptshift"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mtable_2">
+    <xs:sequence>
+      <xs:element name="mtable">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="align"/>
+          <xs:attribute name="rowalign"/>
+          <xs:attribute name="columnalign"/>
+          <xs:attribute name="columnwidth"/>
+          <xs:attribute name="groupalign"/>
+          <xs:attribute name="alignmentscope"/>
+          <xs:attribute name="side">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="left"/>
+                <xs:enumeration value="right"/>
+                <xs:enumeration value="leftoverlap"/>
+                <xs:enumeration value="rightoverlap"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="rowspacing"/>
+          <xs:attribute name="columnspacing"/>
+          <xs:attribute name="rowlines"/>
+          <xs:attribute name="columnlines"/>
+          <xs:attribute name="width"/>
+          <xs:attribute name="frame">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="solid"/>
+                <xs:enumeration value="dashed"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="framespacing"/>
+          <xs:attribute name="equalrows"/>
+          <xs:attribute name="equalcolumns"/>
+          <xs:attribute name="displaystyle">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="true"/>
+                <xs:enumeration value="false"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mtr_2">
+    <xs:sequence>
+      <xs:element name="mtr">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="rowalign"/>
+          <xs:attribute name="columnalign"/>
+          <xs:attribute name="groupalign"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mlabeledtr_2">
+    <xs:sequence>
+      <xs:element name="mlabeledtr">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="rowalign"/>
+          <xs:attribute name="columnalign"/>
+          <xs:attribute name="groupalign"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="mtd_2">
+    <xs:sequence>
+      <xs:element name="mtd">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="rowalign"/>
+          <xs:attribute name="columnalign"/>
+          <xs:attribute name="groupalign"/>
+          <xs:attribute name="rowspan"/>
+          <xs:attribute name="columnspan"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="maction_2">
+    <xs:sequence>
+      <xs:element name="maction">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:group ref="mathml:declare_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="actiontype"/>
+          <xs:attribute name="selection"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ci_2">
+    <xs:sequence>
+      <xs:element name="ci">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="definitionURL"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="csymbol_2">
+    <xs:sequence>
+      <xs:element name="csymbol">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="encoding"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="definitionURL"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="cn_2">
+    <xs:sequence>
+      <xs:element name="cn">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="base"/>
+          <xs:attribute name="definitionURL"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="apply_2">
+    <xs:sequence>
+      <xs:element name="apply">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="fn_2">
+    <xs:sequence>
+      <xs:element name="fn">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="definitionURL"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="lambda_2">
+    <xs:sequence>
+      <xs:element name="lambda">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="reln_2">
+    <xs:sequence>
+      <xs:element name="reln">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="interval_2">
+    <xs:sequence>
+      <xs:element name="interval">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="closure"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="list_6">
+    <xs:sequence>
+      <xs:element name="list">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="order"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="matrix_2">
+    <xs:sequence>
+      <xs:element name="matrix">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="matrixrow_2">
+    <xs:sequence>
+      <xs:element name="matrixrow">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="set_2">
+    <xs:sequence>
+      <xs:element name="set">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="type"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="vector_2">
+    <xs:sequence>
+      <xs:element name="vector">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="piecewise_2">
+    <xs:sequence>
+      <xs:element name="piecewise">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="mathml:piece_2"/>
+            <xs:group minOccurs="0" ref="mathml:otherwise_2"/>
+          </xs:sequence>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="semantics_2">
+    <xs:sequence>
+      <xs:element name="semantics">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="definitionURL"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="declare_2">
+    <xs:sequence>
+      <xs:element name="declare">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="type"/>
+          <xs:attribute name="scope"/>
+          <xs:attribute name="nargs"/>
+          <xs:attribute name="occurrence"/>
+          <xs:attribute name="definitionURL"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="item_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:item2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="thead">
+    <xs:sequence>
+      <xs:group ref="cnxml:thead"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="tfoot">
+    <xs:sequence>
+      <xs:group ref="cnxml:tfoot"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="tbody">
+    <xs:sequence>
+      <xs:group ref="cnxml:tbody"/>
     </xs:sequence>
   </xs:group>
   <xs:element name="mglyph">
@@ -5130,194 +10993,198 @@
   <xs:element name="sep">
     <xs:complexType/>
   </xs:element>
-  <xs:element name="condition">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="condition">
+    <xs:sequence>
+      <xs:element name="condition">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:element name="annotation">
     <xs:complexType mixed="true">
       <xs:attribute ref="xlink:href"/>
@@ -5330,1517 +11197,1549 @@
       <xs:attribute name="encoding"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="annotation-xml">
-    <xs:complexType mixed="true">
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mprescripts"/>
-        <xs:element ref="mathml:none"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:mglyph"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:piece"/>
-        <xs:element ref="mathml:otherwise"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maction"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:math"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-      <xs:attribute name="encoding"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="lowlimit">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="uplimit">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="bvar">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="degree">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="logbase">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="momentabout">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="domainofapplication">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="annotation-xml">
+    <xs:sequence>
+      <xs:element name="annotation-xml">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:piece"/>
+            <xs:group ref="mathml:otherwise"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:group ref="mathml:maction"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:group ref="mathml:math"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="lowlimit">
+    <xs:sequence>
+      <xs:element name="lowlimit">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="uplimit">
+    <xs:sequence>
+      <xs:element name="uplimit">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="bvar">
+    <xs:sequence>
+      <xs:element name="bvar">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="degree">
+    <xs:sequence>
+      <xs:element name="degree">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="logbase">
+    <xs:sequence>
+      <xs:element name="logbase">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="momentabout">
+    <xs:sequence>
+      <xs:element name="momentabout">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="domainofapplication">
+    <xs:sequence>
+      <xs:element name="domainofapplication">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:element name="inverse">
     <xs:complexType>
       <xs:attribute ref="xlink:href"/>
@@ -8181,380 +14080,2712 @@
       <xs:attribute name="encoding"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="piece">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="otherwise">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mathml:csymbol"/>
-        <xs:element ref="mathml:ci"/>
-        <xs:element ref="mathml:cn"/>
-        <xs:element ref="mathml:apply"/>
-        <xs:element ref="mathml:reln"/>
-        <xs:element ref="mathml:lambda"/>
-        <xs:element ref="mathml:condition"/>
-        <xs:element ref="mathml:declare"/>
-        <xs:element ref="mathml:sep"/>
-        <xs:element ref="mathml:semantics"/>
-        <xs:element ref="mathml:annotation"/>
-        <xs:element ref="mathml:annotation-xml"/>
-        <xs:element ref="mathml:integers"/>
-        <xs:element ref="mathml:reals"/>
-        <xs:element ref="mathml:rationals"/>
-        <xs:element ref="mathml:naturalnumbers"/>
-        <xs:element ref="mathml:complexes"/>
-        <xs:element ref="mathml:primes"/>
-        <xs:element ref="mathml:exponentiale"/>
-        <xs:element ref="mathml:imaginaryi"/>
-        <xs:element ref="mathml:notanumber"/>
-        <xs:element ref="mathml:true"/>
-        <xs:element ref="mathml:false"/>
-        <xs:element ref="mathml:emptyset"/>
-        <xs:element ref="mathml:pi"/>
-        <xs:element ref="mathml:eulergamma"/>
-        <xs:element ref="mathml:infinity"/>
-        <xs:element ref="mathml:interval"/>
-        <xs:element ref="mathml:list"/>
-        <xs:element ref="mathml:matrix"/>
-        <xs:element ref="mathml:matrixrow"/>
-        <xs:element ref="mathml:set"/>
-        <xs:element ref="mathml:vector"/>
-        <xs:element ref="mathml:piecewise"/>
-        <xs:element ref="mathml:lowlimit"/>
-        <xs:element ref="mathml:uplimit"/>
-        <xs:element ref="mathml:bvar"/>
-        <xs:element ref="mathml:degree"/>
-        <xs:element ref="mathml:logbase"/>
-        <xs:element ref="mathml:momentabout"/>
-        <xs:element ref="mathml:domainofapplication"/>
-        <xs:element ref="mathml:inverse"/>
-        <xs:element ref="mathml:ident"/>
-        <xs:element ref="mathml:domain"/>
-        <xs:element ref="mathml:codomain"/>
-        <xs:element ref="mathml:image"/>
-        <xs:element ref="mathml:abs"/>
-        <xs:element ref="mathml:conjugate"/>
-        <xs:element ref="mathml:exp"/>
-        <xs:element ref="mathml:factorial"/>
-        <xs:element ref="mathml:arg"/>
-        <xs:element ref="mathml:real"/>
-        <xs:element ref="mathml:imaginary"/>
-        <xs:element ref="mathml:floor"/>
-        <xs:element ref="mathml:ceiling"/>
-        <xs:element ref="mathml:not"/>
-        <xs:element ref="mathml:ln"/>
-        <xs:element ref="mathml:sin"/>
-        <xs:element ref="mathml:cos"/>
-        <xs:element ref="mathml:tan"/>
-        <xs:element ref="mathml:sec"/>
-        <xs:element ref="mathml:csc"/>
-        <xs:element ref="mathml:cot"/>
-        <xs:element ref="mathml:sinh"/>
-        <xs:element ref="mathml:cosh"/>
-        <xs:element ref="mathml:tanh"/>
-        <xs:element ref="mathml:sech"/>
-        <xs:element ref="mathml:csch"/>
-        <xs:element ref="mathml:coth"/>
-        <xs:element ref="mathml:arcsin"/>
-        <xs:element ref="mathml:arccos"/>
-        <xs:element ref="mathml:arctan"/>
-        <xs:element ref="mathml:arccosh"/>
-        <xs:element ref="mathml:arccot"/>
-        <xs:element ref="mathml:arccoth"/>
-        <xs:element ref="mathml:arccsc"/>
-        <xs:element ref="mathml:arccsch"/>
-        <xs:element ref="mathml:arcsec"/>
-        <xs:element ref="mathml:arcsech"/>
-        <xs:element ref="mathml:arcsinh"/>
-        <xs:element ref="mathml:arctanh"/>
-        <xs:element ref="mathml:determinant"/>
-        <xs:element ref="mathml:transpose"/>
-        <xs:element ref="mathml:card"/>
-        <xs:element ref="mathml:quotient"/>
-        <xs:element ref="mathml:divide"/>
-        <xs:element ref="mathml:power"/>
-        <xs:element ref="mathml:rem"/>
-        <xs:element ref="mathml:implies"/>
-        <xs:element ref="mathml:vectorproduct"/>
-        <xs:element ref="mathml:scalarproduct"/>
-        <xs:element ref="mathml:outerproduct"/>
-        <xs:element ref="mathml:setdiff"/>
-        <xs:element ref="mathml:fn"/>
-        <xs:element ref="mathml:compose"/>
-        <xs:element ref="mathml:plus"/>
-        <xs:element ref="mathml:times"/>
-        <xs:element ref="mathml:max"/>
-        <xs:element ref="mathml:min"/>
-        <xs:element ref="mathml:gcd"/>
-        <xs:element ref="mathml:lcm"/>
-        <xs:element ref="mathml:and"/>
-        <xs:element ref="mathml:or"/>
-        <xs:element ref="mathml:xor"/>
-        <xs:element ref="mathml:union"/>
-        <xs:element ref="mathml:intersect"/>
-        <xs:element ref="mathml:cartesianproduct"/>
-        <xs:element ref="mathml:mean"/>
-        <xs:element ref="mathml:sdev"/>
-        <xs:element ref="mathml:variance"/>
-        <xs:element ref="mathml:median"/>
-        <xs:element ref="mathml:mode"/>
-        <xs:element ref="mathml:selector"/>
-        <xs:element ref="mathml:root"/>
-        <xs:element ref="mathml:minus"/>
-        <xs:element ref="mathml:log"/>
-        <xs:element ref="mathml:int"/>
-        <xs:element ref="mathml:diff"/>
-        <xs:element ref="mathml:partialdiff"/>
-        <xs:element ref="mathml:divergence"/>
-        <xs:element ref="mathml:grad"/>
-        <xs:element ref="mathml:curl"/>
-        <xs:element ref="mathml:laplacian"/>
-        <xs:element ref="mathml:sum"/>
-        <xs:element ref="mathml:product"/>
-        <xs:element ref="mathml:limit"/>
-        <xs:element ref="mathml:moment"/>
-        <xs:element ref="mathml:exists"/>
-        <xs:element ref="mathml:forall"/>
-        <xs:element ref="mathml:neq"/>
-        <xs:element ref="mathml:factorof"/>
-        <xs:element ref="mathml:in"/>
-        <xs:element ref="mathml:notin"/>
-        <xs:element ref="mathml:notsubset"/>
-        <xs:element ref="mathml:notprsubset"/>
-        <xs:element ref="mathml:tendsto"/>
-        <xs:element ref="mathml:eq"/>
-        <xs:element ref="mathml:leq"/>
-        <xs:element ref="mathml:lt"/>
-        <xs:element ref="mathml:geq"/>
-        <xs:element ref="mathml:gt"/>
-        <xs:element ref="mathml:equivalent"/>
-        <xs:element ref="mathml:approx"/>
-        <xs:element ref="mathml:subset"/>
-        <xs:element ref="mathml:prsubset"/>
-        <xs:element ref="mathml:mi"/>
-        <xs:element ref="mathml:mn"/>
-        <xs:element ref="mathml:mo"/>
-        <xs:element ref="mathml:mtext"/>
-        <xs:element ref="mathml:ms"/>
-        <xs:element ref="mathml:mspace"/>
-        <xs:element ref="mathml:mrow"/>
-        <xs:element ref="mathml:mfrac"/>
-        <xs:element ref="mathml:msqrt"/>
-        <xs:element ref="mathml:mroot"/>
-        <xs:element ref="mathml:menclose"/>
-        <xs:element ref="mathml:mstyle"/>
-        <xs:element ref="mathml:merror"/>
-        <xs:element ref="mathml:mpadded"/>
-        <xs:element ref="mathml:mphantom"/>
-        <xs:element ref="mathml:mfenced"/>
-        <xs:element ref="mathml:msub"/>
-        <xs:element ref="mathml:msup"/>
-        <xs:element ref="mathml:msubsup"/>
-        <xs:element ref="mathml:munder"/>
-        <xs:element ref="mathml:mover"/>
-        <xs:element ref="mathml:munderover"/>
-        <xs:element ref="mathml:mmultiscripts"/>
-        <xs:element ref="mathml:mtable"/>
-        <xs:element ref="mathml:mtr"/>
-        <xs:element ref="mathml:mlabeledtr"/>
-        <xs:element ref="mathml:mtd"/>
-        <xs:element ref="mathml:maligngroup"/>
-        <xs:element ref="mathml:malignmark"/>
-        <xs:element ref="mathml:maction"/>
-      </xs:choice>
-      <xs:attribute ref="xlink:href"/>
-      <xs:attribute ref="xlink:type"/>
-      <xs:attribute name="class" type="xs:NMTOKENS"/>
-      <xs:attribute name="style"/>
-      <xs:attribute name="id" type="xs:ID"/>
-      <xs:attribute name="xref" type="xs:IDREF"/>
-      <xs:attribute name="other"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:group name="piece">
+    <xs:sequence>
+      <xs:element name="piece">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="otherwise">
+    <xs:sequence>
+      <xs:element name="otherwise">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol"/>
+            <xs:group ref="mathml:ci"/>
+            <xs:group ref="mathml:cn"/>
+            <xs:group ref="mathml:apply"/>
+            <xs:group ref="mathml:reln"/>
+            <xs:group ref="mathml:lambda"/>
+            <xs:group ref="mathml:condition"/>
+            <xs:group ref="mathml:declare"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval"/>
+            <xs:group ref="mathml:list_4"/>
+            <xs:group ref="mathml:matrix"/>
+            <xs:group ref="mathml:matrixrow"/>
+            <xs:group ref="mathml:set"/>
+            <xs:group ref="mathml:vector"/>
+            <xs:group ref="mathml:piecewise"/>
+            <xs:group ref="mathml:lowlimit"/>
+            <xs:group ref="mathml:uplimit"/>
+            <xs:group ref="mathml:bvar"/>
+            <xs:group ref="mathml:degree"/>
+            <xs:group ref="mathml:logbase"/>
+            <xs:group ref="mathml:momentabout"/>
+            <xs:group ref="mathml:domainofapplication"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi"/>
+            <xs:group ref="mathml:mn"/>
+            <xs:group ref="mathml:mo"/>
+            <xs:group ref="mathml:mtext"/>
+            <xs:group ref="mathml:ms"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow"/>
+            <xs:group ref="mathml:mfrac"/>
+            <xs:group ref="mathml:msqrt"/>
+            <xs:group ref="mathml:mroot"/>
+            <xs:group ref="mathml:menclose"/>
+            <xs:group ref="mathml:mstyle"/>
+            <xs:group ref="mathml:merror"/>
+            <xs:group ref="mathml:mpadded"/>
+            <xs:group ref="mathml:mphantom"/>
+            <xs:group ref="mathml:mfenced"/>
+            <xs:group ref="mathml:msub"/>
+            <xs:group ref="mathml:msup"/>
+            <xs:group ref="mathml:msubsup"/>
+            <xs:group ref="mathml:munder"/>
+            <xs:group ref="mathml:mover"/>
+            <xs:group ref="mathml:munderover"/>
+            <xs:group ref="mathml:mmultiscripts"/>
+            <xs:group ref="mathml:mtable"/>
+            <xs:group ref="mathml:mtr"/>
+            <xs:group ref="mathml:mlabeledtr"/>
+            <xs:group ref="mathml:mtd"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="title_7">
+    <xs:sequence>
+      <xs:group ref="cnxml:title2"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="caption_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:caption1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="para_4">
+    <xs:sequence>
+      <xs:group ref="cnxml:para3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="div_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:div1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="definition_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:definition1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="example_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:example1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="figure_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:figure1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="table_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:table1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="rule_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:rule1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="equation_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:equation1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="exercise_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:exercise1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="item_5">
+    <xs:sequence>
+      <xs:group ref="cnxml:item3"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="longdesc_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:longdesc1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="object_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:object1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="image_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:image1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="audio_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:audio1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="video_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:video1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="java-applet_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:java-applet1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="flash_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:flash1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="labview_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:labview1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="text_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:text1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="download_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:download1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="condition_2">
+    <xs:sequence>
+      <xs:element name="condition">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="annotation-xml_2">
+    <xs:sequence>
+      <xs:element name="annotation-xml">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mathml:mspace"/>
+            <xs:element ref="mathml:mprescripts"/>
+            <xs:element ref="mathml:none"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:mglyph"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:piece_2"/>
+            <xs:group ref="mathml:otherwise_2"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:group ref="mathml:maction_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:group ref="mathml:math_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+          <xs:attribute name="encoding"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="lowlimit_2">
+    <xs:sequence>
+      <xs:element name="lowlimit">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="uplimit_2">
+    <xs:sequence>
+      <xs:element name="uplimit">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="bvar_2">
+    <xs:sequence>
+      <xs:element name="bvar">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="degree_2">
+    <xs:sequence>
+      <xs:element name="degree">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="logbase_2">
+    <xs:sequence>
+      <xs:element name="logbase">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="momentabout_2">
+    <xs:sequence>
+      <xs:element name="momentabout">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="domainofapplication_2">
+    <xs:sequence>
+      <xs:element name="domainofapplication">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="piece_2">
+    <xs:sequence>
+      <xs:element name="piece">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="otherwise_2">
+    <xs:sequence>
+      <xs:element name="otherwise">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:csymbol_2"/>
+            <xs:group ref="mathml:ci_2"/>
+            <xs:group ref="mathml:cn_2"/>
+            <xs:group ref="mathml:apply_2"/>
+            <xs:group ref="mathml:reln_2"/>
+            <xs:group ref="mathml:lambda_2"/>
+            <xs:group ref="mathml:condition_2"/>
+            <xs:group ref="mathml:declare_2"/>
+            <xs:element ref="mathml:sep"/>
+            <xs:group ref="mathml:semantics_2"/>
+            <xs:element ref="mathml:annotation"/>
+            <xs:group ref="mathml:annotation-xml_2"/>
+            <xs:element ref="mathml:integers"/>
+            <xs:element ref="mathml:reals"/>
+            <xs:element ref="mathml:rationals"/>
+            <xs:element ref="mathml:naturalnumbers"/>
+            <xs:element ref="mathml:complexes"/>
+            <xs:element ref="mathml:primes"/>
+            <xs:element ref="mathml:exponentiale"/>
+            <xs:element ref="mathml:imaginaryi"/>
+            <xs:element ref="mathml:notanumber"/>
+            <xs:element ref="mathml:true"/>
+            <xs:element ref="mathml:false"/>
+            <xs:element ref="mathml:emptyset"/>
+            <xs:element ref="mathml:pi"/>
+            <xs:element ref="mathml:eulergamma"/>
+            <xs:element ref="mathml:infinity"/>
+            <xs:group ref="mathml:interval_2"/>
+            <xs:group ref="mathml:list_6"/>
+            <xs:group ref="mathml:matrix_2"/>
+            <xs:group ref="mathml:matrixrow_2"/>
+            <xs:group ref="mathml:set_2"/>
+            <xs:group ref="mathml:vector_2"/>
+            <xs:group ref="mathml:piecewise_2"/>
+            <xs:group ref="mathml:lowlimit_2"/>
+            <xs:group ref="mathml:uplimit_2"/>
+            <xs:group ref="mathml:bvar_2"/>
+            <xs:group ref="mathml:degree_2"/>
+            <xs:group ref="mathml:logbase_2"/>
+            <xs:group ref="mathml:momentabout_2"/>
+            <xs:group ref="mathml:domainofapplication_2"/>
+            <xs:element ref="mathml:inverse"/>
+            <xs:element ref="mathml:ident"/>
+            <xs:element ref="mathml:domain"/>
+            <xs:element ref="mathml:codomain"/>
+            <xs:element ref="mathml:image"/>
+            <xs:element ref="mathml:abs"/>
+            <xs:element ref="mathml:conjugate"/>
+            <xs:element ref="mathml:exp"/>
+            <xs:element ref="mathml:factorial"/>
+            <xs:element ref="mathml:arg"/>
+            <xs:element ref="mathml:real"/>
+            <xs:element ref="mathml:imaginary"/>
+            <xs:element ref="mathml:floor"/>
+            <xs:element ref="mathml:ceiling"/>
+            <xs:element ref="mathml:not"/>
+            <xs:element ref="mathml:ln"/>
+            <xs:element ref="mathml:sin"/>
+            <xs:element ref="mathml:cos"/>
+            <xs:element ref="mathml:tan"/>
+            <xs:element ref="mathml:sec"/>
+            <xs:element ref="mathml:csc"/>
+            <xs:element ref="mathml:cot"/>
+            <xs:element ref="mathml:sinh"/>
+            <xs:element ref="mathml:cosh"/>
+            <xs:element ref="mathml:tanh"/>
+            <xs:element ref="mathml:sech"/>
+            <xs:element ref="mathml:csch"/>
+            <xs:element ref="mathml:coth"/>
+            <xs:element ref="mathml:arcsin"/>
+            <xs:element ref="mathml:arccos"/>
+            <xs:element ref="mathml:arctan"/>
+            <xs:element ref="mathml:arccosh"/>
+            <xs:element ref="mathml:arccot"/>
+            <xs:element ref="mathml:arccoth"/>
+            <xs:element ref="mathml:arccsc"/>
+            <xs:element ref="mathml:arccsch"/>
+            <xs:element ref="mathml:arcsec"/>
+            <xs:element ref="mathml:arcsech"/>
+            <xs:element ref="mathml:arcsinh"/>
+            <xs:element ref="mathml:arctanh"/>
+            <xs:element ref="mathml:determinant"/>
+            <xs:element ref="mathml:transpose"/>
+            <xs:element ref="mathml:card"/>
+            <xs:element ref="mathml:quotient"/>
+            <xs:element ref="mathml:divide"/>
+            <xs:element ref="mathml:power"/>
+            <xs:element ref="mathml:rem"/>
+            <xs:element ref="mathml:implies"/>
+            <xs:element ref="mathml:vectorproduct"/>
+            <xs:element ref="mathml:scalarproduct"/>
+            <xs:element ref="mathml:outerproduct"/>
+            <xs:element ref="mathml:setdiff"/>
+            <xs:group ref="mathml:fn_2"/>
+            <xs:element ref="mathml:compose"/>
+            <xs:element ref="mathml:plus"/>
+            <xs:element ref="mathml:times"/>
+            <xs:element ref="mathml:max"/>
+            <xs:element ref="mathml:min"/>
+            <xs:element ref="mathml:gcd"/>
+            <xs:element ref="mathml:lcm"/>
+            <xs:element ref="mathml:and"/>
+            <xs:element ref="mathml:or"/>
+            <xs:element ref="mathml:xor"/>
+            <xs:element ref="mathml:union"/>
+            <xs:element ref="mathml:intersect"/>
+            <xs:element ref="mathml:cartesianproduct"/>
+            <xs:element ref="mathml:mean"/>
+            <xs:element ref="mathml:sdev"/>
+            <xs:element ref="mathml:variance"/>
+            <xs:element ref="mathml:median"/>
+            <xs:element ref="mathml:mode"/>
+            <xs:element ref="mathml:selector"/>
+            <xs:element ref="mathml:root"/>
+            <xs:element ref="mathml:minus"/>
+            <xs:element ref="mathml:log"/>
+            <xs:element ref="mathml:int"/>
+            <xs:element ref="mathml:diff"/>
+            <xs:element ref="mathml:partialdiff"/>
+            <xs:element ref="mathml:divergence"/>
+            <xs:element ref="mathml:grad"/>
+            <xs:element ref="mathml:curl"/>
+            <xs:element ref="mathml:laplacian"/>
+            <xs:element ref="mathml:sum"/>
+            <xs:element ref="mathml:product"/>
+            <xs:element ref="mathml:limit"/>
+            <xs:element ref="mathml:moment"/>
+            <xs:element ref="mathml:exists"/>
+            <xs:element ref="mathml:forall"/>
+            <xs:element ref="mathml:neq"/>
+            <xs:element ref="mathml:factorof"/>
+            <xs:element ref="mathml:in"/>
+            <xs:element ref="mathml:notin"/>
+            <xs:element ref="mathml:notsubset"/>
+            <xs:element ref="mathml:notprsubset"/>
+            <xs:element ref="mathml:tendsto"/>
+            <xs:element ref="mathml:eq"/>
+            <xs:element ref="mathml:leq"/>
+            <xs:element ref="mathml:lt"/>
+            <xs:element ref="mathml:geq"/>
+            <xs:element ref="mathml:gt"/>
+            <xs:element ref="mathml:equivalent"/>
+            <xs:element ref="mathml:approx"/>
+            <xs:element ref="mathml:subset"/>
+            <xs:element ref="mathml:prsubset"/>
+            <xs:group ref="mathml:mi_2"/>
+            <xs:group ref="mathml:mn_2"/>
+            <xs:group ref="mathml:mo_2"/>
+            <xs:group ref="mathml:mtext_2"/>
+            <xs:group ref="mathml:ms_2"/>
+            <xs:element ref="mathml:mspace"/>
+            <xs:group ref="mathml:mrow_2"/>
+            <xs:group ref="mathml:mfrac_2"/>
+            <xs:group ref="mathml:msqrt_2"/>
+            <xs:group ref="mathml:mroot_2"/>
+            <xs:group ref="mathml:menclose_2"/>
+            <xs:group ref="mathml:mstyle_2"/>
+            <xs:group ref="mathml:merror_2"/>
+            <xs:group ref="mathml:mpadded_2"/>
+            <xs:group ref="mathml:mphantom_2"/>
+            <xs:group ref="mathml:mfenced_2"/>
+            <xs:group ref="mathml:msub_2"/>
+            <xs:group ref="mathml:msup_2"/>
+            <xs:group ref="mathml:msubsup_2"/>
+            <xs:group ref="mathml:munder_2"/>
+            <xs:group ref="mathml:mover_2"/>
+            <xs:group ref="mathml:munderover_2"/>
+            <xs:group ref="mathml:mmultiscripts_2"/>
+            <xs:group ref="mathml:mtable_2"/>
+            <xs:group ref="mathml:mtr_2"/>
+            <xs:group ref="mathml:mlabeledtr_2"/>
+            <xs:group ref="mathml:mtd_2"/>
+            <xs:element ref="mathml:maligngroup"/>
+            <xs:element ref="mathml:malignmark"/>
+            <xs:group ref="mathml:maction_2"/>
+          </xs:choice>
+          <xs:attribute ref="xlink:href"/>
+          <xs:attribute ref="xlink:type"/>
+          <xs:attribute name="class" type="xs:NMTOKENS"/>
+          <xs:attribute name="style"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute name="xref" type="xs:IDREF"/>
+          <xs:attribute name="other"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="row">
+    <xs:sequence>
+      <xs:group ref="cnxml:row"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="seealso_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:seealso1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="meaning_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:meaning1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="section_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:section1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subfigure_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:subfigure1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="tgroup_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:tgroup1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="statement_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:statement1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="proof_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:proof1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="problem_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:problem1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="solution_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:solution1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="commentary_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:commentary1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="entry_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:entry"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="entrytbl">
+    <xs:sequence>
+      <xs:group ref="cnxml:entrytbl"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="thead_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:thead1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="tfoot_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:tfoot1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="tbody_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:tbody1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="row_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:row1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="entry_3">
+    <xs:sequence>
+      <xs:group ref="cnxml:entry1"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="entrytbl_2">
+    <xs:sequence>
+      <xs:group ref="cnxml:entrytbl1"/>
+    </xs:sequence>
+  </xs:group>
 </xs:schema>

--- a/client/static/xsd/mdml.xsd
+++ b/client/static/xsd/mdml.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/mdml" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/mdml" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
   <xs:import namespace="http://katalysteducation.org/cmlnle/1.0" schemaLocation="cmlnle.xsd"/>
@@ -10,10 +11,454 @@
   <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
   <xs:import namespace="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" schemaLocation="ns1.xsd"/>
-  <xs:element name="content-id">
+  <xs:element name="content-id" type="xs:string"/>
+  <xs:element name="title" type="xs:string"/>
+  <xs:element name="language" type="xs:string"/>
+  <xs:element name="uuid" type="xs:string"/>
+  <xs:element name="slug" type="xs:string"/>
+  <xs:element name="license">
+    <xs:complexType mixed="true">
+      <xs:attribute name="url" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="content-id">
+    <xs:sequence>
+      <xs:element name="content-id">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:NMTOKEN">
+              <xs:attribute ref="xml:lang"/>
+              <xs:attribute name="class" type="xs:token"/>
+              <xs:attribute ref="s:read-only"/>
+              <xs:anyAttribute processContents="skip"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="repository">
+    <xs:sequence>
+      <xs:element name="repository">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="content-url">
+    <xs:sequence>
+      <xs:element name="content-url">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="title">
+    <xs:sequence>
+      <xs:element name="title">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="short-title">
+    <xs:sequence>
+      <xs:element name="short-title">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subtitle">
+    <xs:sequence>
+      <xs:element name="subtitle">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="version">
+    <xs:sequence>
+      <xs:element name="version">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="created">
+    <xs:sequence>
+      <xs:element name="created">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="revised">
+    <xs:sequence>
+      <xs:element name="revised">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="actors">
+    <xs:sequence>
+      <xs:element name="actors">
+        <xs:complexType>
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="mathml:person"/>
+            <xs:group ref="mathml:organization"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="roles">
+    <xs:sequence>
+      <xs:element name="roles">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:role"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="license">
+    <xs:sequence>
+      <xs:element name="license">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:attribute name="url" use="required"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="extended-attribution">
+    <xs:sequence>
+      <xs:element name="extended-attribution">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:link-group"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="derived-from">
+    <xs:sequence>
+      <xs:element name="derived-from">
+        <xs:complexType>
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:content-id"/>
+              <xs:group ref="mathml:repository"/>
+              <xs:group ref="mathml:content-url"/>
+              <xs:group ref="mathml:title_2"/>
+              <xs:group ref="mathml:short-title"/>
+              <xs:group ref="mathml:subtitle"/>
+              <xs:group ref="mathml:version"/>
+              <xs:group ref="mathml:created"/>
+              <xs:group ref="mathml:revised"/>
+              <xs:group ref="mathml:actors"/>
+              <xs:group ref="mathml:roles"/>
+              <xs:group ref="mathml:license"/>
+              <xs:group ref="mathml:extended-attribution"/>
+              <xs:group ref="mathml:derived-from"/>
+              <xs:group ref="mathml:keywordlist"/>
+              <xs:group ref="mathml:subjectlist"/>
+              <xs:group ref="mathml:education-levellist"/>
+              <xs:group ref="mathml:abstract"/>
+              <xs:group ref="mathml:objectives"/>
+              <xs:group ref="mathml:homepage"/>
+              <xs:group ref="mathml:institution"/>
+              <xs:group ref="mathml:course-code"/>
+              <xs:group ref="mathml:instructor"/>
+              <xs:group ref="mathml:uuid"/>
+              <xs:group ref="mathml:canonical-book-uuid"/>
+              <xs:group ref="mathml:slug"/>
+              <xs:element ref="mdml:ancillary"/>
+              <xs:element ref="mdml:version-history"/>
+            </xs:choice>
+            <xs:group minOccurs="0" ref="mathml:language"/>
+          </xs:sequence>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:attribute ref="s:implementation"/>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="repository"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="keywordlist">
+    <xs:sequence>
+      <xs:element name="keywordlist">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:keyword"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subjectlist">
+    <xs:sequence>
+      <xs:element name="subjectlist">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:subject"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="education-levellist">
+    <xs:sequence>
+      <xs:element name="education-levellist">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:education-level"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="abstract">
+    <xs:sequence>
+      <xs:element name="abstract">
+        <xs:complexType mixed="true">
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="mathml:para_2"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:emphasis"/>
+              <xs:group ref="mathml:term"/>
+              <xs:group ref="mathml:foreign"/>
+              <xs:group ref="mathml:cite"/>
+              <xs:group ref="mathml:span"/>
+              <xs:group ref="mathml:sup"/>
+              <xs:group ref="mathml:sub"/>
+              <xs:group ref="mathml:code_2"/>
+              <xs:group ref="mathml:math"/>
+              <xs:group ref="mathml:quote_2"/>
+              <xs:group ref="mathml:preformat_2"/>
+              <xs:group ref="mathml:list_2"/>
+            </xs:choice>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="objectives">
+    <xs:sequence>
+      <xs:element name="objectives">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="homepage">
+    <xs:sequence>
+      <xs:element name="homepage">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="institution">
+    <xs:sequence>
+      <xs:element name="institution">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="course-code">
+    <xs:sequence>
+      <xs:element name="course-code">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="instructor">
+    <xs:sequence>
+      <xs:element name="instructor">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="uuid">
+    <xs:sequence>
+      <xs:element name="uuid">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="canonical-book-uuid">
+    <xs:sequence>
+      <xs:element name="canonical-book-uuid">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="slug">
+    <xs:sequence>
+      <xs:element name="slug">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="ancillary">
     <xs:complexType>
-      <xs:simpleContent>
-        <xs:extension base="xs:NMTOKEN">
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:attribute name="url" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="version-history">
+    <xs:complexType>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="class" type="xs:token"/>
+      <xs:attribute ref="s:read-only"/>
+      <xs:attribute name="url" use="required"/>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="language">
+    <xs:sequence>
+      <xs:element name="language">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="content-id1">
+    <xs:sequence>
+      <xs:element name="content-id">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:NMTOKEN">
+              <xs:attribute ref="cmlnle:case"/>
+              <xs:attribute ref="cmlnle:reference"/>
+              <xs:attribute ref="cxlxt:born"/>
+              <xs:attribute ref="cxlxt:died"/>
+              <xs:attribute ref="cxlxt:index"/>
+              <xs:attribute ref="cxlxt:name"/>
+              <xs:attribute ref="ns1:color"/>
+              <xs:attribute ref="ns1:font-style"/>
+              <xs:attribute ref="ns1:font-weight"/>
+              <xs:attribute ref="xml:lang"/>
+              <xs:attribute name="class" type="xs:token"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="repository1">
+    <xs:sequence>
+      <xs:element name="repository">
+        <xs:complexType mixed="true">
           <xs:attribute ref="cmlnle:case"/>
           <xs:attribute ref="cmlnle:reference"/>
           <xs:attribute ref="cxlxt:born"/>
@@ -25,702 +470,1026 @@
           <xs:attribute ref="ns1:font-weight"/>
           <xs:attribute ref="xml:lang"/>
           <xs:attribute name="class" type="xs:token"/>
-        </xs:extension>
-      </xs:simpleContent>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="repository">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="content-url">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="title">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="short-title">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="subtitle">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="version">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="created">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="revised">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="actors">
-    <xs:complexType>
-      <xs:choice maxOccurs="unbounded">
-        <xs:element ref="mdml:person"/>
-        <xs:element ref="mdml:organization"/>
-      </xs:choice>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="roles">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="mdml:role"/>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="license">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="url" use="required"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="extended-attribution">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="cnxml:link-group"/>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="derived-from">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mdml:content-id"/>
-        <xs:element ref="mdml:repository"/>
-        <xs:element ref="mdml:content-url"/>
-        <xs:element ref="mdml:title"/>
-        <xs:element ref="mdml:short-title"/>
-        <xs:element ref="mdml:subtitle"/>
-        <xs:element ref="mdml:version"/>
-        <xs:element ref="mdml:created"/>
-        <xs:element ref="mdml:revised"/>
-        <xs:element ref="mdml:actors"/>
-        <xs:element ref="mdml:roles"/>
-        <xs:element ref="mdml:license"/>
-        <xs:element ref="mdml:extended-attribution"/>
-        <xs:element ref="mdml:derived-from"/>
-        <xs:element ref="mdml:keywordlist"/>
-        <xs:element ref="mdml:subjectlist"/>
-        <xs:element ref="mdml:education-levellist"/>
-        <xs:element ref="mdml:abstract"/>
-        <xs:element ref="mdml:language"/>
-        <xs:element ref="mdml:objectives"/>
-        <xs:element ref="mdml:homepage"/>
-        <xs:element ref="mdml:institution"/>
-        <xs:element ref="mdml:course-code"/>
-        <xs:element ref="mdml:instructor"/>
-        <xs:element ref="mdml:uuid"/>
-        <xs:element ref="mdml:canonical-book-uuid"/>
-        <xs:element ref="mdml:slug"/>
-      </xs:choice>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute ref="s:implementation"/>
-      <xs:attribute name="url"/>
-      <xs:attribute name="document"/>
-      <xs:attribute name="version"/>
-      <xs:attribute name="repository"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="keywordlist">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="mdml:keyword"/>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="subjectlist">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="mdml:subject"/>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="education-levellist">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="mdml:education-level"/>
-      </xs:sequence>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="abstract">
-    <xs:complexType mixed="true">
-      <xs:choice maxOccurs="unbounded">
-        <xs:group ref="mathml:para_2"/>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:group ref="mathml:emphasis"/>
-          <xs:group ref="mathml:term"/>
-          <xs:group ref="mathml:foreign"/>
-          <xs:group ref="mathml:cite"/>
-          <xs:group ref="mathml:span"/>
-          <xs:group ref="mathml:sup"/>
-          <xs:group ref="mathml:sub"/>
-          <xs:group ref="mathml:code_2"/>
-          <xs:element ref="mathml:math"/>
-          <xs:group ref="mathml:quote_2"/>
-          <xs:group ref="mathml:preformat_2"/>
-          <xs:group ref="mathml:list_2"/>
-        </xs:choice>
-      </xs:choice>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="language">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="objectives">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="homepage">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="institution">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="course-code">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="instructor">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="uuid">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="canonical-book-uuid">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="slug">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="person">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mdml:honorific"/>
-        <xs:element ref="mdml:firstname"/>
-        <xs:element ref="mdml:othername"/>
-        <xs:element ref="mdml:surname"/>
-        <xs:element ref="mdml:lineage"/>
-        <xs:element ref="mdml:fullname"/>
-        <xs:element ref="mdml:email"/>
-        <xs:element ref="mdml:homepage"/>
-      </xs:choice>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="userid"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="organization">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="mdml:fullname"/>
-        <xs:element ref="mdml:shortname"/>
-        <xs:element ref="mdml:email"/>
-        <xs:element ref="mdml:homepage"/>
-      </xs:choice>
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="userid"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="role">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="type" use="required"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="keyword">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="subject">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="source"/>
-      <xs:attribute name="key"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="education-level">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-      <xs:attribute name="source"/>
-      <xs:attribute name="key"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="honorific">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="firstname">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="othername">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="surname">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="lineage">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="fullname">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="email">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="shortname">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="cmlnle:case"/>
-      <xs:attribute ref="cmlnle:reference"/>
-      <xs:attribute ref="cxlxt:born"/>
-      <xs:attribute ref="cxlxt:died"/>
-      <xs:attribute ref="cxlxt:index"/>
-      <xs:attribute ref="cxlxt:name"/>
-      <xs:attribute ref="ns1:color"/>
-      <xs:attribute ref="ns1:font-style"/>
-      <xs:attribute ref="ns1:font-weight"/>
-      <xs:attribute ref="xml:lang"/>
-      <xs:attribute name="class" type="xs:token"/>
-    </xs:complexType>
-  </xs:element>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="content-url1">
+    <xs:sequence>
+      <xs:element name="content-url">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="title1">
+    <xs:sequence>
+      <xs:element name="title">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="short-title1">
+    <xs:sequence>
+      <xs:element name="short-title">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subtitle1">
+    <xs:sequence>
+      <xs:element name="subtitle">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="version1">
+    <xs:sequence>
+      <xs:element name="version">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="created1">
+    <xs:sequence>
+      <xs:element name="created">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="revised1">
+    <xs:sequence>
+      <xs:element name="revised">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="actors1">
+    <xs:sequence>
+      <xs:element name="actors">
+        <xs:complexType>
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="mathml:person_2"/>
+            <xs:group ref="mathml:organization_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="roles1">
+    <xs:sequence>
+      <xs:element name="roles">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:role_2"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="license1">
+    <xs:sequence>
+      <xs:element name="license">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="url" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="extended-attribution1">
+    <xs:sequence>
+      <xs:element name="extended-attribution">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:link-group_2"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="derived-from1">
+    <xs:sequence>
+      <xs:element name="derived-from">
+        <xs:complexType>
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:content-id_2"/>
+              <xs:group ref="mathml:repository_2"/>
+              <xs:group ref="mathml:content-url_2"/>
+              <xs:group ref="mathml:title_3"/>
+              <xs:group ref="mathml:short-title_2"/>
+              <xs:group ref="mathml:subtitle_2"/>
+              <xs:group ref="mathml:version_2"/>
+              <xs:group ref="mathml:created_2"/>
+              <xs:group ref="mathml:revised_2"/>
+              <xs:group ref="mathml:actors_2"/>
+              <xs:group ref="mathml:roles_2"/>
+              <xs:group ref="mathml:license_2"/>
+              <xs:group ref="mathml:extended-attribution_2"/>
+              <xs:group ref="mathml:derived-from_2"/>
+              <xs:group ref="mathml:keywordlist_2"/>
+              <xs:group ref="mathml:subjectlist_2"/>
+              <xs:group ref="mathml:education-levellist_2"/>
+              <xs:group ref="mathml:abstract_2"/>
+              <xs:group ref="mathml:objectives_2"/>
+              <xs:group ref="mathml:homepage_2"/>
+              <xs:group ref="mathml:institution_2"/>
+              <xs:group ref="mathml:course-code_2"/>
+              <xs:group ref="mathml:instructor_2"/>
+              <xs:group ref="mathml:uuid_2"/>
+              <xs:group ref="mathml:canonical-book-uuid_2"/>
+              <xs:group ref="mathml:slug_2"/>
+            </xs:choice>
+            <xs:group minOccurs="0" ref="mathml:language_2"/>
+          </xs:sequence>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:implementation"/>
+          <xs:attribute name="url"/>
+          <xs:attribute name="document"/>
+          <xs:attribute name="version"/>
+          <xs:attribute name="repository"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="keywordlist1">
+    <xs:sequence>
+      <xs:element name="keywordlist">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:keyword_2"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subjectlist1">
+    <xs:sequence>
+      <xs:element name="subjectlist">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:subject_2"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="education-levellist1">
+    <xs:sequence>
+      <xs:element name="education-levellist">
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="mathml:education-level_2"/>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="abstract1">
+    <xs:sequence>
+      <xs:element name="abstract">
+        <xs:complexType mixed="true">
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="mathml:para_3"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="mathml:emphasis_2"/>
+              <xs:group ref="mathml:term_2"/>
+              <xs:group ref="mathml:foreign_2"/>
+              <xs:group ref="mathml:cite_2"/>
+              <xs:group ref="mathml:span_2"/>
+              <xs:group ref="mathml:sup_2"/>
+              <xs:group ref="mathml:sub_2"/>
+              <xs:group ref="mathml:code_3"/>
+              <xs:group ref="mathml:math_2"/>
+              <xs:group ref="mathml:quote_3"/>
+              <xs:group ref="mathml:preformat_3"/>
+              <xs:group ref="mathml:list_3"/>
+            </xs:choice>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="objectives1">
+    <xs:sequence>
+      <xs:element name="objectives">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="homepage1">
+    <xs:sequence>
+      <xs:element name="homepage">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="institution1">
+    <xs:sequence>
+      <xs:element name="institution">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="course-code1">
+    <xs:sequence>
+      <xs:element name="course-code">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="instructor1">
+    <xs:sequence>
+      <xs:element name="instructor">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="uuid1">
+    <xs:sequence>
+      <xs:element name="uuid">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="canonical-book-uuid1">
+    <xs:sequence>
+      <xs:element name="canonical-book-uuid">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="slug1">
+    <xs:sequence>
+      <xs:element name="slug">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="language1">
+    <xs:sequence>
+      <xs:element name="language">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="person">
+    <xs:sequence>
+      <xs:element name="person">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:honorific"/>
+            <xs:group ref="mathml:firstname"/>
+            <xs:group ref="mathml:othername"/>
+            <xs:group ref="mathml:surname"/>
+            <xs:group ref="mathml:lineage"/>
+            <xs:group ref="mathml:fullname"/>
+            <xs:group ref="mathml:email"/>
+            <xs:group ref="mathml:homepage"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:attribute name="userid"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="organization">
+    <xs:sequence>
+      <xs:element name="organization">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:fullname"/>
+            <xs:group ref="mathml:shortname"/>
+            <xs:group ref="mathml:email"/>
+            <xs:group ref="mathml:homepage"/>
+          </xs:choice>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:attribute name="userid"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="role">
+    <xs:sequence>
+      <xs:element name="role">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:attribute name="type" use="required"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="keyword">
+    <xs:sequence>
+      <xs:element name="keyword">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subject">
+    <xs:sequence>
+      <xs:element name="subject">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:attribute name="source"/>
+          <xs:attribute name="key"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="education-level">
+    <xs:sequence>
+      <xs:element name="education-level">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:attribute name="source"/>
+          <xs:attribute name="key"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="person1">
+    <xs:sequence>
+      <xs:element name="person">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:honorific_2"/>
+            <xs:group ref="mathml:firstname_2"/>
+            <xs:group ref="mathml:othername_2"/>
+            <xs:group ref="mathml:surname_2"/>
+            <xs:group ref="mathml:lineage_2"/>
+            <xs:group ref="mathml:fullname_2"/>
+            <xs:group ref="mathml:email_2"/>
+            <xs:group ref="mathml:homepage_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="userid"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="organization1">
+    <xs:sequence>
+      <xs:element name="organization">
+        <xs:complexType>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="mathml:fullname_2"/>
+            <xs:group ref="mathml:shortname_2"/>
+            <xs:group ref="mathml:email_2"/>
+            <xs:group ref="mathml:homepage_2"/>
+          </xs:choice>
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="userid"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="role1">
+    <xs:sequence>
+      <xs:element name="role">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="type" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="keyword1">
+    <xs:sequence>
+      <xs:element name="keyword">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="subject1">
+    <xs:sequence>
+      <xs:element name="subject">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="source"/>
+          <xs:attribute name="key"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="education-level1">
+    <xs:sequence>
+      <xs:element name="education-level">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute name="source"/>
+          <xs:attribute name="key"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="honorific">
+    <xs:sequence>
+      <xs:element name="honorific">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="firstname">
+    <xs:sequence>
+      <xs:element name="firstname">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="othername">
+    <xs:sequence>
+      <xs:element name="othername">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="surname">
+    <xs:sequence>
+      <xs:element name="surname">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="lineage">
+    <xs:sequence>
+      <xs:element name="lineage">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="fullname">
+    <xs:sequence>
+      <xs:element name="fullname">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="email">
+    <xs:sequence>
+      <xs:element name="email">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="shortname">
+    <xs:sequence>
+      <xs:element name="shortname">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+          <xs:attribute ref="s:read-only"/>
+          <xs:anyAttribute processContents="skip"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="honorific1">
+    <xs:sequence>
+      <xs:element name="honorific">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="firstname1">
+    <xs:sequence>
+      <xs:element name="firstname">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="othername1">
+    <xs:sequence>
+      <xs:element name="othername">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="surname1">
+    <xs:sequence>
+      <xs:element name="surname">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="lineage1">
+    <xs:sequence>
+      <xs:element name="lineage">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="fullname1">
+    <xs:sequence>
+      <xs:element name="fullname">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="email1">
+    <xs:sequence>
+      <xs:element name="email">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="shortname1">
+    <xs:sequence>
+      <xs:element name="shortname">
+        <xs:complexType mixed="true">
+          <xs:attribute ref="cmlnle:case"/>
+          <xs:attribute ref="cmlnle:reference"/>
+          <xs:attribute ref="cxlxt:born"/>
+          <xs:attribute ref="cxlxt:died"/>
+          <xs:attribute ref="cxlxt:index"/>
+          <xs:attribute ref="cxlxt:name"/>
+          <xs:attribute ref="ns1:color"/>
+          <xs:attribute ref="ns1:font-style"/>
+          <xs:attribute ref="ns1:font-weight"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="class" type="xs:token"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
 </xs:schema>

--- a/client/static/xsd/ns1.xsd
+++ b/client/static/xsd/ns1.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>

--- a/client/static/xsd/ns2.xsd
+++ b/client/static/xsd/ns2.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://bibtexml.sf.net/" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://bibtexml.sf.net/" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>

--- a/client/static/xsd/qml.xsd
+++ b/client/static/xsd/qml.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/qml/1.0" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/qml/1.0" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>
   <xs:import namespace="http://katalysteducation.org/cmlnle/1.0" schemaLocation="cmlnle.xsd"/>
@@ -44,8 +45,8 @@
   <xs:element name="question">
     <xs:complexType mixed="true">
       <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="cnxml:section"/>
-        <xs:element ref="cnxml:media"/>
+        <xs:group ref="mathml:section"/>
+        <xs:group ref="mathml:media"/>
       </xs:choice>
     </xs:complexType>
   </xs:element>
@@ -70,16 +71,16 @@
   <xs:element name="hint">
     <xs:complexType mixed="true">
       <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="cnxml:section"/>
-        <xs:element ref="cnxml:media"/>
+        <xs:group ref="mathml:section"/>
+        <xs:group ref="mathml:media"/>
       </xs:choice>
     </xs:complexType>
   </xs:element>
   <xs:element name="feedback">
     <xs:complexType mixed="true">
       <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="cnxml:section"/>
-        <xs:element ref="cnxml:media"/>
+        <xs:group ref="mathml:section"/>
+        <xs:group ref="mathml:media"/>
       </xs:choice>
       <xs:attribute name="correct">
         <xs:simpleType>
@@ -94,8 +95,8 @@
   <xs:element name="key">
     <xs:complexType mixed="true">
       <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="cnxml:section"/>
-        <xs:element ref="cnxml:media"/>
+        <xs:group ref="mathml:section"/>
+        <xs:group ref="mathml:media"/>
       </xs:choice>
       <xs:attribute name="answer"/>
     </xs:complexType>
@@ -103,8 +104,8 @@
   <xs:element name="response">
     <xs:complexType mixed="true">
       <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="cnxml:section"/>
-        <xs:element ref="cnxml:media"/>
+        <xs:group ref="mathml:section"/>
+        <xs:group ref="mathml:media"/>
       </xs:choice>
     </xs:complexType>
   </xs:element>

--- a/client/static/xsd/s.xsd
+++ b/client/static/xsd/s.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/system-info" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://cnx.rice.edu/system-info" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
   <xs:import namespace="http://katalysteducation.org/cmlnle/1.0" schemaLocation="cmlnle.xsd"/>
@@ -10,5 +11,8 @@
   <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
   <xs:import namespace="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" schemaLocation="ns1.xsd"/>
+  <xs:attribute name="read-only" type="xs:string"/>
   <xs:attribute name="implementation"/>
+  <xs:attribute name="local-path"/>
+  <xs:attribute name="version-at-this-collection-version"/>
 </xs:schema>

--- a/client/static/xsd/trang.patch
+++ b/client/static/xsd/trang.patch
@@ -1,0 +1,71 @@
+diff --git a/client/static/xsd/collxml.xsd b/client/static/xsd/collxml.xsd
+index 43d3127..744f1b7 100644
+--- a/client/static/xsd/collxml.xsd
++++ b/client/static/xsd/collxml.xsd
+@@ -30,37 +30,14 @@
+   </xs:element>
+   <xs:element name="metadata">
+     <xs:complexType>
+-      <xs:choice minOccurs="0" maxOccurs="unbounded">
+-        <xs:group ref="mathml:content-id"/>
+-        <xs:group ref="mathml:repository"/>
+-        <xs:group ref="mathml:content-url"/>
+-        <xs:group ref="mathml:title_2"/>
+-        <xs:group ref="mathml:short-title"/>
+-        <xs:group ref="mathml:subtitle"/>
+-        <xs:group ref="mathml:version"/>
+-        <xs:group ref="mathml:created"/>
+-        <xs:group ref="mathml:revised"/>
+-        <xs:group ref="mathml:actors"/>
+-        <xs:group ref="mathml:roles"/>
+-        <xs:group ref="mathml:license"/>
+-        <xs:group ref="mathml:extended-attribution"/>
+-        <xs:group ref="mathml:derived-from"/>
+-        <xs:group ref="mathml:keywordlist"/>
+-        <xs:group ref="mathml:subjectlist"/>
+-        <xs:group ref="mathml:education-levellist"/>
+-        <xs:group ref="mathml:abstract"/>
+-        <xs:group ref="mathml:objectives"/>
+-        <xs:group ref="mathml:homepage"/>
+-        <xs:group ref="mathml:institution"/>
+-        <xs:group ref="mathml:course-code"/>
+-        <xs:group ref="mathml:instructor"/>
+-        <xs:group ref="mathml:uuid"/>
+-        <xs:group ref="mathml:canonical-book-uuid"/>
+-        <xs:group ref="mathml:slug"/>
+-        <xs:element ref="mdml:ancillary"/>
+-        <xs:element ref="mdml:version-history"/>
+-        <xs:group ref="mathml:language"/>
+-      </xs:choice>
++      <xs:all>
++        <xs:element ref="mdml:content-id"/>
++        <xs:element ref="mdml:title"/>
++        <xs:element ref="mdml:license"/>
++        <xs:element ref="mdml:uuid"/>
++        <xs:element ref="mdml:slug"/>
++        <xs:element ref="mdml:language"/>
++      </xs:all>
+       <xs:attribute ref="xml:lang"/>
+       <xs:attribute name="class" type="xs:token"/>
+       <xs:attribute ref="s:read-only"/>
+diff --git a/client/static/xsd/mdml.xsd b/client/static/xsd/mdml.xsd
+index ad83744..0824ea8 100644
+--- a/client/static/xsd/mdml.xsd
++++ b/client/static/xsd/mdml.xsd
+@@ -11,6 +11,16 @@
+   <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+   <xs:import namespace="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" schemaLocation="ns1.xsd"/>
++  <xs:element name="content-id" type="xs:string"/>
++  <xs:element name="title" type="xs:string"/>
++  <xs:element name="language" type="xs:string"/>
++  <xs:element name="uuid" type="xs:string"/>
++  <xs:element name="slug" type="xs:string"/>
++  <xs:element name="license">
++    <xs:complexType mixed="true">
++      <xs:attribute name="url" use="required"/>
++    </xs:complexType>
++  </xs:element>
+   <xs:group name="content-id">
+     <xs:sequence>
+       <xs:element name="content-id">

--- a/client/static/xsd/xlink.xsd
+++ b/client/static/xsd/xlink.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/1999/xlink" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/1999/xlink" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>

--- a/client/static/xsd/xml.xsd
+++ b/client/static/xsd/xml.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" xmlns:collxml="http://cnx.rice.edu/collxml" xmlns:s="http://cnx.rice.edu/system-info" xmlns:cnxml="http://cnx.rice.edu/cnxml" xmlns:ns1="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" xmlns:ns2="http://bibtexml.sf.net/" xmlns:mathml="http://www.w3.org/1998/Math/MathML" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mdml="http://cnx.rice.edu/mdml">
   <xs:import namespace="http://bibtexml.sf.net/" schemaLocation="ns2.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/cnxml" schemaLocation="cnxml.xsd"/>
+  <xs:import namespace="http://cnx.rice.edu/collxml" schemaLocation="collxml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/mdml" schemaLocation="mdml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/qml/1.0" schemaLocation="qml.xsd"/>
   <xs:import namespace="http://cnx.rice.edu/system-info" schemaLocation="s.xsd"/>

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -88,7 +88,10 @@ const viewConfig = {
     // @ts-ignore
     new CopyWebpackPlugin({
       patterns: [{
-        from: 'static'
+        from: 'static',
+        globOptions: {
+          ignore: ["**/*.patch"]
+        }
       }]
     })
   ]


### PR DESCRIPTION
This commit includes:

- An update to the catalog.xml to add the collxml namespace
- Regenerated XSD files based on a shared RelaxNG start for cnxml
  and collxml
- A patch file with manual changes to XSD files generated by trang