### PR TITLE
Add sourcemaps to server stacktraces

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -90,6 +90,14 @@
       "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
       "dev": true
     },
+    "@types/source-map-support": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.4.tgz",
+      "integrity": "sha512-9zGujX1sOPg32XLyfgEB/0G9ZnrjthL/Iv1ZfuAjj8LEilHZEpQSQs1scpRXPhHzGYgWiLz9ldF1cI8JhL+yMw==",
+      "requires": {
+        "source-map": "^0.6.0"
+      }
+    },
     "@types/uuid": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -180,6 +180,11 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
     "camelcase": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
@@ -728,6 +733,20 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "string-width": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "server",
   "dependencies": {
+    "@types/source-map-support": "^0.5.4",
     "glob": "^7.1.6",
     "memoize-one": "^5.1.1",
     "source-map-support": "^0.5.19",

--- a/server/package.json
+++ b/server/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "glob": "^7.1.6",
     "memoize-one": "^5.1.1",
+    "source-map-support": "^0.5.19",
     "uuid": "^8.3.2",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,3 +1,5 @@
+require('source-map-support').install()
+
 import {
   createConnection,
   TextDocuments,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,3 @@
-require('source-map-support').install()
-
 import {
   createConnection,
   TextDocuments,
@@ -36,6 +34,9 @@ import {
 
 import { BookBundle } from './book-bundle'
 import { BundleValidationQueue } from './bundle-validation'
+
+import * as sourcemaps from 'source-map-support'
+sourcemaps.install()
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.


### PR DESCRIPTION
When the language server errors, the stacktrace points to the minified webpack bundle which makes it difficult to find what caused the error. This adds sourcemap support to the server.

![image](https://user-images.githubusercontent.com/253202/125127640-6bb17000-e0c2-11eb-8f9f-355280402c90.png)
