### PR TITLE
:bug: bundle was incorrectly set as removed when another file was actually removed

### DIFF
--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -294,7 +294,9 @@ describe('processFilesystemChange()', () => {
     // Delete non-existent file
     expect((await fireChange(FileChangeType.Deleted, 'media/newpic.png')).size).toBe(0)
     // Delete a file
-    expect((await fireChange(FileChangeType.Deleted, 'modules/m1234/index.cnxml')).size).toBe(1)
+    const deletedModules = await fireChange(FileChangeType.Deleted, 'modules/m1234/index.cnxml')
+    expect(deletedModules.size).toBe(1)
+    expect(first(deletedModules)).toBeInstanceOf(PageNode)
     // Delete a directory
     expect((await fireChange(FileChangeType.Deleted, 'collections')).size).toBe(1)
     expect(sendDiagnosticsStub.callCount).toBe(0)

--- a/server/src/model-manager.ts
+++ b/server/src/model-manager.ts
@@ -193,7 +193,7 @@ export class ModelManager {
         const removedNode = bundle.allBooks.remove(uri) ??
                   bundle.allPages.remove(uri) ??
                   bundle.allImages.remove(uri)
-        if (removedNode !== undefined) s.add(bundle)
+        if (removedNode !== undefined) s.add(removedNode)
         // Remove if it was a directory
         const filePathDir = `${uri}${PATH_SEP}`
         s.union(bundle.allBooks.removeByKeyPrefix(filePathDir))


### PR DESCRIPTION
This was causing the ToC to disappear whenever the user deleted a file (because the Bundle was unloaded instead of the deleted file)