### PR TITLE
:bug: fix Page/Subbook creation messages

### DIFF
--- a/client/src/webview-js/toc-editor/toc-editor.jsx
+++ b/client/src/webview-js/toc-editor/toc-editor.jsx
@@ -284,11 +284,11 @@ const EditorPanel = (props) => {
   }
 
   const handleAddPage = (event) => {
-    vscode.postMessage({ type: 'PAGE_CREATE', bookIndex: props.selectionIndex })
+    vscode.postMessage({ type: TocNodeKind.Page, bookIndex: props.selectionIndex })
   }
 
   const handleAddSubbook = (event) => {
-    vscode.postMessage({ type: 'SUBBOOK_CREATE', slug: selectedTree.slug, bookIndex: props.selectionIndex })
+    vscode.postMessage({ type: TocNodeKind.Subbook, slug: selectedTree.slug, bookIndex: props.selectionIndex })
   }
 
   const handleSelect = (event) => {

--- a/cypress/integration/toc-editor-spec.ts
+++ b/cypress/integration/toc-editor-spec.ts
@@ -266,7 +266,7 @@ import { TocNodeKind } from '../../common/src/toc'
           .click()
         cy.then(() => {
           expect(messagesFromWidget).to.have.length(1)
-          expect(messagesFromWidget[0].type).to.equal('PAGE_CREATE')
+          expect(messagesFromWidget[0].type).to.equal(TocNodeKind.Page)
         })
         cy.wrap(messagesFromWidget).snapshot()
       })
@@ -279,8 +279,8 @@ import { TocNodeKind } from '../../common/src/toc'
           .click()
         cy.then(() => {
           expect(messagesFromWidget).to.have.length(2)
-          expect(messagesFromWidget[0].type).to.equal('SUBBOOK_CREATE')
-          expect(messagesFromWidget[1].type).to.equal('SUBBOOK_CREATE')
+          expect(messagesFromWidget[0].type).to.equal(TocNodeKind.Subbook)
+          expect(messagesFromWidget[1].type).to.equal(TocNodeKind.Subbook)
         })
         cy.wrap(messagesFromWidget).snapshot()
       })

--- a/snapshots.js
+++ b/snapshots.js
@@ -116,7 +116,7 @@ module.exports = {
       "can tell the extension to create Page": {
         "1": [
           {
-            "type": "PAGE_CREATE",
+            "type": "TocNodeKind.Page",
             "bookIndex": 0
           }
         ]
@@ -124,12 +124,12 @@ module.exports = {
       "can tell the extension to create Subbook": {
         "1": [
           {
-            "type": "SUBBOOK_CREATE",
+            "type": "TocNodeKind.Subbook",
             "slug": "test",
             "bookIndex": 0
           },
           {
-            "type": "SUBBOOK_CREATE",
+            "type": "TocNodeKind.Subbook",
             "slug": "test-2",
             "bookIndex": 0
           }


### PR DESCRIPTION
The Tree editor Webview component and the extension client expected different type strings so the "Create Page" and "Create Subbook" messages from Webview were being dropped