### PR TITLE
fix webview disposal problems

### DIFF
--- a/client/specs/extension.spec.ts
+++ b/client/specs/extension.spec.ts
@@ -106,7 +106,7 @@ describe('Extension', () => {
         const pm = extensions[OpenstaxCommand.SHOW_CNXML_PREVIEW] as PanelManager<CnxmlPreviewPanel>
         const panel1 = pm.revealOrNew()
         const panel = (panel1 as any).panel as WebviewPanel // `.panel` is a protected field
-        expect(panel.webview.html.includes('No resource available to preview')).toBeTruthy()
+        expect(panel.webview.html).toEqual(expect.stringContaining('No resource available to preview'))
       })
 
       it('show cnxml preview with a file open', async () => {
@@ -134,7 +134,7 @@ describe('Extension', () => {
         const pm = extensions[OpenstaxCommand.SHOW_CNXML_PREVIEW] as PanelManager<CnxmlPreviewPanel>
         const panel1 = pm.revealOrNew()
         const panel = (panel1 as any).panel as WebviewPanel // `.panel` is a protected field
-        expect(panel.webview.html.includes('<html')).toBeTruthy()
+        expect(panel.webview.html).toEqual(expect.stringContaining('<html'))
       })
     })
   })

--- a/client/specs/utils.spec.ts
+++ b/client/specs/utils.spec.ts
@@ -64,13 +64,13 @@ describe('tests with sinon', () => {
       // eslint-disable-next-line no-template-curly-in-string
       const html = '<document><base href="${BASE_URI}"/></document>'
       const modified = addBaseHref(webview, resource, html)
-      expect(modified.includes('vscode-webview')).toBe(true)
+      expect(modified).toEqual(expect.stringContaining('vscode-webview'))
     })
     it('fixResourceReferences relative', () => {
       const resourceRootDir = '/fake/path'
       const html = '<document><a href="./media/some-image.jpg"></a></document>'
       const modified = fixResourceReferences(webview, html, resourceRootDir)
-      expect(modified.includes('vscode-webview')).toBe(true)
+      expect(modified).toEqual(expect.stringContaining('vscode-webview'))
     })
     it('fixResourceReferences non-relative', () => {
       const resourceRootDir = '/fake/path'
@@ -82,7 +82,7 @@ describe('tests with sinon', () => {
       // eslint-disable-next-line no-template-curly-in-string
       const html = '<document><meta content="${WEBVIEW_CSPSOURCE}"</meta></document>'
       const modified = fixCspSourceReferences(webview, html)
-      expect(modified.includes('vscode-webview')).toBe(true)
+      expect(modified).toEqual(expect.stringContaining('vscode-webview'))
     })
     it('injectEnsuredMessages no body is noop', () => {
       const html = '<html></html>'
@@ -91,8 +91,8 @@ describe('tests with sinon', () => {
     it('injectEnsuredMessages injects messages', () => {
       const html = '<html><body></body></html>'
       const result = Panel.prototype.injectInitialState(html, { test: 'abc' })
-      expect(result.includes('script')).toBe(true)
-      expect(result.includes('{"test":"abc"}')).toBe(true)
+      expect(result).toEqual(expect.stringContaining('script'))
+      expect(result).toEqual(expect.stringContaining('{"test":"abc"}'))
     })
   })
 

--- a/client/src/panel-cnxml-preview.ts
+++ b/client/src/panel-cnxml-preview.ts
@@ -152,7 +152,9 @@ export class CnxmlPreviewPanel extends Panel<PanelIncomingMessage, ScrollToLineO
       return
     }
     const bindingChanged = resource?.fsPath !== this.resourceBinding?.fsPath
-    this.rebindToResource(resource)
+    if (bindingChanged) {
+      this.rebindToResource(resource)
+    }
     const activeEditor = vscode.window.activeTextEditor
     if (activeEditor != null) {
       await this.scrollToRangeStartOfEditor(activeEditor)

--- a/client/src/panel-cnxml-preview.ts
+++ b/client/src/panel-cnxml-preview.ts
@@ -152,7 +152,7 @@ export class CnxmlPreviewPanel extends Panel<PanelIncomingMessage, ScrollToLineO
       return
     }
     const bindingChanged = resource?.fsPath !== this.resourceBinding?.fsPath
-    if (bindingChanged) {
+    if (bindingChanged || this.resourceBinding == null) {
       this.rebindToResource(resource)
     }
     const activeEditor = vscode.window.activeTextEditor

--- a/client/src/panel-cnxml-preview.ts
+++ b/client/src/panel-cnxml-preview.ts
@@ -202,6 +202,9 @@ export class CnxmlPreviewPanel extends Panel<PanelIncomingMessage, ScrollToLineO
   private rebindToResource(resource: vscode.Uri | null): void {
     const oldBinding = this.resourceBinding
     this.resourceBinding = resource
+    if (this.disposed()) {
+      return
+    }
     if (this.resourceBinding == null) {
       this.panel.webview.html = rawTextHtml('No resource available to preview')
       return

--- a/client/src/panel-cnxml-preview.ts
+++ b/client/src/panel-cnxml-preview.ts
@@ -83,6 +83,9 @@ export class CnxmlPreviewPanel extends Panel<PanelIncomingMessage, ScrollToLineO
     this._onDidInnerPanelReload = new vscode.EventEmitter()
     void ensureCatchPromise(this.tryRebindToActiveResource(true))
     this.registerDisposable(vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (editor?.document.uri.fsPath === this.resourceBinding?.fsPath) {
+        return
+      }
       void ensureCatchPromise(this.tryRebindToActiveResource(false))
     }))
     this.registerDisposable(this.context.events.onDidChangeWatchedFiles(ensureCatch(async () => {
@@ -152,9 +155,7 @@ export class CnxmlPreviewPanel extends Panel<PanelIncomingMessage, ScrollToLineO
       return
     }
     const bindingChanged = resource?.fsPath !== this.resourceBinding?.fsPath
-    if (bindingChanged || this.resourceBinding == null) {
-      this.rebindToResource(resource)
-    }
+    this.rebindToResource(resource)
     const activeEditor = vscode.window.activeTextEditor
     if (activeEditor != null) {
       await this.scrollToRangeStartOfEditor(activeEditor)

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -394,7 +394,7 @@ suite('Extension Test Suite', function (this: Suite) {
     await panelBindingChanged
     const refreshCount = rebindingStub.callCount
     await watchedFilesSpy.getCall(0).args[0]()
-    assert.strictEqual(rebindingStub.callCount, refreshCount)
+    assert.strictEqual(rebindingStub.callCount, refreshCount + 1)
   })
   test('cnxml preview throws upon unexpected message', async () => {
     const panel = new CnxmlPreviewPanel({ bookTocs: EMPTY_BOOKS_AND_ORPHANS, resourceRootDir, client: createMockClient(), events: createMockEvents().events })

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -394,7 +394,7 @@ suite('Extension Test Suite', function (this: Suite) {
     await panelBindingChanged
     const refreshCount = rebindingStub.callCount
     await watchedFilesSpy.getCall(0).args[0]()
-    assert.strictEqual(rebindingStub.callCount, refreshCount + 1)
+    assert.strictEqual(rebindingStub.callCount, refreshCount)
   })
   test('cnxml preview throws upon unexpected message', async () => {
     const panel = new CnxmlPreviewPanel({ bookTocs: EMPTY_BOOKS_AND_ORPHANS, resourceRootDir, client: createMockClient(), events: createMockEvents().events })


### PR DESCRIPTION
When a user opens and then closes a Preview panel they may get an error because POET was trying to communicate with a disposed webview.

This checks if the webview has been disposed before trying to change the webview.