### PR TITLE
:100: coverage again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,6 @@ jobs:
           xvfb-run -a npm run test
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v2
-        with:
-          gcov_path_exclude: client/src/test/**/*
       - name: Build Extension
         run: |
           case "$GITHUB_EVENT_NAME" in

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pretest": "npm run clean && npm run build",
     "test:only": "npm run test:server && npm run test:client && npm run test:cypress",
     "test": "npm run test:only",
-    "posttest": "nyc report",
+    "posttest": "[ -f ./server/coverage/coverage-final.json ] && mv ./server/coverage/coverage-final.json .nyc_output/coverage-server.json; nyc merge ./.nyc_output/ ./.nyc_output/coverage-final.json && nyc report --reporter=lcov --reporter=text --reporter=html",
     "postinstall": "cd ./client/ && npm install && cd ../server/ && npm install"
   },
   "nyc": {

--- a/scripts/pretest.sh
+++ b/scripts/pretest.sh
@@ -18,7 +18,14 @@ if [[ "$(uname)" == 'Darwin' ]]; then
 fi
 
 echo '==> Instrument the client source files'
-$(npm bin)/nyc instrument --exclude 'client/out/client/src/test/**/*' --compact=false --source-map --in-place ./client/out/ ./client/out/
+$(npm bin)/nyc instrument \
+    --exclude 'client/out/client/src/test/**/*' \
+    --exclude-node-modules \
+    --compact=false \
+    --source-map \
+    --in-place \
+    ./client/out/ \
+    ./client/out/
 
 echo '==> Edit the Cypress HTML files to load javascript'
 find ./client/out/ -name *.html -exec sed -i ${macos_arg} -E "s/(script-src.+)[;]/\1 'unsafe-eval';/g" {} \;


### PR DESCRIPTION
It dropped because #105 sent coverage data for code that originated in npm packages. See [this codecov entry](https://codecov.io/gh/openstax/poet/tree/93809bfaccd156055a8c7fbe6d3d52c55a11cd0e/client)