### PR TITLE
Move test helpers into separate file so tests do not rerun

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:fix": "npm run lint -- --fix",
     "pretest:cypress": "npm run build && ./scripts/pre-cypress.bash",
     "test:cypress": "cypress run --quiet --config-file ./cypress.json",
+    "pretest:unit": "jest --clearCache",
     "test:unit": "jest --coverage --coverageDirectory ./.nyc_output/",
     "test:unit:watch": "npm run test:unit -- --watch --updateSnapshot",
     "posttest:unit": "mv ./.nyc_output/coverage-final.json ./.nyc_output/coverage-jest.json",

--- a/server/src/fix-document-ids.spec.ts
+++ b/server/src/fix-document-ids.spec.ts
@@ -4,8 +4,7 @@ import * as xpath from 'xpath-ts'
 import { DOMParser, XMLSerializer } from 'xmldom'
 import { fixDocument, idFixer, padLeft } from './fix-document-ids'
 import mockfs from 'mock-fs'
-import { pageMaker } from './model/page.spec'
-import { bundleMaker } from './model/bundle.spec'
+import { bundleMaker, pageMaker } from './model/spec-helpers'
 
 describe('Element ID creation', () => {
   describe('fixDocument', () => {

--- a/server/src/fix-document-ids.spec.ts
+++ b/server/src/fix-document-ids.spec.ts
@@ -4,7 +4,7 @@ import * as xpath from 'xpath-ts'
 import { DOMParser, XMLSerializer } from 'xmldom'
 import { fixDocument, idFixer, padLeft } from './fix-document-ids'
 import mockfs from 'mock-fs'
-import { bundleMaker, pageMaker } from './model/spec-helpers'
+import { bundleMaker, pageMaker } from './model/spec-helpers.spec'
 
 describe('Element ID creation', () => {
   describe('fixDocument', () => {

--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -10,7 +10,7 @@ import xmlFormat from 'xml-formatter'
 import { expectValue, Opt, join, PathKind } from './model/utils'
 import { Bundle, BundleValidationKind } from './model/bundle'
 import { ModelManager } from './model-manager'
-import { first, FS_PATH_HELPER, ignoreConsoleWarnings, loadSuccess, makeBundle } from './model/util.spec'
+import { first, FS_PATH_HELPER, ignoreConsoleWarnings, loadSuccess, makeBundle } from './model/spec-helpers'
 import { Job, JobRunner } from './job-runner'
 import { PageInfo, pageMaker } from './model/page.spec'
 

--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -10,15 +10,12 @@ import xmlFormat from 'xml-formatter'
 import { expectValue, Opt, join, PathKind } from './model/utils'
 import { Bundle, BundleValidationKind } from './model/bundle'
 import { ModelManager } from './model-manager'
-import { first, FS_PATH_HELPER, ignoreConsoleWarnings, loadSuccess, makeBundle } from './model/spec-helpers'
+import { bookMaker, bundleMaker, first, FS_PATH_HELPER, ignoreConsoleWarnings, loadSuccess, makeBundle, PageInfo, pageMaker } from './model/spec-helpers'
 import { Job, JobRunner } from './job-runner'
-import { PageInfo, pageMaker } from './model/page.spec'
 
 import { PageNode, PageValidationKind } from './model/page'
 import { TocModification, TocModificationKind, TocNodeKind } from '../../common/src/toc'
 import { BooksAndOrphans, DiagnosticSource } from '../../common/src/requests'
-import { bookMaker } from './model/book.spec'
-import { bundleMaker } from './model/bundle.spec'
 import { URI, Utils } from 'vscode-uri'
 
 ModelManager.debug = () => {} // Turn off logging

--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -10,7 +10,7 @@ import xmlFormat from 'xml-formatter'
 import { expectValue, Opt, join, PathKind } from './model/utils'
 import { Bundle, BundleValidationKind } from './model/bundle'
 import { ModelManager } from './model-manager'
-import { bookMaker, bundleMaker, first, FS_PATH_HELPER, ignoreConsoleWarnings, loadSuccess, makeBundle, PageInfo, pageMaker } from './model/spec-helpers'
+import { bookMaker, bundleMaker, first, FS_PATH_HELPER, ignoreConsoleWarnings, loadSuccess, makeBundle, PageInfo, pageMaker } from './model/spec-helpers.spec'
 import { Job, JobRunner } from './job-runner'
 
 import { PageNode, PageValidationKind } from './model/page'

--- a/server/src/model/book.spec.ts
+++ b/server/src/model/book.spec.ts
@@ -1,5 +1,5 @@
 import { BookValidationKind } from './book'
-import { expectErrors, first, loadSuccess, makeBundle } from './util.spec'
+import { expectErrors, first, loadSuccess, makeBundle } from './spec-helpers'
 import { pageMaker } from './page.spec'
 
 describe('Book validations', () => {

--- a/server/src/model/book.spec.ts
+++ b/server/src/model/book.spec.ts
@@ -1,13 +1,12 @@
 import { BookValidationKind } from './book'
-import { expectErrors, first, loadSuccess, makeBundle } from './spec-helpers'
-import { pageMaker } from './page.spec'
+import { bookMaker, BookMakerTocNode, expectErrors, first, loadSuccess, makeBundle, pageMaker } from './spec-helpers'
 
 describe('Book validations', () => {
   it(BookValidationKind.DUPLICATE_CHAPTER_TITLE.title, () => {
     const bundle = makeBundle()
     const book = first(loadSuccess(bundle).books)
     const chapterTitle = 'Kinematics'
-    const toc: TocNode[] = [
+    const toc: BookMakerTocNode[] = [
       { title: chapterTitle, children: [] },
       { title: chapterTitle, children: [] }
     ]
@@ -24,7 +23,7 @@ describe('Book validations', () => {
   it(BookValidationKind.DUPLICATE_PAGE.title, () => {
     const bundle = makeBundle()
     const book = first(loadSuccess(bundle).books)
-    const toc: TocNode[] = [
+    const toc: BookMakerTocNode[] = [
       { title: 'Chapter 1', children: ['m00001'] },
       { title: 'Chapter 2', children: ['m00001'] }
     ]
@@ -34,50 +33,3 @@ describe('Book validations', () => {
     expectErrors(book, [BookValidationKind.DUPLICATE_PAGE, BookValidationKind.DUPLICATE_PAGE])
   })
 })
-
-type TocNode = {
-  title: string
-  children: TocNode[]
-} | string
-interface BookMakerInfo {
-  title?: string
-  slug?: string
-  uuid?: string
-  language?: string
-  licenseUrl?: string
-  toc?: TocNode[]
-}
-export function bookMaker(info: BookMakerInfo) {
-  const i = {
-    title: info.title ?? 'test collection',
-    slug: info.slug ?? 'slug1',
-    langauge: info.language ?? 'xxyyzz',
-    licenseUrl: info.licenseUrl ?? 'http://creativecommons.org/licenses/by/4.0/',
-    uuid: info.uuid ?? '00000000-0000-4000-0000-000000000000',
-    toc: info.toc ?? []
-  }
-  return `<col:collection xmlns:col="http://cnx.rice.edu/collxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns="http://cnx.rice.edu/collxml">
-    <col:metadata>
-      <md:title>${i.title}</md:title>
-      <md:slug>${i.slug}</md:slug>
-      <md:uuid>${i.uuid}</md:uuid>
-      <md:language>${i.langauge}</md:language>
-      <md:license url="${i.licenseUrl}"/>
-    </col:metadata>
-    <col:content>
-        ${i.toc.map(tocToString).join('\n')}
-    </col:content>
-</col:collection>`
-}
-function tocToString(node: TocNode): string {
-  if (typeof node === 'string') {
-    return `<col:module document="${node}" />`
-  } else {
-    return `<col:subcollection>
-        <md:title>${node.title}</md:title>
-        <col:content>
-            ${node.children.map(tocToString).join('\n')}
-        </col:content>
-    </col:subcollection>`
-  }
-}

--- a/server/src/model/book.spec.ts
+++ b/server/src/model/book.spec.ts
@@ -1,5 +1,5 @@
 import { BookValidationKind } from './book'
-import { bookMaker, BookMakerTocNode, expectErrors, first, loadSuccess, makeBundle, pageMaker } from './spec-helpers'
+import { bookMaker, BookMakerTocNode, expectErrors, first, loadSuccess, makeBundle, pageMaker } from './spec-helpers.spec'
 
 describe('Book validations', () => {
   it(BookValidationKind.DUPLICATE_CHAPTER_TITLE.title, () => {

--- a/server/src/model/bundle.spec.ts
+++ b/server/src/model/bundle.spec.ts
@@ -1,6 +1,6 @@
 import expect from 'expect'
 import { Bundle, BundleValidationKind } from './bundle'
-import { bundleMaker, expectErrors, first, loadSuccess, makeBundle, read } from './spec-helpers'
+import { bundleMaker, expectErrors, first, loadSuccess, makeBundle, read } from './spec-helpers.spec'
 
 describe('Bundle validations', () => {
   it(BundleValidationKind.NO_BOOKS.title, () => {

--- a/server/src/model/bundle.spec.ts
+++ b/server/src/model/bundle.spec.ts
@@ -1,27 +1,6 @@
 import expect from 'expect'
 import { Bundle, BundleValidationKind } from './bundle'
-import { expectErrors, first, loadSuccess, makeBundle, read } from './spec-helpers'
-
-interface BundleMakerInfo {
-  version?: number
-  books?: Array<string | {slug: string, href: string}>
-}
-export function bundleMaker(info: BundleMakerInfo) {
-  const i = {
-    version: info.version ?? 1,
-    books: (info.books ?? []).map(b => {
-      if (typeof b === 'string') {
-        const slug = b
-        return { slug, href: `../collections/${slug}.collection.xml` }
-      } else {
-        return b
-      }
-    })
-  }
-  return `<container xmlns="https://openstax.org/namespaces/book-container" version="1">
-${i.books.map(({ slug, href }) => `<book slug="${slug}" href="${href}" />`).join('\n')}
-</container>`
-}
+import { bundleMaker, expectErrors, first, loadSuccess, makeBundle, read } from './spec-helpers'
 
 describe('Bundle validations', () => {
   it(BundleValidationKind.NO_BOOKS.title, () => {

--- a/server/src/model/bundle.spec.ts
+++ b/server/src/model/bundle.spec.ts
@@ -1,6 +1,6 @@
 import expect from 'expect'
 import { Bundle, BundleValidationKind } from './bundle'
-import { expectErrors, first, loadSuccess, makeBundle, read } from './util.spec'
+import { expectErrors, first, loadSuccess, makeBundle, read } from './spec-helpers'
 
 interface BundleMakerInfo {
   version?: number

--- a/server/src/model/fileish.spec.ts
+++ b/server/src/model/fileish.spec.ts
@@ -1,7 +1,7 @@
 import expect from 'expect'
 import { Opt } from './utils'
 import { Fileish } from './fileish'
-import { first, FS_PATH_HELPER, makeBundle } from './util.spec'
+import { first, FS_PATH_HELPER, makeBundle } from './spec-helpers'
 
 describe('The abstract ancestor class', () => {
   let previousNodeEnv: Opt<string>

--- a/server/src/model/fileish.spec.ts
+++ b/server/src/model/fileish.spec.ts
@@ -1,7 +1,7 @@
 import expect from 'expect'
 import { Opt } from './utils'
 import { Fileish } from './fileish'
-import { first, FS_PATH_HELPER, makeBundle } from './spec-helpers'
+import { first, FS_PATH_HELPER, makeBundle } from './spec-helpers.spec'
 
 describe('The abstract ancestor class', () => {
   let previousNodeEnv: Opt<string>

--- a/server/src/model/page.spec.ts
+++ b/server/src/model/page.spec.ts
@@ -1,7 +1,7 @@
 import expect from 'expect'
 import * as path from 'path'
 import { ELEMENT_TO_PREFIX, PageNode, PageValidationKind, UNTITLED_FILE } from './page'
-import { expectErrors, first, FS_PATH_HELPER, makeBundle } from './util.spec'
+import { expectErrors, first, FS_PATH_HELPER, makeBundle } from './spec-helpers'
 
 describe('Page', () => {
   let page = null as unknown as PageNode

--- a/server/src/model/page.spec.ts
+++ b/server/src/model/page.spec.ts
@@ -1,7 +1,7 @@
 import expect from 'expect'
 import * as path from 'path'
 import { ELEMENT_TO_PREFIX, PageNode, PageValidationKind, UNTITLED_FILE } from './page'
-import { expectErrors, first, FS_PATH_HELPER, makeBundle, pageMaker } from './spec-helpers'
+import { expectErrors, first, FS_PATH_HELPER, makeBundle, pageMaker } from './spec-helpers.spec'
 
 describe('Page', () => {
   let page = null as unknown as PageNode

--- a/server/src/model/page.spec.ts
+++ b/server/src/model/page.spec.ts
@@ -1,7 +1,7 @@
 import expect from 'expect'
 import * as path from 'path'
 import { ELEMENT_TO_PREFIX, PageNode, PageValidationKind, UNTITLED_FILE } from './page'
-import { expectErrors, first, FS_PATH_HELPER, makeBundle } from './spec-helpers'
+import { expectErrors, first, FS_PATH_HELPER, makeBundle, pageMaker } from './spec-helpers'
 
 describe('Page', () => {
   let page = null as unknown as PageNode
@@ -35,38 +35,6 @@ describe('Page', () => {
       .toThrow("Expected one but found 2 results that match '//md:uuid'")
   })
 })
-
-export interface PageInfo {
-  uuid?: string
-  title?: string | null // null means omit the whole element
-  elementIds?: string[]
-  imageHrefs?: string[]
-  pageLinks?: Array<{targetPage?: string, targetId?: string, url?: string}>
-  extraCnxml?: string
-}
-export function pageMaker(info: PageInfo) {
-  const i = {
-    title: info.title !== undefined ? info.title : 'TestTitle',
-    uuid: info.uuid !== undefined ? info.uuid : '00000000-0000-4000-0000-000000000000',
-    elementIds: info.elementIds !== undefined ? info.elementIds : [],
-    imageHrefs: info.imageHrefs !== undefined ? info.imageHrefs : [],
-    pageLinks: info.pageLinks !== undefined ? info.pageLinks.map(({ targetPage, targetId, url }) => ({ targetPage, targetId, url })) : [],
-    extraCnxml: info.extraCnxml !== undefined ? info.extraCnxml : ''
-  }
-  const titleElement = i.title === null ? '' : `<title>${i.title}</title>`
-  return `<document xmlns="http://cnx.rice.edu/cnxml">
-  ${titleElement}
-  <metadata xmlns:md="http://cnx.rice.edu/mdml">
-    <md:uuid>${i.uuid}</md:uuid>
-  </metadata>
-  <content>
-${i.imageHrefs.map(href => `    <image src="${href}"/>`).join('\n')}
-${i.pageLinks.map(({ targetPage, targetId, url }) => `    <link document="${targetPage ?? ''}" target-id="${targetId ?? ''}" url="${url ?? ''}"/>`).join('\n')}
-${i.elementIds.map(id => `<para id="${id}"/>`).join('\n')}
-${i.extraCnxml}
-  </content>
-</document>`
-}
 
 describe('Page validations', () => {
   it(PageValidationKind.MISSING_RESOURCE.title, () => {

--- a/server/src/model/quarx.spec.ts
+++ b/server/src/model/quarx.spec.ts
@@ -1,7 +1,7 @@
 import expect from 'expect'
 import * as Quarx from 'quarx'
 import { TocNode, TocNodeKind } from './utils'
-import { first, loadSuccess, makeBundle, read } from './util.spec'
+import { first, loadSuccess, makeBundle, read } from './spec-helpers'
 import { bookMaker } from './book.spec'
 import { PageNode } from './page'
 

--- a/server/src/model/quarx.spec.ts
+++ b/server/src/model/quarx.spec.ts
@@ -1,8 +1,7 @@
 import expect from 'expect'
 import * as Quarx from 'quarx'
 import { TocNode, TocNodeKind } from './utils'
-import { first, loadSuccess, makeBundle, read } from './spec-helpers'
-import { bookMaker } from './book.spec'
+import { bookMaker, first, loadSuccess, makeBundle, read } from './spec-helpers'
 import { PageNode } from './page'
 
 describe('Quarx.autorun code', () => {

--- a/server/src/model/quarx.spec.ts
+++ b/server/src/model/quarx.spec.ts
@@ -1,7 +1,7 @@
 import expect from 'expect'
 import * as Quarx from 'quarx'
 import { TocNode, TocNodeKind } from './utils'
-import { bookMaker, first, loadSuccess, makeBundle, read } from './spec-helpers'
+import { bookMaker, first, loadSuccess, makeBundle, read } from './spec-helpers.spec'
 import { PageNode } from './page'
 
 describe('Quarx.autorun code', () => {

--- a/server/src/model/spec-helpers.spec.ts
+++ b/server/src/model/spec-helpers.spec.ts
@@ -6,6 +6,12 @@ import I from 'immutable'
 import { Bundle } from './bundle'
 import { Fileish, ValidationKind } from './fileish'
 
+describe('spec-helpers Dummy', () => {
+  it('trivially passes because Jest requires every spec file to have at least one test', () => {
+    expect(true).toBe(true)
+  })
+})
+
 export const REPO_ROOT = path.join(__dirname, '..', '..', '..')
 
 export const read = (filePath: string) => readFileSync(filePath, 'utf-8')

--- a/server/src/model/spec-helpers.ts
+++ b/server/src/model/spec-helpers.ts
@@ -1,0 +1,53 @@
+import expect from 'expect'
+import SinonRoot from 'sinon'
+import { readFileSync } from 'fs'
+import * as path from 'path'
+import I from 'immutable'
+import { Bundle } from './bundle'
+import { Fileish, ValidationKind } from './fileish'
+
+export const REPO_ROOT = path.join(__dirname, '..', '..', '..')
+
+export const read = (filePath: string) => readFileSync(filePath, 'utf-8')
+
+/* Copy/Pasted from ./utils.ts to remove cyclic dependency */
+interface PathHelper<T> {
+  join: (root: T, ...components: string[]) => T
+  dirname: (p: T) => T
+  canonicalize: (p: T) => T
+}
+
+export const FS_PATH_HELPER: PathHelper<string> = {
+  join: path.join,
+  dirname: path.dirname,
+  canonicalize: (x) => x
+}
+
+export function first<T>(col: I.Set<T> | I.List<T>) {
+  const f = col.toArray()[0]
+  expect(f).toBeTruthy()
+  return f
+}
+
+export const makeBundle = () => new Bundle(FS_PATH_HELPER, REPO_ROOT)
+
+export function loadSuccess<T extends Fileish>(n: T, skipInitialLoadedCheck = false, expectedErrorCount = 0) {
+  if (!skipInitialLoadedCheck) expect(n.isLoaded).toBeFalsy()
+  n.load(read(n.absPath))
+  expect(n.isLoaded).toBeTruthy()
+  expect(n.exists).toBeTruthy()
+  expect(n.validationErrors.errors.size).toBe(expectedErrorCount)
+  return n // for daisy-chaining
+}
+
+export function ignoreConsoleWarnings(fn: () => void) {
+  const warnStub = SinonRoot.stub(console, 'warn')
+  fn()
+  warnStub.restore()
+}
+
+export function expectErrors<T extends Fileish>(node: T, validationKinds: ValidationKind[]) {
+  const v = node.validationErrors
+  expect(v.nodesToLoad.size).toBe(0) // Everything should have loaded
+  expect(v.errors.toArray().map(e => e.message).sort()).toEqual(validationKinds.map(v => v.title).sort())
+}

--- a/server/src/model/util.spec.ts
+++ b/server/src/model/util.spec.ts
@@ -2,7 +2,7 @@ import expect from 'expect'
 import * as xpath from 'xpath-ts'
 import { DOMParser } from 'xmldom'
 import { calculateElementPositions } from './utils'
-import { ignoreConsoleWarnings, loadSuccess, makeBundle } from './spec-helpers'
+import { ignoreConsoleWarnings, loadSuccess, makeBundle } from './spec-helpers.spec'
 
 describe('calculateElementPositions', function () {
   it('should return start and end positions using siblings when available', () => {

--- a/server/src/model/util.spec.ts
+++ b/server/src/model/util.spec.ts
@@ -1,15 +1,8 @@
 import expect from 'expect'
-import SinonRoot from 'sinon'
-import { readFileSync } from 'fs'
-import * as path from 'path'
 import * as xpath from 'xpath-ts'
 import { DOMParser } from 'xmldom'
-import I from 'immutable'
-import { PathHelper, calculateElementPositions } from './utils'
-import { Bundle } from './bundle'
-import { Fileish, ValidationKind } from './fileish'
-
-const REPO_ROOT = path.join(__dirname, '..', '..', '..')
+import { calculateElementPositions } from './utils'
+import { ignoreConsoleWarnings, loadSuccess, makeBundle } from './spec-helpers'
 
 describe('calculateElementPositions', function () {
   it('should return start and end positions using siblings when available', () => {
@@ -80,40 +73,3 @@ describe('Bugfixes', () => {
     expect(bundle.validationErrors.errors.size).toBe(0)
   })
 })
-
-export const read = (filePath: string) => readFileSync(filePath, 'utf-8')
-
-export const FS_PATH_HELPER: PathHelper<string> = {
-  join: path.join,
-  dirname: path.dirname,
-  canonicalize: (x) => x
-}
-
-export function first<T>(col: I.Set<T> | I.List<T>) {
-  const f = col.toArray()[0]
-  expect(f).toBeTruthy()
-  return f
-}
-
-export const makeBundle = () => new Bundle(FS_PATH_HELPER, REPO_ROOT)
-
-export function loadSuccess<T extends Fileish>(n: T, skipInitialLoadedCheck = false, expectedErrorCount = 0) {
-  if (!skipInitialLoadedCheck) expect(n.isLoaded).toBeFalsy()
-  n.load(read(n.absPath))
-  expect(n.isLoaded).toBeTruthy()
-  expect(n.exists).toBeTruthy()
-  expect(n.validationErrors.errors.size).toBe(expectedErrorCount)
-  return n // for daisy-chaining
-}
-
-export function ignoreConsoleWarnings(fn: () => void) {
-  const warnStub = SinonRoot.stub(console, 'warn')
-  fn()
-  warnStub.restore()
-}
-
-export function expectErrors<T extends Fileish>(node: T, validationKinds: ValidationKind[]) {
-  const v = node.validationErrors
-  expect(v.nodesToLoad.size).toBe(0) // Everything should have loaded
-  expect(v.errors.toArray().map(e => e.message).sort()).toEqual(validationKinds.map(v => v.title).sort())
-}


### PR DESCRIPTION
Importing a test helper from a spec file caused all of the tests in that file to rerun. This made for some confusing errors.

The helpers were moved into s `.spec.ts` file because code coverage reports all non- `.spec.ts` files