### PR TITLE
1519: use public git api for tagging

### DIFF
--- a/client/src/git-api/git.d.ts
+++ b/client/src/git-api/git.d.ts
@@ -139,6 +139,14 @@ export interface CommitOptions {
   requireUserConfig?: boolean
 }
 
+export interface FetchOptions {
+  remote?: string
+  ref?: string
+  all?: boolean
+  prune?: boolean
+  depth?: number
+}
+
 export interface BranchQuery {
   readonly remote?: boolean
   readonly pattern?: string
@@ -164,6 +172,7 @@ export interface Repository {
   show: (ref: string, path: string) => Promise<string>
   getCommit: (ref: string) => Promise<Commit>
 
+  add: (paths: string[]) => Promise<void>
   clean: (paths: string[]) => Promise<void>
 
   apply: (patch: string, reverse?: boolean) => Promise<void>
@@ -185,6 +194,9 @@ export interface Repository {
 
   getMergeBase: (ref1: string, ref2: string) => Promise<string>
 
+  tag: (name: string, upstream: string) => Promise<void>
+  deleteTag: (name: string) => Promise<void>
+
   status: () => Promise<void>
   checkout: (treeish: string) => Promise<void>
 
@@ -192,7 +204,7 @@ export interface Repository {
   removeRemote: (name: string) => Promise<void>
   renameRemote: (name: string, newName: string) => Promise<void>
 
-  fetch: (remote?: string, ref?: string, depth?: number) => Promise<void>
+  fetch: ((options?: FetchOptions) => Promise<void>) & ((remote?: string, ref?: string, depth?: number) => Promise<void>)
   pull: (unshallow?: boolean) => Promise<void>
   push: (remoteName?: string, branchName?: string, setUpstream?: boolean, force?: ForcePushMode) => Promise<void>
 
@@ -215,6 +227,12 @@ export interface RemoteSourceProvider {
   getRemoteSources: (query?: string) => ProviderResult<RemoteSource[]>
   getBranches?: (url: string) => ProviderResult<string[]>
   publishRepository?: (repository: Repository) => Promise<void>
+}
+
+export interface RemoteSourcePublisher {
+  readonly name: string
+  readonly icon?: string // codicon name
+  publishRepository: (repository: Repository) => Promise<void>
 }
 
 export interface Credentials {
@@ -251,6 +269,7 @@ export interface API {
   init: (root: Uri) => Promise<Repository | null>
   openRepository: (root: Uri) => Promise<Repository | null>
 
+  registerRemoteSourcePublisher: (publisher: RemoteSourcePublisher) => Disposable
   registerRemoteSourceProvider: (provider: RemoteSourceProvider) => Disposable
   registerCredentialsProvider: (provider: CredentialsProvider) => Disposable
   registerPushErrorHandler: (handler: PushErrorHandler) => Disposable

--- a/client/src/push-content.ts
+++ b/client/src/push-content.ts
@@ -352,7 +352,7 @@ export const tagContent = async (): Promise<void> => {
   if (tag === undefined) { return }
 
   try {
-    await (repo as any)._repository.tag(tag) // when VSCode API is updated -> await repo.tag(tag)
+    await repo.tag(tag, 'Build in CORGI')
   } catch (err) {
     const e = err as GitError
     const message: string = e.gitErrorCode === undefined ? e.message : /* istanbul ignore next */ e.gitErrorCode

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -934,9 +934,7 @@ suite('Push Button Test Suite', function (this: Suite) {
       fetch: fetchStub,
       diffWithHEAD: diffWithHEADStub,
       push: pushStub,
-      _repository: {
-        tag: tagStub
-      }
+      tag: tagStub
     } as any as Repository
 
     sinon.stub(pushContent, 'getRepo').returns(stubRepo)


### PR DESCRIPTION
I updated the git definition to the current version and updated `tagContent`, based on [this createTag implementation](https://github.com/microsoft/vscode/blob/a8482cf68441dc042ccf3679c5da65ec4ed4fb51/extensions/git/src/commands.ts#L1956), to use the public api for tagging.