### PR TITLE
Add book-shrinker CLI command

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -32,10 +32,24 @@ Validation responses can either be a set of Errors with source line information 
 
 # Demo commandline validator
 
-To show/verify that the model works outside the language server, there is a CLI script that can validate a book repository.
+To show/verify that the model works outside the language server, here are a couple useful CLI scripts:
+
+## Lint a book and find broken redirects
 
 To run it:
 
 ```bash
-npx ts-node@10.1.0 ./src/model/_cli.ts /path/to/book/repo /path/to/another/book/repo
+npx ts-node@10.1.0 ./src/model/_cli.ts lint /path/to/book/repo /path/to/another/book/repo
+```
+
+
+## Create a smaller book
+
+Specify which books and which items in the ToC to keep (chapters/Pages, 0-indexed) and this will delete unused images, pages, and books while keeping the repo valid.
+
+**Note:** If you specify a Page that links to another book, that Page will be included in the set of pages that are kept, even if it is in another book.
+
+```bash
+# Keep the Preface and Chapter 3 of precalc and the Chapter 10 Introduction in Algebra&Trig
+npx ts-node@10.1.0 ./src/model/_cli.ts shrink /path/to/osbooks-college-algebra-bundle precalculus-2e:0,3 algebra-and-trigonometry-2e:10.0
 ```

--- a/server/src/model/_cli.ts
+++ b/server/src/model/_cli.ts
@@ -5,20 +5,27 @@
 // -------------------------
 // How to run:
 //
-// npx ts-node@10.1.0 ./_cli.ts /path/to/book/repo
+// npx ts-node@10.1.0 ./_cli.ts lint /path/to/book/repo
+// npx ts-node@10.1.0 ./_cli.ts shrink /path/to/book/repo bookslug:0,9.0,9.7 bookslug2:13.0
 //
 // (10.2 has a bug: https://github.com/TypeStrong/ts-node/issues/1426)
 // -------------------------
 
+import { DOMParser, XMLSerializer } from 'xmldom'
 import http from 'http' // easier to use node-fetch but didn't want to add a dependency
 import https from 'https'
 import fs from 'fs'
 import path from 'path'
 import I from 'immutable'
-import { PathHelper } from './utils'
+import { expectValue, PathHelper, select, TocNodeKind } from './utils'
 import { Bundle } from './bundle'
 import { Fileish } from './fileish'
-import { PageLinkKind } from './page'
+import { PageLinkKind, PageNode } from './page'
+import { BookNode, TocNodeWithRange, TocPageWithRange, TocSubbookWithRange } from './book'
+import { ResourceNode } from './resource'
+import { removeNode, writeBookToc } from '../model-manager'
+import { BookRootNode, BookToc, ClientTocNode } from '../../../common/src/toc'
+import { fromBook, IdMap } from '../book-toc-utils'
 
 console.log('WARN: Manually setting NODE_ENV=production so we get nicer error messages')
 process.env.NODE_ENV = 'production'
@@ -40,18 +47,22 @@ const pathHelper: PathHelper<string> = {
   canonicalize: (x) => x
 }
 
-;(async function () {
-  const bookDirs = process.argv.length >= 3 ? process.argv.slice(2) : [process.cwd()]
+function loadRepo(repoPath: string) {
+  const bundle = new Bundle(pathHelper, repoPath)
+  let nodesToLoad = I.Set<Fileish>()
+  do {
+    nodesToLoad = bundle.allNodes.flatMap(n => n.validationErrors.nodesToLoad).filter(n => !n.isLoaded && n.validationErrors.errors.size === 0)
+    console.log('Loading', nodesToLoad.size, 'file(s)...')
+    nodesToLoad.forEach(loadNode)
+  } while (nodesToLoad.size > 0)
+  return bundle
+}
+
+async function lint(bookDirs: string[]) {
   let errorCount = 0
   for (const rootPath of bookDirs) {
     console.log('Validating', toRelPath(rootPath))
-    const bundle = new Bundle(pathHelper, rootPath)
-    let nodesToLoad = I.Set<Fileish>()
-    do {
-      nodesToLoad = bundle.allNodes.flatMap(n => n.validationErrors.nodesToLoad).filter(n => !n.isLoaded && n.validationErrors.errors.size === 0)
-      console.log('Loading', nodesToLoad.size, 'file(s)...')
-      nodesToLoad.forEach(loadNode)
-    } while (nodesToLoad.size > 0)
+    const bundle = loadRepo(rootPath)
 
     console.log('')
     console.log('This directory contains:')
@@ -135,4 +146,176 @@ const pathHelper: PathHelper<string> = {
   }
   await sleep(10 * 1000)
   process.exit(errorCount)
+}
+
+function recFindLeafPages(acc: TocPageWithRange[], node: TocSubbookWithRange) {
+  node.children.forEach(c => {
+    if (c.type === TocNodeKind.Page) {
+      acc.push(c)
+    } else {
+      recFindLeafPages(acc, c)
+    }
+  })
+}
+
+function traverse(node: BookNode|TocNodeWithRange, indexes: number[]): TocPageWithRange[] {
+  if (node instanceof BookNode) {
+    return traverse(node.toc[indexes[0]], indexes.slice(1))
+  } else if (node.type === TocNodeKind.Page) {
+    if (indexes.length !== 0) { throw new Error(`Encountered a Page earlier than expected. The ToC indexes indicate we should keep going but the ToC tree has already arrived at this page: '${node.page.absPath}'`) }
+    return [node]
+  } else {
+    if (indexes.length === 0) {
+      // keep this whole Chapter/Unit
+      const acc: TocPageWithRange[] = []
+      recFindLeafPages(acc, node)
+      return acc
+    } else {
+      return traverse(node.children[indexes[0]], indexes.slice(1))
+    }
+  }
+}
+
+/* Returns true if this node has nothing worth keeping (trimMe) */
+function trimNodes(node: ClientTocNode|BookToc, keepPages: Set<PageNode>): boolean {
+  if (node.type === TocNodeKind.Page) {
+    const hasKeeper = [...keepPages].find(n => n.absPath === node.value.absPath) !== undefined
+    return !hasKeeper
+  } else {
+    const pendingRemovals = new Set<ClientTocNode>()
+    let children: ClientTocNode[] = []
+    if (node.type === BookRootNode.Singleton) {
+      children = node.tocTree
+    } else {
+      children = node.children
+    }
+    children.forEach(c => {
+      if (trimNodes(c, keepPages)) {
+        pendingRemovals.add(c)
+      }
+    })
+    for (const r of pendingRemovals) {
+      removeNode(node, r)
+    }
+
+    // node.children is rewritten inside removeNode() so re-get it
+    if (node.type === BookRootNode.Singleton) {
+      children = node.tocTree
+    } else {
+      children = node.children
+    }
+
+    return children.length === 0
+  }
+}
+interface MinDefinition {
+  slug: string
+  sections: number[][]
+}
+
+function pageAccumulator(acc: Set<PageNode>, page: PageNode) {
+  if (!acc.has(page)) {
+    acc.add(page)
+    page.pageLinks.forEach(l => {
+      if (l.type === PageLinkKind.PAGE || l.type === PageLinkKind.PAGE_ELEMENT) {
+        pageAccumulator(acc, l.page)
+      }
+    })
+  }
+}
+
+async function shrink(repoDir: string, entries: MinDefinition[]) {
+  const keepBooks = new Set<BookNode>()
+  const keepPages = new Set<PageNode>()
+  const keepResources = new Set<ResourceNode>()
+  const bundle = loadRepo(repoDir)
+
+  // Load up the initial dependencies (these will be Pages)
+  entries.forEach(entry => {
+    const book = expectValue(bundle.books.find(b => b.slug === entry.slug), `Could not find book with slug '${entry.slug}'`)
+    const pages = entry.sections.map(s => traverse(book, s)).flat()
+    keepBooks.add(book)
+    pages.forEach(p => pageAccumulator(keepPages, p.page))
+  })
+  keepPages.forEach(p => {
+    p.resources.forEach(r => keepResources.add(r))
+    // Add any books whose pages are not in one of the books that have already been selected
+    let isInABook = false
+    keepBooks.forEach(b => {
+      if (b.pages.contains(p)) {
+        isInABook = true
+      }
+    })
+    if (!isInABook) {
+      // Find a book that it is in and add it to ourBooks
+      bundle.books.forEach(b => {
+        if (b.pages.contains(p)) {
+          keepBooks.add(b)
+        }
+      })
+    }
+  })
+  // Finally! We are ready to delete everything that is not in our keep set.
+  // First, let's update the model with a simplified ToC for each book
+  const tocIdMap = new IdMap<string, TocSubbookWithRange|PageNode>((v) => {
+    return 'itdoesnotmatter'
+  })
+  for (const b of keepBooks) {
+    const bookToc = fromBook(tocIdMap, b)
+    trimNodes(bookToc, keepPages)
+    await writeBookToc(b, bookToc)
+  }
+
+  // If the books have shrunk, then update the META-INF/books.xml file
+  if (bundle.books.size !== keepBooks.size) {
+    const keepSlugs = new Set([...keepBooks].map(b => b.slug))
+    // Just parse the XML because we're lazy. Or maybe it's less work to generate new XML (minus the collection id)
+    const metainfStr = fs.readFileSync(bundle.absPath, 'utf-8')
+    const doc = new DOMParser().parseFromString(metainfStr, 'text/xml')
+
+    const bookEls = [...select('/bk:container/bk:book', doc) as Element[]]
+    bookEls.forEach(el => {
+      if (!keepSlugs.has(expectValue(el.getAttribute('slug'), 'BUG: slug attribute is missing on book element'))) {
+        expectValue(el.parentNode, 'BUG: the book element clearly has a parent element').removeChild(el)
+      }
+    })
+
+    const serailizedXml = new XMLSerializer().serializeToString(doc)
+    fs.writeFileSync(bundle.absPath, serailizedXml)
+  }
+
+  const filesToDelete = I.Set<Fileish>()
+    .union(bundle.allBooks.all.subtract(I.Set(keepBooks)))
+    .union(bundle.allPages.all.subtract(I.Set(keepPages)))
+    .union(bundle.allResources.all.subtract(I.Set(keepResources)))
+  console.log('Deleting files:', filesToDelete.size)
+  filesToDelete.forEach(f => fs.unlinkSync(f.absPath))
+}
+
+;(async function () {
+  switch (process.argv[2]) {
+    case 'lint': {
+      const bookDirs = process.argv.length >= 4 ? process.argv.slice(3) : [process.cwd()]
+      await lint(bookDirs)
+      break
+    }
+    case 'shrink': {
+      const repoDir = process.argv[3]
+      const args = process.argv.slice(4)
+      const entries = args.map(entry => {
+        const [slug, sectionsStr] = entry.split(':')
+        const sections1 = sectionsStr.split(',')
+        const sections = sections1.map(s => s.split('.').map(nStr => Number.parseInt(nStr)))
+        return { slug, sections }
+      })
+      await shrink(repoDir, entries)
+      break
+    }
+    default: {
+      console.log(`Unsupported command '${process.argv[2]}'. Expected one of 'lint' or 'shrink'`)
+      console.log('Help: specify the command followed by arguments:')
+      console.log('./_cli.ts lint /path/to/book/repo')
+      console.log('./_cli.ts shrink /path/to/book/repo bookslug:0,9.0,9.7 bookslug2:13.0')
+    }
+  }
 })().then(null, (err) => { throw err })


### PR DESCRIPTION
When working on a large book it is often useful to create a smaller book, usually a chapter or just a couple of Pages.

Other approaches usually fail to account for the following which this PR handles:

- keeping images that are in the desired Pages
- keeping Pages that are linked to from desired Pages
- keeping Books from the Pages added in the previous bullet item
