### PR TITLE
:art: Use icons in the ToC

### DIFF
--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -29,7 +29,7 @@ import { Substitute } from '@fluffy-spoon/substitute'
 import { LanguageClient } from 'vscode-languageclient/node'
 import { ExtensionServerRequest } from '../../../../common/src/requests'
 import { Disposer, ExtensionEvents, ExtensionHostContext, Panel } from '../../panel'
-import { TocTreesProvider, TocTreeItem, toggleTocTreesFilteringHandler } from './../../toc-trees'
+import { TocTreesProvider, TocTreeItem, toggleTocTreesFilteringHandler, TocItemIcon } from './../../toc-trees'
 import * as utils from './../../utils' // Used for dependency mocking in tests
 
 const ROOT_DIR_REL = '../../../../../../'
@@ -970,6 +970,7 @@ suite('Extension Test Suite', function (this: Suite) {
     const fakeWorkspacePath = '/tmp/fakeworkspace'
     sinon.stub(utils, 'getRootPathUri').returns(vscode.Uri.file(fakeWorkspacePath))
     const module1Item = new TocTreeItem(
+      TocItemIcon.Page,
       'Module1',
       vscode.TreeItemCollapsibleState.None,
       [],
@@ -981,6 +982,7 @@ suite('Extension Test Suite', function (this: Suite) {
       'm00001'
     )
     const module2Item = new TocTreeItem(
+      TocItemIcon.Page,
       'Module2',
       vscode.TreeItemCollapsibleState.None,
       [],
@@ -992,6 +994,7 @@ suite('Extension Test Suite', function (this: Suite) {
       'm00002'
     )
     const module3Item = new TocTreeItem(
+      TocItemIcon.Page,
       'Module3',
       vscode.TreeItemCollapsibleState.None,
       [],
@@ -1003,6 +1006,7 @@ suite('Extension Test Suite', function (this: Suite) {
       'm00003'
     )
     const module3ItemToggled = new TocTreeItem(
+      TocItemIcon.Page,
       'Module3 (m00003)',
       vscode.TreeItemCollapsibleState.None,
       [],
@@ -1014,11 +1018,13 @@ suite('Extension Test Suite', function (this: Suite) {
       undefined
     )
     const subcollectionItem = new TocTreeItem(
+      TocItemIcon.SubBook,
       'subcollection',
       vscode.TreeItemCollapsibleState.Collapsed,
       [module1Item, module2Item]
     )
     const collection1Item = new TocTreeItem(
+      TocItemIcon.Book,
       'Collection1',
       vscode.TreeItemCollapsibleState.Collapsed,
       [subcollectionItem],
@@ -1029,6 +1035,7 @@ suite('Extension Test Suite', function (this: Suite) {
       }
     )
     const collection2Item = new TocTreeItem(
+      TocItemIcon.Book,
       'Collection2',
       vscode.TreeItemCollapsibleState.Collapsed,
       [module3Item],

--- a/client/src/toc-trees.ts
+++ b/client/src/toc-trees.ts
@@ -1,8 +1,14 @@
-import vscode from 'vscode'
+import vscode, { ThemeIcon } from 'vscode'
 import { getRootPathUri, expect, constructCollectionUri, constructModuleUri } from './utils'
 import { BundleTreesResponse, requestBundleTrees } from '../../common/src/requests'
 import { TocTreeCollection, TocTreeElementType, TocTreeModule } from '../../common/src/toc-tree'
 import { ExtensionHostContext } from './panel'
+
+export const TocItemIcon = {
+  Page: ThemeIcon.File,
+  Book: new ThemeIcon('book'),
+  SubBook: ThemeIcon.Folder
+}
 
 export class TocTreesProvider implements vscode.TreeDataProvider<TocTreeItem> {
   private readonly _onDidChangeTreeData: vscode.EventEmitter<TocTreeItem | undefined> = new vscode.EventEmitter<TocTreeItem | undefined>()
@@ -25,6 +31,7 @@ export class TocTreesProvider implements vscode.TreeDataProvider<TocTreeItem> {
   getTreeItem(element: TocTreeItem): TocTreeItem {
     if (this.isFilterMode && (element.description != null)) {
       return new TocTreeItem(
+        element.iconPath,
         `${element.label} (${element.description})`,
         element.collapsibleState,
         element.children,
@@ -65,6 +72,7 @@ export class TocTreeItem extends vscode.TreeItem {
   parent: TocTreeItem | undefined = undefined
 
   constructor(
+    public readonly iconPath: ThemeIcon,
     public readonly label: string,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
     public readonly children: TocTreeItem[],
@@ -88,10 +96,11 @@ export class TocTreeItem extends vscode.TreeItem {
     })
 
     if ((treeCollection.type === TocTreeElementType.subcollection) || (treeCollection.slug == null)) {
-      return new TocTreeItem(treeCollection.title, collapsibleState, children)
+      return new TocTreeItem(TocItemIcon.SubBook, treeCollection.title, collapsibleState, children)
     }
 
     return new TocTreeItem(
+      TocItemIcon.Book,
       treeCollection.title,
       collapsibleState,
       children,
@@ -101,6 +110,7 @@ export class TocTreeItem extends vscode.TreeItem {
 
   static fromModule(treeModule: TocTreeModule, workspaceUri: vscode.Uri): TocTreeItem {
     return new TocTreeItem(
+      TocItemIcon.Page,
       treeModule.title,
       vscode.TreeItemCollapsibleState.None,
       [],


### PR DESCRIPTION
Small tweak to put book & page icons in the ToC to clarify what is a Book and what is a Page

![image](https://user-images.githubusercontent.com/253202/131360424-7a8194a7-1f60-4082-9652-2affcde6d0b9.png)
