### PR TITLE
bug: fix "Duplicate UUID" error when a new Page/Module is added

### DIFF
--- a/server/src/model-manager.ts
+++ b/server/src/model-manager.ts
@@ -187,7 +187,7 @@ export class ModelManager {
     // Add all the orphaned Images/Pages/Books dangling around in the filesystem without loading them
     const files = glob.sync('{modules/*/index.cnxml,media/*.*,collections/*.collection.xml}', { cwd: URI.parse(this.bundle.workspaceRootUri).fsPath, absolute: true })
     Quarx.batch(() => {
-      files.forEach(absPath => expectValue(findOrCreateNode(this.bundle, URI.parse(absPath).toString()), `BUG? We found files that the bundle did not recognize: ${absPath}`))
+      files.forEach(absPath => expectValue(findOrCreateNode(this.bundle, this.bundle.pathHelper.canonicalize(absPath)), `BUG? We found files that the bundle did not recognize: ${absPath}`))
     })
     // Load everything before we can know where the orphans are
     this.performInitialValidation()
@@ -497,7 +497,7 @@ export class ModelManager {
         continue
       }
       const pageUri = Utils.joinPath(pageDirUri, newModuleId, 'index.cnxml')
-      const page = this.bundle.allPages.getOrAdd(pageUri.fsPath)
+      const page = this.bundle.allPages.getOrAdd(pageUri.fsPath) // fsPath works for tests and gets converted to file:// for real
 
       const doc = new DOMParser().parseFromString(template(), 'text/xml')
       selectOne('/cnxml:document/cnxml:title', doc).textContent = title

--- a/server/src/model/_cli.ts
+++ b/server/src/model/_cli.ts
@@ -31,7 +31,8 @@ function loadNode(n: Fileish) {
 
 const pathHelper: PathHelper<string> = {
   join: path.join,
-  dirname: path.dirname
+  dirname: path.dirname,
+  canonicalize: (x) => x
 }
 
 ;(async function () {

--- a/server/src/model/book.ts
+++ b/server/src/model/book.ts
@@ -60,7 +60,7 @@ export class BookNode extends Fileish {
         }
         case 'module': {
           const pageId = expectValue(selectOne('@document', childNode).nodeValue, 'BUG: missing @document on col:module')
-          const page = super.bundle.allPages.getOrAdd(join(this._pathHelper, PathKind.COLLECTION_TO_MODULEID, this.absPath, pageId))
+          const page = super.bundle.allPages.getOrAdd(join(this.pathHelper, PathKind.COLLECTION_TO_MODULEID, this.absPath, pageId))
           return {
             type: TocNodeKind.Page,
             page,

--- a/server/src/model/bundle.ts
+++ b/server/src/model/bundle.ts
@@ -8,9 +8,9 @@ import { Fileish, ValidationCheck } from './fileish'
 import { ImageNode } from './image'
 
 export class Bundle extends Fileish implements Bundleish {
-  public readonly allImages: Factory<ImageNode> = new Factory((absPath: string) => new ImageNode(this, this._pathHelper, absPath))
-  public readonly allPages: Factory<PageNode> = new Factory((absPath: string) => new PageNode(this, this._pathHelper, absPath))
-  public readonly allBooks = new Factory((absPath: string) => new BookNode(this, this._pathHelper, absPath))
+  public readonly allImages: Factory<ImageNode> = new Factory((absPath: string) => new ImageNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
+  public readonly allPages: Factory<PageNode> = new Factory((absPath: string) => new PageNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
+  public readonly allBooks = new Factory((absPath: string) => new BookNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
   private readonly _books = Quarx.observable.box<Opt<I.Set<WithRange<BookNode>>>>(undefined)
 
   constructor(pathHelper: PathHelper<string>, public readonly workspaceRootUri: string) {
@@ -23,7 +23,7 @@ export class Bundle extends Fileish implements Bundleish {
     this._books.set(I.Set(bookNodes.map(b => {
       const range = calculateElementPositions(b)
       const href = expectValue(b.getAttribute('href'), 'ERROR: Missing @href attribute on book element')
-      const book = this.allBooks.getOrAdd(join(this._pathHelper, PathKind.ABS_TO_REL, this.absPath, href))
+      const book = this.allBooks.getOrAdd(join(this.pathHelper, PathKind.ABS_TO_REL, this.absPath, href))
       return {
         v: book,
         range

--- a/server/src/model/factory.spec.ts
+++ b/server/src/model/factory.spec.ts
@@ -4,7 +4,7 @@ import { Factory } from './factory'
 describe('Factory', () => {
   it('instantiates a new object when the key does not exist', () => {
     let counter = 0
-    const f = new Factory(() => ({ thing: counter++ }))
+    const f = new Factory(() => ({ thing: counter++ }), (x) => x)
     expect(f.get('key1')).toBeUndefined()
     expect(f.getOrAdd('key1').thing).toEqual(0)
     expect(f.get('key1')).not.toBeUndefined()
@@ -15,7 +15,7 @@ describe('Factory', () => {
     expect(f.get('key2')).not.toBeUndefined()
   })
   it('removesByKeyPrefix works', () => {
-    const f = new Factory((x) => ({ foo: x, bar: 'dummy-object' }))
+    const f = new Factory((x) => ({ foo: x, bar: 'dummy-object' }), (x) => x)
     f.getOrAdd('keyPrefix1')
     f.getOrAdd('keyPrefix2')
     f.getOrAdd('anotherprefix')

--- a/server/src/model/factory.ts
+++ b/server/src/model/factory.ts
@@ -3,13 +3,14 @@ import I from 'immutable'
 import { Opt } from './utils'
 export class Factory<T> {
   private readonly _map = Quarx.observable.box(I.Map<string, T>())
-  constructor(private readonly builder: (filePath: string) => T) { }
+  constructor(private readonly builder: (filePath: string) => T, private readonly canonicalizer: (filePath: string) => string) { }
   get(absPath: string): Opt<T> {
     const m = this._map.get()
     return m.get(absPath)
   }
 
   getOrAdd(absPath: string) {
+    absPath = this.canonicalizer(absPath)
     const m = this._map.get()
     const v = m.get(absPath)
     if (v !== undefined) {
@@ -22,6 +23,7 @@ export class Factory<T> {
   }
 
   public remove(absPath: string) {
+    absPath = this.canonicalizer(absPath)
     const m = this._map.get()
     const item = m.get(absPath)
     this._map.set(m.delete(absPath))
@@ -29,6 +31,7 @@ export class Factory<T> {
   }
 
   public removeByKeyPrefix(pathPrefix: string) {
+    pathPrefix = this.canonicalizer(pathPrefix)
     const m = this._map.get()
     const removedItems = m.filter((_, key) => key.startsWith(pathPrefix))
     this._map.set(m.filter((_, key) => !key.startsWith(pathPrefix)))

--- a/server/src/model/fileish.ts
+++ b/server/src/model/fileish.ts
@@ -43,9 +43,12 @@ export abstract class Fileish {
   private readonly _isLoaded = Quarx.observable.box(false)
   private readonly _exists = Quarx.observable.box(false)
   private readonly _parseError = Quarx.observable.box<Opt<ParseError>>(undefined)
+  public readonly absPath
   protected parseXML: Opt<(doc: Document) => void> // Subclasses define this
 
-  constructor(private _bundle: Opt<Bundleish>, protected _pathHelper: PathHelper<string>, public readonly absPath: string) { }
+  constructor(private _bundle: Opt<Bundleish>, public pathHelper: PathHelper<string>, absPath: string) {
+    this.absPath = this.pathHelper.canonicalize(absPath)
+  }
 
   static debug = (...args: any[]) => {} // console.debug
   protected abstract getValidationChecks(): ValidationCheck[]

--- a/server/src/model/page.ts
+++ b/server/src/model/page.ts
@@ -121,7 +121,7 @@ export class PageNode extends Fileish {
     const imageNodes = select('//cnxml:image/@src', doc) as Attr[]
     this._imageLinks.set(I.Set(imageNodes.map(attr => {
       const src = expectValue(attr.nodeValue, 'BUG: Attribute does not have a value')
-      const image = super.bundle.allImages.getOrAdd(join(this._pathHelper, PathKind.ABS_TO_REL, this.absPath, src))
+      const image = super.bundle.allImages.getOrAdd(join(this.pathHelper, PathKind.ABS_TO_REL, this.absPath, src))
       // Get the line/col position of the <image> tag
       const imageNode = expectValue(attr.ownerElement, 'BUG: attributes always have a parent element')
       const range = calculateElementPositions(imageNode)
@@ -139,7 +139,7 @@ export class PageNode extends Fileish {
       if (toUrl !== undefined) {
         return { range, type: PageLinkKind.URL, url: toUrl }
       }
-      const toPage = toDocument !== undefined ? super.bundle.allPages.getOrAdd(join(this._pathHelper, PathKind.MODULE_TO_MODULEID, this.absPath, toDocument)) : this
+      const toPage = toDocument !== undefined ? super.bundle.allPages.getOrAdd(join(this.pathHelper, PathKind.MODULE_TO_MODULEID, this.absPath, toDocument)) : this
       if (toTargetId !== undefined) {
         return {
           range,

--- a/server/src/model/util.spec.ts
+++ b/server/src/model/util.spec.ts
@@ -85,7 +85,8 @@ export const read = (filePath: string) => readFileSync(filePath, 'utf-8')
 
 export const FS_PATH_HELPER: PathHelper<string> = {
   join: path.join,
-  dirname: path.dirname
+  dirname: path.dirname,
+  canonicalize: (x) => x
 }
 
 export function first<T>(col: I.Set<T> | I.List<T>) {

--- a/server/src/model/utils.ts
+++ b/server/src/model/utils.ts
@@ -33,6 +33,7 @@ export interface Position {
 export interface PathHelper<T> {
   join: (root: T, ...components: string[]) => T
   dirname: (p: T) => T
+  canonicalize: (p: T) => T
 }
 
 export interface Range {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -39,14 +39,17 @@ function getBundleForUri(uri: string): ModelManager {
 
 const pathHelper = {
   join: (uri: string, ...relPaths: string[]) => Utils.joinPath(URI.parse(uri), ...relPaths).toString(),
-  dirname: (uri: string) => Utils.dirname(URI.parse(uri)).toString()
+  dirname: (uri: string) => Utils.dirname(URI.parse(uri)).toString(),
+  canonicalize: (uri: string) => {
+    return URI.parse(uri).toString()
+  }
 }
 
 export /* for server-handler.ts */ const bundleFactory = new Factory(workspaceUri => {
   const filePath = workspaceUri
   const b = new Bundle(pathHelper, filePath)
   return new ModelManager(b, connection)
-})
+}, (x) => pathHelper.canonicalize(x))
 
 const consoleDebug = (...args: any[]) => {
   console.debug(...args)
@@ -129,7 +132,6 @@ connection.onDidChangeWatchedFiles(({ changes }) => {
       const manager = getBundleForUri(change.uri)
       await manager.processFilesystemChange(change)
     }
-    await connection.sendRequest('onDidChangeWatchedFiles')
   }
   inner().catch(err => { throw err })
 })


### PR DESCRIPTION
The error isn't that the Page has a Duplicate UUID, it's that the absPath string is sometimes a `/path/to/file` and other times is `file:///path/to/file`

This PR makes it so that the path is always consistent