### PR TITLE
Change Tag Content to Build in CORGI

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       },
       {
         "command": "openstax.tagContent",
-        "title": "Tag Content",
+        "title": "Build in CORGI",
         "category": "Openstax"
       },
       {
@@ -109,7 +109,7 @@
     "viewsWelcome": [
       {
         "view": "openstax-controls",
-        "contents": "[Open ToC Editor](command:openstax.showTocEditor)\n[Push Content](command:openstax.pushContent)\n[Tag Content](command:openstax.tagContent)"
+        "contents": "[Open ToC Editor](command:openstax.showTocEditor)\n[Push Content](command:openstax.pushContent)\n[Build in CORGI](command:openstax.tagContent)"
       }
     ],
     "menus": {


### PR DESCRIPTION
Now using 7 char short hash for tags instead of release/release candidate.

The move to using short hashes for tags was desirable, but not required, because short hashes have more implicit meaning.

## Question
Should there be a way to build a commit from POET more than once?

It looks like it was possible to create a release and a release candidate tag for the same commit. With these changes, you can only build a commit from POET once. This could become frustrating if someone wants to rebuild a commit to test pipeline fixes/changes. Of course, rebuilding from the CORGI UI is always an option, but it adds an extra step.