### PR TITLE
Fix issues related to running client tests in local environments

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,7 @@
     "name": "Run Extension <gitpod>. Make sure .vscode-test/ exists by running the client tests. Open port 6080 to see the app inside vnc",
     "type": "node",
     "request": "launch",
-    "runtimeExecutable": "${workspaceFolder}/.vscode-test/vscode-linux-x64-1.54.1/VSCode-linux-x64/code",
+    "runtimeExecutable": "${workspaceFolder}/.vscode-test/vscode-linux-x64-1.56.2/VSCode-linux-x64/code",
     "args": [
       "${workspaceFolder}/out/test/data/test-repo",
       "--no-sandbox",

--- a/client/src/test/runTest.ts
+++ b/client/src/test/runTest.ts
@@ -4,7 +4,7 @@ import { runTests } from 'vscode-test'
 
 async function main(): Promise<void> {
   try {
-    const version = '1.54.1' // Update this in .vscode/launch.json too when it changes
+    const version = '1.56.2' // Update this in .vscode/launch.json too when it changes
 
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -210,7 +210,7 @@ suite('Extension Test Suite', function (this: Suite) {
       html,
       (panel) => {
         const modified = addBaseHref(panel.webview, resource, html)
-        assert(modified.includes('vscode-webview-resource'))
+        assert(modified.includes('vscode-webview'))
       }
     )
   })
@@ -220,7 +220,7 @@ suite('Extension Test Suite', function (this: Suite) {
       html,
       (panel) => {
         const modified = fixResourceReferences(panel.webview, html, TEST_DATA_DIR)
-        assert(modified.includes('vscode-webview-resource'))
+        assert(modified.includes('vscode-webview'))
       }
     )
   })
@@ -241,7 +241,7 @@ suite('Extension Test Suite', function (this: Suite) {
       html,
       (panel) => {
         const modified = fixCspSourceReferences(panel.webview, html)
-        assert(modified.includes('vscode-webview-resource'))
+        assert(modified.includes('vscode-webview'))
       }
     )
   })

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -475,6 +475,7 @@ suite('Extension Test Suite', function (this: Suite) {
   test('cnxml preview rebinds to resource in the active editor', async () => {
     const uri = expect(getRootPathUri())
     const panel = new CnxmlPreviewPanel({ resourceRootDir, client: createMockClient(), events: createMockEvents().events })
+    await sleep(100) // FIXME: Make me go away (see https://github.com/openstax/cnx/issues/1569)
     assert.strictEqual((panel as any).resourceBinding, null)
 
     const resourceFirst = uri.with({ path: path.join(uri.path, 'modules', 'm00001', 'index.cnxml') })
@@ -517,6 +518,7 @@ suite('Extension Test Suite', function (this: Suite) {
   test('cnxml preview only rebinds to cnxml', async () => {
     const uri = expect(getRootPathUri())
     const panel = new CnxmlPreviewPanel({ resourceRootDir, client: createMockClient(), events: createMockEvents().events })
+    await sleep(100) // FIXME: Make me go away (see https://github.com/openstax/cnx/issues/1569)
 
     const resourceFirst = uri.with({ path: path.join(uri.path, 'modules', 'm00001', 'index.cnxml') })
     const resourceBindingChangedExpectedFirst: Promise<vscode.Uri | null> = new Promise((resolve, reject) => {
@@ -719,6 +721,7 @@ suite('Extension Test Suite', function (this: Suite) {
     const watchedFilesSpy = sinon.spy(mockEvents.events, 'onDidChangeWatchedFiles')
     const resource = uri.with({ path: path.join(uri.path, 'modules', 'm00001', 'index.cnxml') })
     const panel = new CnxmlPreviewPanel({ resourceRootDir, client: createMockClient(), events: mockEvents.events })
+    await sleep(100) // FIXME: Make me go away (see https://github.com/openstax/cnx/issues/1569)
     const rebindingStub = sinon.spy(panel as any, 'rebindToResource')
     const panelBindingChanged = new Promise((resolve, reject) => {
       panel.onDidChangeResourceBinding((event) => {
@@ -747,6 +750,7 @@ suite('Extension Test Suite', function (this: Suite) {
   test('panel hidden and refocused', async () => {
     const command = OpenstaxCommand.SHOW_IMAGE_MANAGER
     await vscode.commands.executeCommand(command)
+    await sleep(100) // FIXME: Make me go away (see https://github.com/openstax/cnx/issues/1569)
     const panelManager = expect((await extensionExports)[command])
 
     // Hide panel by opening another tab

--- a/scripts/pretest.sh
+++ b/scripts/pretest.sh
@@ -7,10 +7,10 @@ test_repo_dest=./client/out/client/src/test/data/test-repo
 
 cp -r ./client/dist/* ./client/out/
 [[ -d "${test_repo_dest}" ]] || mkdir -p "${test_repo_dest}"
-cp -r ./collections/ "${test_repo_dest}"
-cp -r ./media/ "${test_repo_dest}"
-cp -r ./modules/ "${test_repo_dest}"
-cp -r ./.vscode/ "${test_repo_dest}"
+cp -r ./collections "${test_repo_dest}"
+cp -r ./media "${test_repo_dest}"
+cp -r ./modules "${test_repo_dest}"
+cp -r ./.vscode "${test_repo_dest}"
 
 macos_arg=''
 if [[ "$(uname)" == 'Darwin' ]]; then


### PR DESCRIPTION
This PR addresses a few failures that were observed when running client tests locally (though all pass on CI) due to the following factors:

* Running tests on macOS
* Running tests with a newer version of VSCode (relative to `1.54.1` which the CI [currently runs with](https://github.com/openstax/poet/blob/471c372711b1961a38e121720e00afc98071cb11/client/src/test/runTest.ts#L7))

It also goes ahead and updates the version of vscode used for tests to `1.56.2`. 