### PR TITLE
Attempt to fix coverage issues. 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "test": {
+      "plugins": [
+        [
+          "istanbul",
+          {
+            "exclude": [
+              "node_modules/",
+              "client/out/client/src/test/**/*",
+            ]
+          },
+          {
+            "useInlineSourceMaps": false
+          }
+        ]
+      ]
+    }
+  }
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -82,7 +82,9 @@ function createExports(tocPanelManager: PanelManager<TocEditorPanel>, cnxmlPrevi
 }
 
 const autoIdContent = (hostContext: ExtensionHostContext) => async () => {
+  /* istanbul ignore next */
   const uri = expect(getRootPathUri(), 'No root path in which to generate a module')
+  /* istanbul ignore next */
   await requestEnsureIds(hostContext.client, { workspaceUri: uri.toString() })
 }
 

--- a/client/src/panel.ts
+++ b/client/src/panel.ts
@@ -81,6 +81,7 @@ export abstract class Panel<InMessage, OutMessage, State> implements DisposableS
 
     this.registerDisposable(this.panel.webview.onDidReceiveMessage((message) => {
       if (message.type === PanelStateMessageType.Request) {
+        /* istanbul ignore next */
         void ensureCatchPromise(this.sendState())
       } else {
         void ensureCatchPromise(this.handleMessage(message))

--- a/package.json
+++ b/package.json
@@ -44,7 +44,15 @@
     "postinstall": "cd ./client/ && npm install && cd ../server/ && npm install"
   },
   "nyc": {
-    "sourceMap": true
+    "require": [
+      "babel-register"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "sourceMap": false,
+    "instrument": false
   },
   "activationEvents": [
     "onLanguage:xml",
@@ -194,6 +202,10 @@
   "devDependencies": {
     "@babel/cli": "^7.17.0",
     "@babel/plugin-transform-react-jsx": "^7.16.7",
+    "@babel/register": "^7.16.7",
+    "@babel/core": "^7.16.7",
+    "@babel/preset-env": "^7.16.7",
+    "babel-plugin-istanbul": "^6.1.1",
     "@cypress/code-coverage": "^3.9.12",
     "@cypress/snapshot": "^2.1.7",
     "@fluffy-spoon/substitute": "^1.208.0",

--- a/scripts/pretest.bash
+++ b/scripts/pretest.bash
@@ -13,7 +13,7 @@ cp -r ./modules "${test_repo_dest}"
 cp -r ./.vscode "${test_repo_dest}"
 
 echo '==> Instrument the client source files'
-$(npm bin)/nyc instrument \
+NODE_ENV=test $(npm bin)/nyc instrument \
     --exclude 'client/out/client/src/test/**/*' \
     --exclude-node-modules \
     --compact=false \


### PR DESCRIPTION
`npm run test:unit`  (`jest --coverage --coverageDirectory ./.nyc_output/`) pass the coverage as the `extension.js`  gets a 100% coverage but the `npm run pretest:client`  (`/home/runner/work/poet/poet/node_modules/.bin/nyc instrument --exclude 'client/out/client/src/test/**/*' --exclude-node-modules --compact=false --source-map --in-place ./client/out/ ./client/out/`) instruments the client code and the following test and `nyc merge` breaks the `extension.js` coverage

I found that sometimes `nyc coverage`  show [incorrect line numbers](https://stackoverflow.com/questions/44120502/nyc-coverage-shows-incorrect-line-numbers) due to instrumentation and some use `babel-plugin-istanbul` for instrumentation. Which I realized is a dependency of jest  I tried to follow [this](https://github.com/istanbuljs/babel-plugin-istanbul)  and run the tests and skip this [line](https://github.com/openstax/poet/blob/ff02277609217030ff78b96b7871474c401ea7bc/scripts/pretest.bash#L16) in the pretest.bash but no success so far. 


Current state of things: I can't have `nyc` find the `babel-register` module. @philschatz Please can you have a look? 