### PR TITLE
Reload workspace settings on activation

### DIFF
--- a/client/specs/__mocks__/vscode.js
+++ b/client/specs/__mocks__/vscode.js
@@ -36,7 +36,12 @@ const window = {
 
 const workspace = {
   textDocuments: [],
-  getConfiguration: jest.fn(),
+  getConfiguration: jest.fn(() => ({
+    get: jest.fn((section, defaultValue) => defaultValue),
+    has: jest.fn(),
+    inspect: jest.fn(),
+    update: jest.fn()
+  })),
   workspaceFolders: [],
   createFileSystemWatcher: jest.fn(() => ({
     onDidCreate: jest.fn(),
@@ -132,6 +137,8 @@ const ViewColumn = {
     Nine: 9,
 }
 
+const ConfigurationTarget = { Global: 1, Workspace: 2, WorkspaceFolder: 3 }
+
 const vscode = {
   version: REQUIRED_VSCODE_VERSION,
   languages,
@@ -159,6 +166,7 @@ const vscode = {
   CodeActionKind,
   CallHierarchyItem,
   ThemeIcon,
+  ConfigurationTarget,
 };
 
 module.exports = { ...vscode, default: vscode };

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -3,7 +3,7 @@ import { LanguageClient } from 'vscode-languageclient/node'
 import { pushContent, tagContent } from './push-content'
 import { TocEditorPanel } from './panel-toc-editor'
 import { CnxmlPreviewPanel } from './panel-cnxml-preview'
-import { expect, ensureCatch, launchLanguageServer, populateXsdSchemaFiles } from './utils'
+import { expect, ensureCatch, launchLanguageServer, populateXsdSchemaFiles, configureWorkspaceSettings } from './utils'
 import { OpenstaxCommand } from './extension-types'
 import { ExtensionHostContext, Panel, PanelManager } from './panel'
 import { ImageManagerPanel } from './panel-image-manager'
@@ -35,6 +35,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
   // detect Theia. Alert the user if they are running Theia
   /* istanbul ignore next */
   expect(process.env.GITPOD_HOST != null && process.env.EDITOR?.includes('code') === false ? undefined : true, 'You seem to be running the Theia editor. Change your Settings in your profile')
+
+  // This must run before languageServerLauncher
+  await configureWorkspaceSettings()
 
   client = languageServerLauncher(context)
   await populateXsdSchemaFiles(resourceRootDir)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -36,11 +36,23 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
   /* istanbul ignore next */
   expect(process.env.GITPOD_HOST != null && process.env.EDITOR?.includes('code') === false ? undefined : true, 'You seem to be running the Theia editor. Change your Settings in your profile')
 
-  await configureWorkspaceSettings()
+  const extensionIDs = [
+    'redhat.vscode-xml',
+    'vscode.git',
+    'cweijan.git-history-plus'
+  ]
+  for (const id of extensionIDs) {
+    const extension = vscode.extensions.getExtension(id)
+    if (extension === undefined) {
+      await vscode.commands.executeCommand('workbench.extensions.installExtension', id)
+    }
+  }
 
   client = languageServerLauncher(context)
   await populateXsdSchemaFiles(resourceRootDir)
   await client.onReady()
+
+  await configureWorkspaceSettings()
 
   // It is a logic error for anything else to listen to this event from the client.
   // It is only allowed a single handler, from what we can tell

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -36,7 +36,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
   /* istanbul ignore next */
   expect(process.env.GITPOD_HOST != null && process.env.EDITOR?.includes('code') === false ? undefined : true, 'You seem to be running the Theia editor. Change your Settings in your profile')
 
-  // This must run before languageServerLauncher
   await configureWorkspaceSettings()
 
   client = languageServerLauncher(context)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -36,23 +36,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
   /* istanbul ignore next */
   expect(process.env.GITPOD_HOST != null && process.env.EDITOR?.includes('code') === false ? undefined : true, 'You seem to be running the Theia editor. Change your Settings in your profile')
 
-  const extensionIDs = [
-    'redhat.vscode-xml',
-    'vscode.git',
-    'cweijan.git-history-plus'
-  ]
-  for (const id of extensionIDs) {
-    const extension = vscode.extensions.getExtension(id)
-    if (extension === undefined) {
-      await vscode.commands.executeCommand('workbench.extensions.installExtension', id)
-    }
-  }
+  await configureWorkspaceSettings()
 
   client = languageServerLauncher(context)
   await populateXsdSchemaFiles(resourceRootDir)
   await client.onReady()
-
-  await configureWorkspaceSettings()
 
   // It is a logic error for anything else to listen to this event from the client.
   // It is only allowed a single handler, from what we can tell

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -5,7 +5,7 @@ import vscode from 'vscode'
 import SinonRoot from 'sinon'
 import { GitErrorCodes, Repository, CommitOptions, RepositoryState, Branch, RefType } from '../../git-api/git.d'
 import 'source-map-support/register'
-import { expect as expectOrig, getRootPathUri } from './../../utils'
+import { configureWorkspaceSettings, expect as expectOrig, getRootPathUri } from './../../utils'
 import { activate, deactivate, forwardOnDidChangeWorkspaceFolders } from './../../extension'
 import { ImageManagerPanel } from './../../panel-image-manager'
 import { CnxmlPreviewPanel, rawTextHtml, tagElementsWithLineNumbers } from './../../panel-cnxml-preview'
@@ -539,6 +539,24 @@ suite('Extension Test Suite', function (this: Suite) {
     await forwarder('test_event' as unknown as vscode.WorkspaceFoldersChangeEvent)
     const expected = ['onDidChangeWorkspaceFolders', 'test_event']
     assert((mockClient.sendRequest as SinonRoot.SinonStub).calledOnceWith(...expected))
+  })
+  test('configureWorkspaceSettings changes files.associations', async () => {
+    const getStub = sinon.stub().returns({})
+    const hasStub = sinon.stub().returns(false)
+    const inspectStub = sinon.stub().returns({})
+    const updateStub = sinon.stub().resolves()
+    const property = 'files.associations'
+    const target = vscode.ConfigurationTarget.Workspace
+    sinon.stub(vscode.workspace, 'getConfiguration').returns({
+      get: getStub,
+      has: hasStub,
+      inspect: inspectStub,
+      update: updateStub
+    })
+    await configureWorkspaceSettings()
+    assert(getStub.calledOnceWith('files.associations'))
+    assert(updateStub.calledWith(property, '', target))
+    assert(updateStub.calledWith(property, { '*.cnxml': 'xml' }, target))
   })
 
   this.afterAll(async () => {

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -5,7 +5,7 @@ import vscode from 'vscode'
 import SinonRoot from 'sinon'
 import { GitErrorCodes, Repository, CommitOptions, RepositoryState, Branch, RefType } from '../../git-api/git.d'
 import 'source-map-support/register'
-import { configureWorkspaceSettings, expect as expectOrig, getRootPathUri } from './../../utils'
+import { expect as expectOrig, getRootPathUri } from './../../utils'
 import { activate, deactivate, forwardOnDidChangeWorkspaceFolders } from './../../extension'
 import { ImageManagerPanel } from './../../panel-image-manager'
 import { CnxmlPreviewPanel, rawTextHtml, tagElementsWithLineNumbers } from './../../panel-cnxml-preview'
@@ -174,6 +174,7 @@ suite('Extension Test Suite', function (this: Suite) {
   })
   test('show cnxml preview with no file open', async () => {
     assert.strictEqual(vscode.window.activeTextEditor, undefined)
+    await sleep(500) // FIXME: Make me go away (see https://github.com/openstax/cnx/issues/1569)
     await withPanelFromCommand(OpenstaxCommand.SHOW_CNXML_PREVIEW, async (panel) => {
       assert(panel.webview.html.includes('No resource available to preview'))
     })
@@ -539,24 +540,6 @@ suite('Extension Test Suite', function (this: Suite) {
     await forwarder('test_event' as unknown as vscode.WorkspaceFoldersChangeEvent)
     const expected = ['onDidChangeWorkspaceFolders', 'test_event']
     assert((mockClient.sendRequest as SinonRoot.SinonStub).calledOnceWith(...expected))
-  })
-  test('configureWorkspaceSettings changes files.associations', async () => {
-    const getStub = sinon.stub().returns({})
-    const hasStub = sinon.stub().returns(false)
-    const inspectStub = sinon.stub().returns({})
-    const updateStub = sinon.stub().resolves()
-    const property = 'files.associations'
-    const target = vscode.ConfigurationTarget.Workspace
-    sinon.stub(vscode.workspace, 'getConfiguration').returns({
-      get: getStub,
-      has: hasStub,
-      inspect: inspectStub,
-      update: updateStub
-    })
-    await configureWorkspaceSettings()
-    assert(getStub.calledOnceWith('files.associations'))
-    assert(updateStub.calledWith(property, '', target))
-    assert(updateStub.calledWith(property, { '*.cnxml': 'xml' }, target))
   })
 
   this.afterAll(async () => {

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -219,11 +219,10 @@ export function getErrorDiagnosticsBySource(): Map<string, Array<[vscode.Uri, vs
 export async function configureWorkspaceSettings(): Promise<void> {
   const config = vscode.workspace.getConfiguration()
   const property = 'files.associations'
-  const value = config.get(property, {})
   const target = vscode.ConfigurationTarget.Workspace
+  let value = config.get(property, {})
   if (Object.keys(value).length < 1) {
-    void vscode.window.showErrorMessage(`BUG: Could not reload ${property} because it was unset.`)
-    return
+    value = { '*.cnxml': 'xml' }
   }
   await config.update(property, '', target)
   await config.update(property, value, target)

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -221,7 +221,7 @@ export async function configureWorkspaceSettings(): Promise<void> {
   const property = 'files.associations'
   const target = vscode.ConfigurationTarget.Workspace
   let value = config.get(property, {})
-  if (Object.keys(value).length < 1) {
+  if (Object.keys(value).length === 0) {
     value = { '*.cnxml': 'xml' }
   }
   await config.update(property, '', target)

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -211,11 +211,20 @@ export function getErrorDiagnosticsBySource(): Map<string, Array<[vscode.Uri, vs
   return errorsBySource
 }
 
+/**
+ * This is, hopefully, a temporary solution to the settings.json file failing to load in GitPod.
+ * It sets the value of one property to '', then resets it to it's original value, effectively
+ * forcing the settings to reload.
+ */
 export async function configureWorkspaceSettings(): Promise<void> {
   const config = vscode.workspace.getConfiguration()
-  await config.update(
-    'files.associations',
-    { '*.cnxml': 'xml' },
-    vscode.ConfigurationTarget.Workspace
-  )
+  const property = 'files.associations'
+  const value = config.get(property, {})
+  const target = vscode.ConfigurationTarget.Workspace
+  if (Object.keys(value).length < 1) {
+    void vscode.window.showErrorMessage(`BUG: Could not reload ${property} because it was unset.`)
+    return
+  }
+  await config.update(property, '', target)
+  await config.update(property, value, target)
 }

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -210,3 +210,12 @@ export function getErrorDiagnosticsBySource(): Map<string, Array<[vscode.Uri, vs
 
   return errorsBySource
 }
+
+export async function configureWorkspaceSettings(): Promise<void> {
+  const config = vscode.workspace.getConfiguration()
+  await config.update(
+    'files.associations',
+    { '*.cnxml': 'xml' },
+    vscode.ConfigurationTarget.Workspace
+  )
+}


### PR DESCRIPTION
This is one part of a quick solution to our GitPod problems. There might be a more permanent solution available; however, I have not found one. 

With this change, activating POET will cause vscode to reload the settings.json file. This should fix file associations not working correctly.