### PR TITLE
:art: kaizen: Only write XSD files when in a book repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ For debugging, open the webview developer tools by opening the command pallete a
 
 ### Running Tests
 
+Many tests are written to run using the [jest](https://jestjs.io) test runner and can be debugged using the VSCode debugger. To enable this feature, follow the instructions to set the [Auto-Attach setting in VSCode](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_auto-attach) and then run `npm run test:unit` or `npm run test:unit:watch`.
+
 #### Client Tests
 
 The tests for client require running the `npm run build` script beforehand. The client tests can be run via command line as follows:

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,9 +1,11 @@
+import path from 'path'
+import fs from 'fs'
 import vscode from 'vscode'
 import { LanguageClient } from 'vscode-languageclient/node'
 import { pushContent, tagContent } from './push-content'
 import { TocEditorPanel } from './panel-toc-editor'
 import { CnxmlPreviewPanel } from './panel-cnxml-preview'
-import { expect, ensureCatch, launchLanguageServer, populateXsdSchemaFiles } from './utils'
+import { expect, ensureCatch, launchLanguageServer, populateXsdSchemaFiles, getRootPathUri } from './utils'
 import { OpenstaxCommand } from './extension-types'
 import { ExtensionHostContext, Panel, PanelManager } from './panel'
 import { ImageManagerPanel } from './panel-image-manager'
@@ -37,7 +39,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
   expect(process.env.GITPOD_HOST != null && process.env.EDITOR?.includes('code') === false ? undefined : true, 'You seem to be running the Theia editor. Change your Settings in your profile')
 
   client = languageServerLauncher(context)
-  await populateXsdSchemaFiles(resourceRootDir)
+
+  // If this is not a book repo then don't bother writing the XSD files
+  const workspaceRoot = getRootPathUri()
+  if (workspaceRoot !== null && fs.existsSync(path.join(workspaceRoot.fsPath, 'META-INF/books.xml'))) {
+    await populateXsdSchemaFiles(resourceRootDir)
+  }
+
   await client.onReady()
 
   // It is a logic error for anything else to listen to this event from the client.


### PR DESCRIPTION
If you have POET installed, it should only create XSD files in book repositories.

Otherwise it just litters every workspace you open. For example, see the files tab in [this PR](https://github.com/openstax/content-manager-approved-books/pull/118)