### PR TITLE
:bug: fix the webview state by asking for updated state

### DIFF
--- a/client/specs/__snapshots__/panel-toc-editor.spec.ts.snap
+++ b/client/specs/__snapshots__/panel-toc-editor.spec.ts.snap
@@ -3,55 +3,58 @@
 exports[`Toc Editor PanelTocEditor sends a message to Webview when the content is updated 1`] = `
 Array [
   Object {
-    "editable": Array [
-      Object {
-        "absPath": "/fake/path",
-        "language": "language",
-        "licenseUrl": "licenseUrl",
-        "slug": "slug",
-        "title": "title",
-        "tocTree": Array [
-          Object {
-            "children": Array [
-              Object {
-                "absPath": "/fake/path/to/file",
-                "fileId": "fileId",
-                "subtitle": "fileId",
-                "title": "title",
-                "token": "token",
-                "type": "TocNodeKind.Page",
-              },
-            ],
-            "title": "title",
-            "token": "token",
-            "type": "TocNodeKind.Subbook",
-          },
-        ],
-        "type": "BookRootNode.Singleton",
-        "uuid": "uuid",
-      },
-    ],
-    "uneditable": Array [
-      Object {
-        "slug": "mock-slug__source-only",
-        "title": "All Modules",
-        "tocTree": Array [
-          Object {
-            "absPath": "/fake/path/to/file",
-            "fileId": "fileId",
-            "subtitle": "fileId",
-            "title": "title",
-            "token": "token",
-            "type": "TocNodeKind.Page",
-          },
-        ],
-      },
-      Object {
-        "slug": "mock-slug__source-only",
-        "title": "Orphan Modules",
-        "tocTree": Array [],
-      },
-    ],
+    "state": Object {
+      "editable": Array [
+        Object {
+          "absPath": "/fake/path",
+          "language": "language",
+          "licenseUrl": "licenseUrl",
+          "slug": "slug",
+          "title": "title",
+          "tocTree": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "absPath": "/fake/path/to/file",
+                  "fileId": "fileId",
+                  "subtitle": "fileId",
+                  "title": "title",
+                  "token": "token",
+                  "type": "TocNodeKind.Page",
+                },
+              ],
+              "title": "title",
+              "token": "token",
+              "type": "TocNodeKind.Subbook",
+            },
+          ],
+          "type": "BookRootNode.Singleton",
+          "uuid": "uuid",
+        },
+      ],
+      "uneditable": Array [
+        Object {
+          "slug": "mock-slug__source-only",
+          "title": "All Modules",
+          "tocTree": Array [
+            Object {
+              "absPath": "/fake/path/to/file",
+              "fileId": "fileId",
+              "subtitle": "fileId",
+              "title": "title",
+              "token": "token",
+              "type": "TocNodeKind.Page",
+            },
+          ],
+        },
+        Object {
+          "slug": "mock-slug__source-only",
+          "title": "Orphan Modules",
+          "tocTree": Array [],
+        },
+      ],
+    },
+    "type": "PanelStateMessageType.Response",
   },
 ]
 `;

--- a/client/specs/panel-toc-editor.spec.ts
+++ b/client/specs/panel-toc-editor.spec.ts
@@ -6,11 +6,12 @@ import vscode, { Disposable, Event, EventEmitter, Uri, ViewColumn, WebviewPanel 
 import { BookRootNode, BookToc, TocNodeKind, TocModificationKind } from '../../common/src/toc'
 import * as utils from '../src/utils' // Used for dependency mocking in tests
 import { TocItemIcon, TocTreeItem, TocTreesProvider, toggleTocTreesFilteringHandler } from '../src/toc-trees-provider'
-import { PanelIncomingMessage, PanelOutgoingMessage, TocEditorPanel } from '../src/panel-toc-editor'
+import { PanelIncomingMessage, TocEditorPanel } from '../src/panel-toc-editor'
 import { LanguageClient } from 'vscode-languageclient/node'
 import { EMPTY_BOOKS_AND_ORPHANS, ExtensionServerRequest } from '../../common/src/requests'
 import { ExtensionEvents, ExtensionHostContext } from '../src/panel'
 import { BookOrTocNode, TocsTreeProvider } from '../src/book-tocs'
+import { PanelStateMessage, PanelStateMessageType } from '../../common/src/webview-constants'
 
 const TEST_OUT_DIR = join(__dirname, '../src')
 const resourceRootDir = TEST_OUT_DIR
@@ -335,8 +336,9 @@ describe('Toc Editor', () => {
       const v = { books: [testToc], orphans: [] }
       expect(postMessageStub.callCount).toBe(0)
       await p.update(v)
-      const message: PanelOutgoingMessage = postMessageStub.firstCall.args[0]
-      const allModules = message.uneditable[0]
+      const message: PanelStateMessage<any> = postMessageStub.firstCall.args[0]
+      expect(message.type).toBe(PanelStateMessageType.Response)
+      const allModules = message.state.uneditable[0]
       expect(allModules.tocTree.length).toBe(2)
       expect(allModules.tocTree[0].fileId).toBe('fileId1')
       expect(allModules.tocTree[1].fileId).toBe('fileId2')

--- a/client/specs/panel.spec.ts
+++ b/client/specs/panel.spec.ts
@@ -6,7 +6,7 @@ import { Disposable, WebviewPanel } from 'vscode'
 describe('panel', () => {
   const sinon = Sinon.createSandbox()
 
-  class TestPanel extends Panel<boolean, string> {
+  class TestPanel extends Panel<boolean, string, null> {
     public webviewPanel: WebviewPanel
     constructor() {
       super({
@@ -21,6 +21,8 @@ describe('panel', () => {
       } as unknown as WebviewPanel)
       this.webviewPanel = this.panel
     }
+
+    protected getState() { return null }
 
     async handleMessage(message: boolean) {}
   }

--- a/client/specs/utils.spec.ts
+++ b/client/specs/utils.spec.ts
@@ -85,17 +85,13 @@ describe('tests with sinon', () => {
     })
     it('injectEnsuredMessages no body is noop', () => {
       const html = '<html></html>'
-      expect(Panel.prototype.injectEnsuredMessages(html, [{ test: 'abc' }])).toBe(html)
+      expect(Panel.prototype.injectInitialState(html, { test: 'abc' })).toBe(html)
     })
     it('injectEnsuredMessages injects messages', () => {
       const html = '<html><body></body></html>'
-      const result = Panel.prototype.injectEnsuredMessages(html, [{ test: 'abc' }])
+      const result = Panel.prototype.injectInitialState(html, { test: 'abc' })
       expect(result.includes('script')).toBe(true)
-      expect(result.includes('[{"test":"abc"}]')).toBe(true)
-    })
-    it('injectEnsuredMessages zero length messages is noop', () => {
-      const html = '<html><body></body></html>'
-      expect(Panel.prototype.injectEnsuredMessages(html, [])).toBe(html)
+      expect(result.includes('{"test":"abc"}')).toBe(true)
     })
   })
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -30,7 +30,7 @@ export const forwardOnDidChangeWorkspaceFolders = (clientInner: LanguageClient) 
   await clientInner.sendRequest('onDidChangeWorkspaceFolders', event)
 }
 
-type ExtensionExports = { [key in OpenstaxCommand]: PanelManager<Panel<unknown, unknown>> }
+type ExtensionExports = { [key in OpenstaxCommand]: PanelManager<Panel<unknown, unknown, unknown>> }
 export async function activate(context: vscode.ExtensionContext): Promise<ExtensionExports> {
   // detect Theia. Alert the user if they are running Theia
   /* istanbul ignore next */

--- a/client/src/panel-image-manager.ts
+++ b/client/src/panel-image-manager.ts
@@ -33,10 +33,12 @@ const initPanel = (context: ExtensionHostContext): vscode.WebviewPanel => {
   return panel
 }
 
-export class ImageManagerPanel extends Panel<PanelIncomingMessage, void> {
+export class ImageManagerPanel extends Panel<PanelIncomingMessage, void, null> {
   constructor(private readonly context: ExtensionHostContext) {
     super(initPanel(context))
   }
+
+  protected getState() { return null }
 
   async handleMessage(message: PanelIncomingMessage): Promise<void> {
     const { mediaUploads } = message

--- a/client/src/panel-image-manager.ts
+++ b/client/src/panel-image-manager.ts
@@ -33,12 +33,13 @@ const initPanel = (context: ExtensionHostContext): vscode.WebviewPanel => {
   return panel
 }
 
-export class ImageManagerPanel extends Panel<PanelIncomingMessage, void, null> {
+export class ImageManagerPanel extends Panel<PanelIncomingMessage, void, void> {
   constructor(private readonly context: ExtensionHostContext) {
     super(initPanel(context))
   }
 
-  protected getState() { return null }
+  /* istanbul ignore next */
+  protected getState() { throw new Error('BUG: Not implemented') }
 
   async handleMessage(message: PanelIncomingMessage): Promise<void> {
     const { mediaUploads } = message

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -16,6 +16,7 @@ import { DOMParser, XMLSerializer } from 'xmldom'
 import { Substitute } from '@fluffy-spoon/substitute'
 import { LanguageClient } from 'vscode-languageclient/node'
 import { EMPTY_BOOKS_AND_ORPHANS, DiagnosticSource, ExtensionServerRequest } from '../../../../common/src/requests'
+import { PanelStateMessageType } from '../../../../common/src/webview-constants'
 import { Disposer, ExtensionEvents, ExtensionHostContext, Panel } from '../../panel'
 
 const ROOT_DIR_REL = '../../../../../../'
@@ -233,7 +234,7 @@ suite('Extension Test Suite', function (this: Suite) {
       path.join(resourceRootDir, 'cnxml-to-html5.xsl'),
       'utf-8'
     )
-    assert((panel.postMessage as SinonRoot.SinonSpy).calledWith({ type: 'refresh', xml: xmlExpectedSecond, xsl: xsl }))
+    assert((panel.postMessage as SinonRoot.SinonSpy).calledWith({ type: PanelStateMessageType.Response, state: { xml: xmlExpectedSecond, xsl: xsl } }))
     assert.strictEqual((panel as any).resourceBinding.fsPath, resourceSecond.fsPath)
   }).timeout(5000)
   test('cnxml preview only rebinds to cnxml', async () => {
@@ -556,10 +557,12 @@ suite('Disposables', function (this: Suite) {
     panel.webview.html = rawTextHtml('test')
     return panel
   }
-  class TestPanel extends Panel<void, void> {
+  class TestPanel extends Panel<void, void, null> {
     constructor(private readonly context: ExtensionHostContext) {
       super(initTestPanel(context))
     }
+
+    protected getState() { return null }
 
     async handleMessage(_message: undefined): Promise<void> {
       throw new Error('Method not implemented.')

--- a/client/src/webview-js/cnxml-preview/cnxml-preview.js
+++ b/client/src/webview-js/cnxml-preview/cnxml-preview.js
@@ -1,4 +1,5 @@
 import './index.less'
+import { PanelStateMessageType } from '~common-api~/webview-constants'
 
 let vscode
 
@@ -104,6 +105,9 @@ window.addEventListener('scroll', () => {
 window.addEventListener('DOMContentLoaded', () => {
   // https://code.visualstudio.com/api/extension-guides/webview#scripts-and-message-passing
   vscode = acquireVsCodeApi() // eslint-disable-line no-undef
+  // vscode only allows calling acquireVsCodeApi once.
+  // Since we called it we will redefine the function so it does not error.
+  window.acquireVsCodeApi = () => vscode
 
   preview = document.querySelector('#preview')
   preview.innerHTML = '' // remove the "JS did not run" message
@@ -113,8 +117,8 @@ window.addEventListener('DOMContentLoaded', () => {
 window.addEventListener('message', event => {
   const request = event.data
   const type = request.type
-  if (type === 'refresh') {
-    handleRefresh(request.xml, request.xsl)
+  if (type === PanelStateMessageType.Response) {
+    handleRefresh(request.state.xml, request.state.xsl)
   } else if (type === 'scroll-in-preview') {
     scrollToElementOfSourceLine(parseFloat(request.line))
   } else {

--- a/client/src/webview-js/cnxml-preview/cnxml-preview.js
+++ b/client/src/webview-js/cnxml-preview/cnxml-preview.js
@@ -107,6 +107,7 @@ window.addEventListener('DOMContentLoaded', () => {
   vscode = acquireVsCodeApi() // eslint-disable-line no-undef
   // vscode only allows calling acquireVsCodeApi once.
   // Since we called it we will redefine the function so it does not error.
+  /* istanbul ignore next */
   window.acquireVsCodeApi = () => vscode
 
   preview = document.querySelector('#preview')

--- a/client/src/webview-js/toc-editor/toc-editor.jsx
+++ b/client/src/webview-js/toc-editor/toc-editor.jsx
@@ -9,6 +9,7 @@ import { PanelStateMessageType } from '~common-api~/webview-constants'
 const vscode = acquireVsCodeApi() // eslint-disable-line no-undef
 // vscode only allows calling acquireVsCodeApi once.
 // Since we called it we will redefine the function so it does not error.
+/* istanbul ignore next */
 window.acquireVsCodeApi = () => vscode
 
 const nodeType = 'toc-element'

--- a/client/src/webview-js/toc-editor/toc-editor.jsx
+++ b/client/src/webview-js/toc-editor/toc-editor.jsx
@@ -426,6 +426,7 @@ window.addEventListener('message', event => {
   const oldData = previousState?.treesData
   const message /*: PanelOutgoingMessage | PanelStateMessage<PanelState> */ = event.data
 
+  /* istanbul ignore if */
   if (message.type !== PanelStateMessageType.Response) {
     console.error('[TOC_EDITOR_WEBVIEW] BUG? Unknown Message type', message)
     return

--- a/common/src/webview-constants.ts
+++ b/common/src/webview-constants.ts
@@ -1,0 +1,10 @@
+
+export enum PanelStateMessageType {
+  Request = 'PanelStateMessageType.Request',
+  Response = 'PanelStateMessageType.Response'
+}
+
+export interface PanelStateMessage<S> {
+  type: PanelStateMessageType.Response
+  state: S
+}

--- a/cypress/integration/cnxml-preview-spec.ts
+++ b/cypress/integration/cnxml-preview-spec.ts
@@ -1,5 +1,6 @@
 // Shares a namespace with the other specfiles if not scoped
 import { PanelIncomingMessage, PanelOutgoingMessage, ScrollInEditorIncoming } from '../../client/src/panel-cnxml-preview'
+import { PanelStateMessageType } from '../../common/src/webview-constants'
 {
   // The HTML file that cypress should load when running tests (relative to the project root)
   const htmlPath = './client/out/client/src/cnxml-preview.html'
@@ -12,7 +13,7 @@ import { PanelIncomingMessage, PanelOutgoingMessage, ScrollInEditorIncoming } fr
     }
     function sendXml(xmlStr: string): void {
       cy.fixture('cnxml-to-html5.xsl').then(xsl => {
-        sendMessage({ type: 'refresh', xml: xmlStr, xsl: xsl })
+        sendMessage({ type: PanelStateMessageType.Response, state: { xml: xmlStr, xsl: xsl } })
       })
     }
     function createCnxmlFromContent(content: string): string {

--- a/cypress/integration/cnxml-preview-spec.ts
+++ b/cypress/integration/cnxml-preview-spec.ts
@@ -1,12 +1,12 @@
 // Shares a namespace with the other specfiles if not scoped
-import { PanelIncomingMessage, PanelOutgoingMessage, ScrollInEditorIncoming } from '../../client/src/panel-cnxml-preview'
-import { PanelStateMessageType } from '../../common/src/webview-constants'
+import { PanelIncomingMessage, ScrollInEditorIncoming, ScrollToLineOutgoing } from '../../client/src/panel-cnxml-preview'
+import { PanelStateMessage, PanelStateMessageType } from '../../common/src/webview-constants'
 {
   // The HTML file that cypress should load when running tests (relative to the project root)
   const htmlPath = './client/out/client/src/cnxml-preview.html'
 
   describe('cnxml-preview Webview Tests', () => {
-    function sendMessage(msg: PanelOutgoingMessage): void {
+    function sendMessage(msg: ScrollToLineOutgoing | PanelStateMessage<any>): void {
       cy.window().then($window => {
         $window.postMessage(msg, '*')
       })
@@ -43,7 +43,7 @@ import { PanelStateMessageType } from '../../common/src/webview-constants'
     })
 
     it('Errors when malformed outgoing message is sent', () => {
-      sendMessage(({ type: 'xml', somethingOtherThanXml: 'hello' } as unknown as PanelOutgoingMessage))
+      sendMessage(({ type: 'xml', somethingOtherThanXml: 'hello' } as unknown as PanelStateMessage<any>))
       cy.get('#preview *').should('not.exist')
     })
 

--- a/cypress/integration/toc-editor-spec.ts
+++ b/cypress/integration/toc-editor-spec.ts
@@ -1,6 +1,7 @@
 // Shares a namespace with the other specfiles if not scoped
 import { PanelIncomingMessage, PanelOutgoingMessage, Bookish, TreeItemWithToken } from '../../client/src/panel-toc-editor'
 import { TocNodeKind } from '../../common/src/toc'
+import { PanelStateMessageType } from '../../common/src/webview-constants'
 {
   // The HTML file that cypress should load when running tests (relative to the project root)
   const htmlPath = './client/out/client/src/toc-editor.html'
@@ -66,10 +67,14 @@ import { TocNodeKind } from '../../common/src/toc'
   }
 
   describe('toc-editor Webview Tests', () => {
-    function sendMessage(msg: PanelOutgoingMessage): void {
-      cy.log('sending message', msg)
+    function sendStateMessage(msg: PanelOutgoingMessage): void {
+      const m = {
+        type: PanelStateMessageType.Response,
+        state: msg
+      }
+      cy.log('sending state update message', m)
       cy.window().then($window => {
-        $window.postMessage(msg, '*')
+        $window.postMessage(m, '*')
       })
     }
 
@@ -102,7 +107,7 @@ import { TocNodeKind } from '../../common/src/toc'
       cy.get('[data-app-init]').should('not.exist')
     })
     it('will load when a message is sent (empty)', () => {
-      sendMessage({
+      sendStateMessage({
         editable: [],
         uneditable: []
       })
@@ -112,14 +117,14 @@ import { TocNodeKind } from '../../common/src/toc'
     })
     it('will load when a message is sent', () => {
       const book = buildBook([['Introduction'], 'Appendix'])
-      sendMessage({ editable: [book], uneditable: [] })
+      sendStateMessage({ editable: [book], uneditable: [] })
       cy.get('[data-app-init]').should('exist')
       cy.get('.panel-editable .rst__node').should('have.length', 2)
       cy.get('.panel-uneditable .rst__node').should('not.exist')
     })
     it('will load when a message is sent (expanded)', () => {
       const book = buildBook([{ expanded: true, children: ['Introduction'] }, 'Appendix'])
-      sendMessage({ editable: [book], uneditable: [] })
+      sendStateMessage({ editable: [book], uneditable: [] })
       cy.get('[data-app-init]').should('exist')
       cy.get('.panel-editable .rst__node').should('have.length', 3)
       cy.get('.panel-uneditable .rst__node').should('not.exist')
@@ -130,13 +135,13 @@ import { TocNodeKind } from '../../common/src/toc'
         editable: [book1],
         uneditable: []
       }
-      sendMessage(message)
+      sendStateMessage(message)
       cy.get('[data-render-cached]').should('not.exist')
-      sendMessage(message)
+      sendStateMessage(message)
       cy.get('[data-render-cached]').should('exist')
 
       const book2 = buildBook([['Introduction'], 'Appendix'])
-      sendMessage({ editable: [book2], uneditable: [] })
+      sendStateMessage({ editable: [book2], uneditable: [] })
       cy.get('[data-render-cached]').should('not.exist')
     })
     it('will not re-render on same data (expanded)', () => {
@@ -145,22 +150,22 @@ import { TocNodeKind } from '../../common/src/toc'
         editable: [book1],
         uneditable: []
       }
-      sendMessage(message)
+      sendStateMessage(message)
       cy.get('[data-render-cached]').should('not.exist')
-      sendMessage(message)
+      sendStateMessage(message)
       cy.get('[data-render-cached]').should('exist')
 
       const book2 = buildBook([{ expanded: true, children: ['Introduction'] }, 'Appendix'])
-      sendMessage({ editable: [book2], uneditable: [] })
+      sendStateMessage({ editable: [book2], uneditable: [] })
       cy.get('[data-render-cached]').should('not.exist')
     })
     it('will preserve expanded nodes on reload', () => {
       const book1 = buildBook([{ expanded: true, children: ['Introduction'] }, ['Introduction']], { startAt: DO_NOT_INCREMENT })
-      sendMessage({ editable: [book1], uneditable: [] })
+      sendStateMessage({ editable: [book1], uneditable: [] })
       cy.get('.panel-editable .rst__node').should('have.length', 3)
 
       const book2 = buildBook([{ expanded: true, children: ['Introduction'] }, ['Introduction'], ['Introduction']], { startAt: DO_NOT_INCREMENT })
-      sendMessage({ editable: [book2], uneditable: [] })
+      sendStateMessage({ editable: [book2], uneditable: [] })
 
       // Would be 3 if the expanded subcollection was not preserved
       // Would be 4 if new nodes were initially collapsed
@@ -171,7 +176,7 @@ import { TocNodeKind } from '../../common/src/toc'
       beforeEach(() => {
         const book = buildBook([{ expanded: true, children: ['Introduction'] }, 'Appendix'])
         const orphans = buildBook(['Module 3', 'Module 4'])
-        sendMessage({
+        sendStateMessage({
           editable: [book],
           uneditable: [orphans]
         })
@@ -213,7 +218,7 @@ import { TocNodeKind } from '../../common/src/toc'
         const book1 = buildBook([{ expanded: true, children: ['Introduction', 'Appending To Lists'] }, 'Appendix'])
         const book2 = buildBook([{ expanded: true, children: ['Introduction', 'Deleting From Lists'] }, 'Appendix'], { title: 'test collection 2', slug: 'test-2' })
         const orphans = buildBook(['Module 3', 'Module 4'])
-        sendMessage({ editable: [book1, book2], uneditable: [orphans] })
+        sendStateMessage({ editable: [book1, book2], uneditable: [orphans] })
       })
       it('highlights elements that match search by title', () => {
         cy.get('.panel-editable .search')

--- a/cypress/integration/toc-editor-spec.ts
+++ b/cypress/integration/toc-editor-spec.ts
@@ -1,5 +1,5 @@
 // Shares a namespace with the other specfiles if not scoped
-import { PanelIncomingMessage, PanelOutgoingMessage, Bookish, TreeItemWithToken } from '../../client/src/panel-toc-editor'
+import { PanelIncomingMessage, Bookish, TreeItemWithToken, PanelState } from '../../client/src/panel-toc-editor'
 import { TocNodeKind } from '../../common/src/toc'
 import { PanelStateMessageType } from '../../common/src/webview-constants'
 {
@@ -67,7 +67,7 @@ import { PanelStateMessageType } from '../../common/src/webview-constants'
   }
 
   describe('toc-editor Webview Tests', () => {
-    function sendStateMessage(msg: PanelOutgoingMessage): void {
+    function sendStateMessage(msg: PanelState): void {
       const m = {
         type: PanelStateMessageType.Response,
         state: msg
@@ -131,7 +131,7 @@ import { PanelStateMessageType } from '../../common/src/webview-constants'
     })
     it('will not re-render on same data (expanded)', () => {
       const book1 = buildBook([['Introduction']])
-      const message: PanelOutgoingMessage = {
+      const message: PanelState = {
         editable: [book1],
         uneditable: []
       }
@@ -146,7 +146,7 @@ import { PanelStateMessageType } from '../../common/src/webview-constants'
     })
     it('will not re-render on same data (expanded)', () => {
       const book1 = buildBook([{ expanded: true, children: ['Introduction'] }])
-      const message: PanelOutgoingMessage = {
+      const message: PanelState = {
         editable: [book1],
         uneditable: []
       }


### PR DESCRIPTION
When switching back and forth between a webview tab, only the initial state is reloaded (we bake the initial state into the the HTML so it shows up immediately).

To address this, whenever the Webview panel loads it sends a message to the extension asking for updated state.

This PR adds 2 special message types that are sent between the webview panel and the extension:

- `{ type: PanelStateMessageType.Request }` is sent to the extension from the webview as soon as the webview is loaded
- `{ type: PanelStateMessageType.Response, state: S }` is sent to the webview from the extension whenever the concrete Panel class calls sendState (aka. when the state changes)


# Notes

Listed below are annoyances with webview panels and workarounds we use:

## Webview runs in an iframe

- the extension and the webview panel use `postMessage()` and `window.addEventListener('message', () => ...)` to communicate.

## Webview HTML needs to explicitly say which sources for images/css/JS are allowed

- we need to set the CSP attributes properly
- since we don't know which domain we'll be loaded from, we need to inject the allowed URL
- for any JS on the page we need to tag it with a nonce key and include that key in the CSP tag

## Message sending/receiving is async

To speed up the process, we "embed" the initial JSON message into the HTML

## A webview panel is disposed when the tab is no longer active

So we need to request updated data from the extension by sending a `postMessage`.
