### PR TITLE
:bug: stop at breakpoints when debugging

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -15,7 +15,7 @@ const extensionConfig = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'extension.bundle.js',
     libraryTarget: 'commonjs2',
-    devtoolModuleFilenameTemplate: '../../../[resource-path]'
+    devtoolModuleFilenameTemplate: '../[resource-path]'
   },
   devtool: 'source-map',
   externals: {


### PR DESCRIPTION
tiny tweak. The path to the source code was incorrect in the sourcemaps for the POET extension.

This resulted in not being able to set breakpoints in VSCode