### PR TITLE
Find all orphan files in a book repo

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -42,6 +42,14 @@ To run it:
 npx ts-node@10.1.0 ./src/model/_cli.ts lint /path/to/book/repo /path/to/another/book/repo
 ```
 
+## Find orphaned files
+
+To run it:
+
+```bash
+npx ts-node@10.1.0 ./src/model/_cli.ts orphans /path/to/book/repo /path/to/another/book/repo
+```
+
 
 ## Create a smaller book
 


### PR DESCRIPTION
This lists all orphan files in a repository.

Example treating the POET repo as a book:

```
$ npx ts-node@10.1.0 ./server/src/model/_cli.ts orphans . | grep -v node_modules   # ignore the node_modules files
Validating 
Loading 1 file(s)...

This directory contains:
  Books: 1
  Pages: 1
  Images: 0
Found orphans 37361

.../client/static/xsd/ns1.xsd
.../package-lock.json
...
```