### PR TITLE
validate iframe paths

### DIFF
--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -322,8 +322,8 @@ describe('Image Autocomplete', () => {
     const imagePath = '../../media/image.png'
     const orphanedPath = '../../media/orphan.png'
 
-    const existingImage = manager.bundle.allImages.getOrAdd(joinPath(page, imagePath))
-    const orphanedImage = manager.bundle.allImages.getOrAdd(joinPath(page, orphanedPath))
+    const existingImage = manager.bundle.allResources.getOrAdd(joinPath(page, imagePath))
+    const orphanedImage = manager.bundle.allResources.getOrAdd(joinPath(page, orphanedPath))
     existingImage.load('image-bits')
     orphanedImage.load('image-bits')
 
@@ -331,9 +331,9 @@ describe('Image Autocomplete', () => {
     expect(page.validationErrors.nodesToLoad.toArray()).toEqual([])
     expect(page.validationErrors.errors.toArray()).toEqual([])
 
-    expect(page.imageLinks.size).toBe(1)
-    const firstImageRef = first(page.imageLinks)
-    const results = manager.autocompleteImages(page, { line: firstImageRef.range.start.line, character: firstImageRef.range.start.character + '<image src="X'.length })
+    expect(page.resourceLinks.size).toBe(1)
+    const firstImageRef = first(page.resourceLinks)
+    const results = manager.autocompleteResources(page, { line: firstImageRef.range.start.line, character: firstImageRef.range.start.character + '<image src="X'.length })
     expect(results).not.toEqual([])
     expect(results[0].label).toBe(orphanedPath)
   })
@@ -344,8 +344,8 @@ describe('Image Autocomplete', () => {
     const imagePath = '../../media/image.png'
     const orphanedPath = '../../media/orphan.png'
 
-    const existingImage = manager.bundle.allImages.getOrAdd(joinPath(page, imagePath))
-    const orphanedImage = manager.bundle.allImages.getOrAdd(joinPath(page, orphanedPath))
+    const existingImage = manager.bundle.allResources.getOrAdd(joinPath(page, imagePath))
+    const orphanedImage = manager.bundle.allResources.getOrAdd(joinPath(page, orphanedPath))
     existingImage.load('image-bits')
     orphanedImage.load('image-bits')
 
@@ -354,7 +354,7 @@ describe('Image Autocomplete', () => {
     expect(page.validationErrors.errors.toArray()).toEqual([])
 
     const cursor = { line: 0, character: 0 }
-    const results = manager.autocompleteImages(page, cursor)
+    const results = manager.autocompleteResources(page, cursor)
     expect(results).toEqual([])
   })
 
@@ -365,9 +365,9 @@ describe('Image Autocomplete', () => {
     const orphanedPath = '../../media/orphan.png'
     const missingPath = ''
 
-    const existingImage = manager.bundle.allImages.getOrAdd(joinPath(page, imagePath))
-    const orphanedImage = manager.bundle.allImages.getOrAdd(joinPath(page, orphanedPath))
-    const missingImage = manager.bundle.allImages.getOrAdd(joinPath(page, missingPath))
+    const existingImage = manager.bundle.allResources.getOrAdd(joinPath(page, imagePath))
+    const orphanedImage = manager.bundle.allResources.getOrAdd(joinPath(page, orphanedPath))
+    const missingImage = manager.bundle.allResources.getOrAdd(joinPath(page, missingPath))
     existingImage.load('image-bits')
     orphanedImage.load('image-bits')
     missingImage.load('')
@@ -376,8 +376,8 @@ describe('Image Autocomplete', () => {
     expect(page.validationErrors.nodesToLoad.toArray()).toEqual([])
     expect(page.validationErrors.errors.toArray()).toEqual([])
 
-    const secondImageRef = page.imageLinks.toArray()[1]
-    const results = manager.autocompleteImages(page, { line: secondImageRef.range.start.line, character: secondImageRef.range.start.character + '<image'.length })
+    const secondImageRef = page.resourceLinks.toArray()[1]
+    const results = manager.autocompleteResources(page, { line: secondImageRef.range.start.line, character: secondImageRef.range.start.character + '<image'.length })
     expect(results).toEqual([])
   })
 })

--- a/server/src/model/_cli.ts
+++ b/server/src/model/_cli.ts
@@ -52,7 +52,7 @@ const pathHelper: PathHelper<string> = {
     console.error('This directory contains:')
     console.error('  Books:', bundle.allBooks.size)
     console.error('  Pages:', bundle.allPages.size)
-    console.error('  Images:', bundle.allImages.size)
+    console.error('  Images:', bundle.allResources.size)
 
     const validationErrors = bundle.allNodes.flatMap(n => n.validationErrors.errors)
     console.error('Validation Errors:', validationErrors.size)

--- a/server/src/model/bundle.ts
+++ b/server/src/model/bundle.ts
@@ -5,10 +5,10 @@ import { Factory } from './factory'
 import { PageNode } from './page'
 import { BookNode } from './book'
 import { Fileish, ValidationCheck } from './fileish'
-import { ImageNode } from './image'
+import { ResourceNode } from './resource'
 
 export class Bundle extends Fileish implements Bundleish {
-  public readonly allImages: Factory<ImageNode> = new Factory((absPath: string) => new ImageNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
+  public readonly allResources: Factory<ResourceNode> = new Factory((absPath: string) => new ResourceNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
   public readonly allPages: Factory<PageNode> = new Factory((absPath: string) => new PageNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
   public readonly allBooks = new Factory((absPath: string) => new BookNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
   private readonly _books = Quarx.observable.box<Opt<I.Set<WithRange<BookNode>>>>(undefined)
@@ -32,7 +32,7 @@ export class Bundle extends Fileish implements Bundleish {
   }
 
   public get allNodes() {
-    return I.Set([this]).union(this.allBooks.all).union(this.allPages.all).union(this.allImages.all)
+    return I.Set([this]).union(this.allBooks.all).union(this.allPages.all).union(this.allResources.all)
   }
 
   public get books() {

--- a/server/src/model/page.spec.ts
+++ b/server/src/model/page.spec.ts
@@ -69,10 +69,10 @@ ${i.extraCnxml}
 }
 
 describe('Page validations', () => {
-  it(PageValidationKind.MISSING_IMAGE, () => {
+  it(PageValidationKind.MISSING_RESOURCE, () => {
     const bundle = makeBundle()
     const page = bundle.allPages.getOrAdd('somepage/filename')
-    const image = bundle.allImages.getOrAdd('someimage')
+    const image = bundle.allResources.getOrAdd('someimage')
     const info = { imageHrefs: [path.relative(path.dirname(page.absPath), image.absPath)] }
     page.load(pageMaker(info))
     // Verify the image needs to be loaded
@@ -80,7 +80,7 @@ describe('Page validations', () => {
     expect(first(page.validationErrors.nodesToLoad)).toBe(image)
     // At first the image does not exist:
     image.load(undefined)
-    expect(first(page.validationErrors.errors).message).toBe(PageValidationKind.MISSING_IMAGE)
+    expect(first(page.validationErrors.errors).message).toBe(PageValidationKind.MISSING_RESOURCE)
     // And then it does:
     image.load('somebits')
     expect(page.validationErrors.errors.size).toBe(0)

--- a/server/src/model/page.ts
+++ b/server/src/model/page.ts
@@ -118,7 +118,7 @@ export class PageNode extends Fileish {
 
     this._elementIds.set(I.Set((select('//cnxml:*[@id]', doc) as Element[]).map(el => textWithRange(el, 'id'))))
 
-    const imageNodes = select('//cnxml:image/@src', doc) as Attr[]
+    const imageNodes = select('//cnxml:*[self::cnxml:image or self::cnxml:iframe]/@src', doc) as Attr[]
     this._imageLinks.set(I.Set(imageNodes.map(attr => {
       const src = expectValue(attr.nodeValue, 'BUG: Attribute does not have a value')
       const image = super.bundle.allImages.getOrAdd(join(this.pathHelper, PathKind.ABS_TO_REL, this.absPath, src))

--- a/server/src/model/page.ts
+++ b/server/src/model/page.ts
@@ -2,10 +2,20 @@ import I from 'immutable'
 import * as Quarx from 'quarx'
 import { Opt, Position, PathKind, WithRange, textWithRange, select, selectOne, calculateElementPositions, expectValue, HasRange, NOWHERE, join, equalsOpt, equalsWithRange, tripleEq } from './utils'
 import { Fileish, ValidationCheck } from './fileish'
-import { ImageNode } from './image'
+import { ResourceNode } from './resource'
 
+enum ResourceLinkKind {
+  Image,
+  IFrame
+}
+export type ResourceLink = ImageLink | IFrameLink
 export interface ImageLink extends HasRange {
-  image: ImageNode
+  type: ResourceLinkKind.Image
+  target: ResourceNode
+}
+export interface IFrameLink extends HasRange {
+  type: ResourceLinkKind.IFrame
+  target: ResourceNode
 }
 
 export enum PageLinkKind {
@@ -49,7 +59,7 @@ export class PageNode extends Fileish {
   private readonly _uuid = Quarx.observable.box<Opt<WithRange<string>>>(undefined, { equals: equalsOptWithRange })
   private readonly _title = Quarx.observable.box<Opt<WithRange<string>>>(undefined, { equals: equalsOptWithRange })
   private readonly _elementIds = Quarx.observable.box<Opt<I.Set<WithRange<string>>>>(undefined)
-  private readonly _imageLinks = Quarx.observable.box<Opt<I.Set<ImageLink>>>(undefined)
+  private readonly _resourceLinks = Quarx.observable.box<Opt<I.Set<ResourceLink>>>(undefined)
   private readonly _pageLinks = Quarx.observable.box<Opt<I.Set<PageLink>>>(undefined)
   public uuid() { return this.ensureLoaded(this._uuid).v }
   public get optTitle() {
@@ -93,12 +103,12 @@ export class PageNode extends Fileish {
     }
   }
 
-  public get images() {
-    return this.imageLinks.map(l => l.image)
+  public get resources() {
+    return this.resourceLinks.map(l => l.target)
   }
 
-  public get imageLinks() {
-    return this.ensureLoaded(this._imageLinks)
+  public get resourceLinks() {
+    return this.ensureLoaded(this._resourceLinks)
   }
 
   public get pageLinks() {
@@ -118,15 +128,21 @@ export class PageNode extends Fileish {
 
     this._elementIds.set(I.Set((select('//cnxml:*[@id]', doc) as Element[]).map(el => textWithRange(el, 'id'))))
 
-    const imageNodes = select('//cnxml:*[self::cnxml:image or self::cnxml:iframe]/@src', doc) as Attr[]
-    this._imageLinks.set(I.Set(imageNodes.map(attr => {
+    const toResourceLink = (type: ResourceLinkKind, attr: Attr): ResourceLink => {
       const src = expectValue(attr.nodeValue, 'BUG: Attribute does not have a value')
-      const image = super.bundle.allImages.getOrAdd(join(this.pathHelper, PathKind.ABS_TO_REL, this.absPath, src))
+      const target = super.bundle.allResources.getOrAdd(join(this.pathHelper, PathKind.ABS_TO_REL, this.absPath, src))
       // Get the line/col position of the <image> tag
       const imageNode = expectValue(attr.ownerElement, 'BUG: attributes always have a parent element')
       const range = calculateElementPositions(imageNode)
-      return { image, range }
-    })))
+      return { type, target, range }
+    }
+
+    const imageNodes = select('//cnxml:image/@src', doc) as Attr[]
+    const iframeNodes = select('//cnxml:iframe/@src', doc) as Attr[]
+    const imageLinks = imageNodes.map(n => toResourceLink(ResourceLinkKind.Image, n))
+    const iframeLinks = iframeNodes.map(n => toResourceLink(ResourceLinkKind.IFrame, n))
+
+    this._resourceLinks.set(I.Set([...imageLinks, ...iframeLinks]))
 
     const linkNodes = select('//cnxml:link', doc) as Element[]
     const changeEmptyToNull = (str: string | null): Opt<string> => (str === '' || str === null) ? undefined : str
@@ -164,13 +180,13 @@ export class PageNode extends Fileish {
   }
 
   protected getValidationChecks(): ValidationCheck[] {
-    const imageLinks = this.imageLinks
+    const resourceLinks = this.resourceLinks
     const pageLinks = this.pageLinks
     return [
       {
-        message: PageValidationKind.MISSING_IMAGE,
-        nodesToLoad: imageLinks.map(l => l.image),
-        fn: () => imageLinks.filter(img => !img.image.exists).map(l => l.range)
+        message: PageValidationKind.MISSING_RESOURCE,
+        nodesToLoad: resourceLinks.map(l => l.target),
+        fn: () => resourceLinks.filter(img => !img.target.exists).map(l => l.range)
       },
       {
         message: PageValidationKind.MISSING_TARGET,
@@ -212,7 +228,7 @@ export class PageNode extends Fileish {
 }
 
 export enum PageValidationKind {
-  MISSING_IMAGE = 'Image file does not exist',
+  MISSING_RESOURCE = 'Target resource file does not exist',
   MISSING_TARGET = 'Link target does not exist',
   MALFORMED_UUID = 'Malformed UUID',
   DUPLICATE_UUID = 'Duplicate Page/Module UUID',

--- a/server/src/model/resource.ts
+++ b/server/src/model/resource.ts
@@ -1,6 +1,7 @@
 import { Fileish } from './fileish'
 
-export class ImageNode extends Fileish {
+// This can be an Image or an IFrame
+export class ResourceNode extends Fileish {
   /* istanbul ignore next */
   protected getValidationChecks() { return [] }
 }

--- a/server/src/model/utils.ts
+++ b/server/src/model/utils.ts
@@ -3,7 +3,7 @@ import I from 'immutable'
 import * as xpath from 'xpath-ts'
 import { PageNode } from './page'
 import { Factory } from './factory'
-import { ImageNode } from './image'
+import { ResourceNode } from './resource'
 
 export const NS_COLLECTION = 'http://cnx.rice.edu/collxml'
 const NS_CNXML = 'http://cnx.rice.edu/cnxml'
@@ -68,7 +68,7 @@ export interface TocPage<T> { type: TocNodeKind.Page, readonly page: T }
 
 export interface Bundleish {
   allPages: Factory<PageNode>
-  allImages: Factory<ImageNode>
+  allResources: Factory<ResourceNode>
   workspaceRootUri: string
   isDuplicateUuid: (uuid: string) => boolean
 }

--- a/server/src/server-handler.ts
+++ b/server/src/server-handler.ts
@@ -13,13 +13,13 @@ export function bundleEnsureIdsHandler(): (request: BundleEnsureIdsParams) => Pr
   }
 }
 
-export async function imageAutocompleteHandler(documentPosition: CompletionParams, manager: ModelManager): Promise<CompletionItem[]> {
+export async function resourceAutocompleteHandler(documentPosition: CompletionParams, manager: ModelManager): Promise<CompletionItem[]> {
   await manager.loadEnoughForOrphans()
   const cursor = documentPosition.position
   const page = manager.bundle.allPages.get(documentPosition.textDocument.uri)
 
   if (page !== undefined) {
-    return manager.autocompleteImages(page, cursor)
+    return manager.autocompleteResources(page, cursor)
   }
   return []
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -15,7 +15,7 @@ import { URI, Utils } from 'vscode-uri'
 import { expectValue } from './model/utils'
 
 import { ExtensionServerRequest } from '../../common/src/requests'
-import { bundleEnsureIdsHandler, imageAutocompleteHandler } from './server-handler'
+import { bundleEnsureIdsHandler, resourceAutocompleteHandler } from './server-handler'
 
 import * as sourcemaps from 'source-map-support'
 import { Bundle } from './model/bundle'
@@ -154,7 +154,7 @@ connection.onCompletionResolve((a: CompletionItem, token: CancellationToken): Co
 
 connection.onCompletion(async (params: CompletionParams): Promise<CompletionItem[]> => {
   const manager = getBundleForUri(params.textDocument.uri)
-  return await imageAutocompleteHandler(params, manager)
+  return await resourceAutocompleteHandler(params, manager)
 })
 connection.onDocumentLinks(async ({ textDocument }) => {
   const { uri } = textDocument


### PR DESCRIPTION
Pretty much do the same as what we do for image paths but with a different error message maybe?

## Changes

- The Problems area now says `Target resource file does not exist` instead of `Image file does not exist` for both broken images and iframes
- autocompletion works for both images and iframes
    - should we be smart enough in this PR and distinguish between autocompleting an `<image src=>` and an `<iframe src=>` ?

## To-do

- [x] rename "Image" to "Resource" because Images and IFrames are resources