### PR TITLE
upgrade codecov action to v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           xvfb-run -a npm run test
       - name: Upload Code Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           gcov_path_exclude: client/src/test/**/*
       - name: Build Extension


### PR DESCRIPTION
Codecov is not reporting when commits are pushed so I thought this might be why (looks like it's not the reason).

Also, codecov has deprecated v1 of their action: https://github.com/marketplace/actions/codecov