### PR TITLE
Fix Langauge Server errors that arise during testing

### DIFF
--- a/client/src/push-content.ts
+++ b/client/src/push-content.ts
@@ -2,16 +2,11 @@ import vscode from 'vscode'
 import { expect, getErrorDiagnosticsBySource, getRootPathUri } from './utils'
 import { GitExtension, GitErrorCodes, CommitOptions, Repository, RefType, Ref } from './git-api/git'
 import { ExtensionHostContext } from './panel'
-import { requestEnsureIds } from '../../common/src/requests'
+import { DiagnosticSource, requestEnsureIds } from '../../common/src/requests'
 
 export enum Tag {
   release = 'Release',
   candidate = 'Release Candidate'
-}
-
-export enum DiagnosticSource {
-  xml = 'xml',
-  cnxml = 'cnxml'
 }
 
 export const PushValidationModal = {

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -27,7 +27,7 @@ import { DOMParser, XMLSerializer } from 'xmldom'
 import * as xpath from 'xpath-ts'
 import { Substitute } from '@fluffy-spoon/substitute'
 import { LanguageClient } from 'vscode-languageclient/node'
-import { ExtensionServerRequest } from '../../../../common/src/requests'
+import { DiagnosticSource, ExtensionServerRequest } from '../../../../common/src/requests'
 import { Disposer, ExtensionEvents, ExtensionHostContext, Panel } from '../../panel'
 import { TocTreesProvider, TocTreeItem, toggleTocTreesFilteringHandler, TocItemIcon } from './../../toc-trees'
 import * as utils from './../../utils' // Used for dependency mocking in tests
@@ -886,11 +886,11 @@ suite('Extension Test Suite', function (this: Suite) {
     const fileUri = { path: '/test.cnxml', scheme: 'file' } as any as vscode.Uri
     const cnxmlError = {
       severity: vscode.DiagnosticSeverity.Error,
-      source: pushContent.DiagnosticSource.cnxml
+      source: DiagnosticSource.cnxml
     } as any as vscode.Diagnostic
     const xmlError = {
       severity: vscode.DiagnosticSeverity.Error,
-      source: pushContent.DiagnosticSource.xml
+      source: DiagnosticSource.xml
     } as any as vscode.Diagnostic
     const errorsBySource = new Map<string, Array<[vscode.Uri, vscode.Diagnostic]>>()
     const showErrorMsgStub = sinon.stub(vscode.window, 'showErrorMessage')
@@ -899,15 +899,15 @@ suite('Extension Test Suite', function (this: Suite) {
     assert(await pushContent.canPush(errorsBySource))
 
     // CNXML errors
-    errorsBySource.set(pushContent.DiagnosticSource.cnxml, [[fileUri, cnxmlError]])
+    errorsBySource.set(DiagnosticSource.cnxml, [[fileUri, cnxmlError]])
     assert(!(await pushContent.canPush(errorsBySource)))
     assert(showErrorMsgStub.calledOnceWith(pushContent.PushValidationModal.cnxmlErrorMsg, { modal: true }))
 
     // Both CNXML and XML errors
     errorsBySource.clear()
     showErrorMsgStub.reset()
-    errorsBySource.set(pushContent.DiagnosticSource.cnxml, [[fileUri, cnxmlError]])
-    errorsBySource.set(pushContent.DiagnosticSource.xml, [[fileUri, xmlError]])
+    errorsBySource.set(DiagnosticSource.cnxml, [[fileUri, cnxmlError]])
+    errorsBySource.set(DiagnosticSource.xml, [[fileUri, xmlError]])
     assert(!(await pushContent.canPush(errorsBySource)))
     assert(showErrorMsgStub.calledOnceWith(pushContent.PushValidationModal.cnxmlErrorMsg, { modal: true }))
 
@@ -915,7 +915,7 @@ suite('Extension Test Suite', function (this: Suite) {
     errorsBySource.clear()
     showErrorMsgStub.reset()
     showErrorMsgStub.returns(Promise.resolve(undefined))
-    errorsBySource.set(pushContent.DiagnosticSource.xml, [[fileUri, xmlError]])
+    errorsBySource.set(DiagnosticSource.xml, [[fileUri, xmlError]])
     assert(!(await pushContent.canPush(errorsBySource)))
     assert(showErrorMsgStub.calledOnceWith(pushContent.PushValidationModal.xmlErrorMsg, { modal: true }))
 
@@ -923,7 +923,7 @@ suite('Extension Test Suite', function (this: Suite) {
     errorsBySource.clear()
     showErrorMsgStub.reset()
     showErrorMsgStub.returns(Promise.resolve(pushContent.PushValidationModal.xmlErrorIgnoreItem as any as vscode.MessageItem))
-    errorsBySource.set(pushContent.DiagnosticSource.xml, [[fileUri, xmlError]])
+    errorsBySource.set(DiagnosticSource.xml, [[fileUri, xmlError]])
     assert(await pushContent.canPush(errorsBySource))
     assert(showErrorMsgStub.calledOnceWith(pushContent.PushValidationModal.xmlErrorMsg, { modal: true }))
   })

--- a/common/src/requests.ts
+++ b/common/src/requests.ts
@@ -1,5 +1,10 @@
 import { TocTreeModule, TocTreeCollection } from './toc-tree'
 
+export enum DiagnosticSource {
+  xml = 'xml',
+  cnxml = 'cnxml'
+}
+
 // Mock out the basic need of the LanguageClient for common,
 // since we can't import the client lib.
 interface LanguageClient {

--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -12,6 +12,7 @@ import { Job, JobRunner } from './job-runner'
 import { PageInfo, pageMaker } from './model/page.spec'
 
 import { PageNode } from './model/page'
+import { DiagnosticSource } from '../../common/src/requests'
 
 ModelManager.debug = () => {} // Turn off logging
 JobRunner.debug = () => {} // Turn off logging
@@ -130,6 +131,12 @@ describe('Bundle Manager', () => {
     expect(diagnosticsObj.uri).toBeTruthy()
     expect(diagnosticsObj.diagnostics).toBeTruthy()
     expect(() => JSON.stringify(diagnosticsObj)).not.toThrow()
+  })
+  it('populates the Diagnostics.source field so that pushContent can filter on it', () => {
+    loadSuccess(manager.bundle)
+    manager.updateFileContents(manager.bundle.absPath, 'I am not XML so a Parse Error should be sent to diagnostics')
+    expect(sendDiagnosticsStub.callCount).toBe(1)
+    expect(sendDiagnosticsStub.firstCall.args[0].diagnostics[0].source).toBe(DiagnosticSource.cnxml)
   })
 })
 

--- a/server/src/model-manager.ts
+++ b/server/src/model-manager.ts
@@ -5,6 +5,7 @@ import I from 'immutable'
 import { Connection } from 'vscode-languageserver'
 import { CompletionItem, CompletionItemKind, Diagnostic, DiagnosticSeverity, DocumentLink, FileChangeType, FileEvent, TextEdit } from 'vscode-languageserver-protocol'
 import { URI } from 'vscode-uri'
+import { DiagnosticSource } from '../../common/src/requests'
 import { TocTreeModule, TocTreeCollection, TocTreeElement, TocTreeElementType } from '../../common/src/toc-tree'
 import { Opt, expectValue, Position, inRange, Range } from './model/utils'
 import { BookNode, TocNode, TocNodeKind } from './model/book'
@@ -241,7 +242,7 @@ export class ModelManager {
     if (nodesToLoad.isEmpty()) {
       const uri = node.absPath
       const diagnostics = errors.toSet().map(err => {
-        return Diagnostic.create(err.range, err.message, DiagnosticSeverity.Error)
+        return Diagnostic.create(err.range, err.message, DiagnosticSeverity.Error, undefined, DiagnosticSource.cnxml)
       }).toArray()
       this.conn.sendDiagnostics({
         uri,

--- a/server/src/server-handler.ts
+++ b/server/src/server-handler.ts
@@ -20,7 +20,7 @@ export function bundleEnsureIdsHandler(): (request: BundleEnsureIdsArgs) => Prom
   return async (request: BundleEnsureIdsArgs) => {
     const manager = bundleFactory.getOrAdd(request.workspaceUri)
     // TODO: fix modules in parallel. Problem: Could be a memory hog.
-    const pages = manager.bundle.allPages.all
+    const pages = manager.bundle.allPages.all.filter(p => p.exists && p.isLoaded)
     await Promise.all(pages.map(async p => await fixModule(p)))
   }
 }


### PR DESCRIPTION
- run fix-document-ids only on files that actually exist
- send `Diagnostics.source = 'cnxml'` so pushContent can prevent users from pushing errors
