### PR TITLE
Add MathML validator class that encapsulates math validation

### DIFF
--- a/server/src/model/external-validator.ts
+++ b/server/src/model/external-validator.ts
@@ -1,7 +1,0 @@
-import { ValidationCheck } from './fileish'
-import { PageNode } from './page'
-
-export interface ExternalValidator {
-  parseXML: (doc: Document) => void
-  getValidationChecks: (page: PageNode) => ValidationCheck[]
-}

--- a/server/src/model/external-validator.ts
+++ b/server/src/model/external-validator.ts
@@ -1,0 +1,7 @@
+import { ValidationCheck } from './fileish'
+import { PageNode } from './page'
+
+export interface ExternalValidator {
+  parseXML: (doc: Document) => void
+  getValidationChecks: (page: PageNode) => ValidationCheck[]
+}

--- a/server/src/model/mathml-validator.spec.ts
+++ b/server/src/model/mathml-validator.spec.ts
@@ -1,0 +1,32 @@
+import { MathValidationKind } from './mathml-validator'
+import { expectErrors, makeBundle, pageMaker } from './spec-helpers.spec'
+
+describe('MathML Validator', () => {
+  it('causes no errors to use valid values', () => {
+    const bundle = makeBundle()
+    const page = bundle.allPages.getOrAdd('somepage/filename')
+    const info = {
+      extraCnxml: '<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mspace width="0.5em"/></math>'
+    }
+    page.load(pageMaker(info))
+    expectErrors(page, [])
+  })
+  it(`causes ${MathValidationKind.EMPTY_MSPACE_WIDTH.title} when mspace width is empty`, () => {
+    const bundle = makeBundle()
+    const page = bundle.allPages.getOrAdd('somepage/filename')
+    const info = {
+      extraCnxml: '<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mspace width=""/></math>'
+    }
+    page.load(pageMaker(info))
+    expectErrors(page, [MathValidationKind.EMPTY_MSPACE_WIDTH])
+  })
+  it(`causes ${MathValidationKind.NEGATIVE_MSPACE_WIDTH.title} when mspace width is negative`, () => {
+    const bundle = makeBundle()
+    const page = bundle.allPages.getOrAdd('somepage/filename')
+    const info = {
+      extraCnxml: '<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mspace width="-0.2em"/></math>'
+    }
+    page.load(pageMaker(info))
+    expectErrors(page, [MathValidationKind.NEGATIVE_MSPACE_WIDTH])
+  })
+})

--- a/server/src/model/mathml-validator.ts
+++ b/server/src/model/mathml-validator.ts
@@ -1,0 +1,55 @@
+import I from 'immutable'
+import * as Quarx from 'quarx'
+
+import { ValidationCheck, ValidationKind } from './fileish'
+import { Opt, WithRange, select, calculateElementPositions, expectValue } from './utils'
+import { ExternalValidator } from './external-validator'
+import { PageNode } from './page'
+
+export class MathValidationKind extends ValidationKind {
+  static NEGATIVE_MSPACE_WIDTH = new MathValidationKind('mspace width cannot be negative')
+  static EMPTY_MSPACE_WIDTH = new MathValidationKind('mspace width cannot be empty')
+}
+
+export class MMLValidator implements ExternalValidator {
+  private readonly _mspaceWidths = Quarx.observable.box<Opt<I.Set<WithRange<string>>>>(undefined)
+
+  public parseXML(doc: Document): void {
+    const mspaceWidths = select('//m:mspace/@width', doc) as Attr[]
+    this._mspaceWidths.set(I.Set(mspaceWidths.map(attr => {
+      const width = expectValue(attr.nodeValue, 'BUG: Attribute does not have a value')
+      const mspaceNode = expectValue(attr.ownerElement, 'BUG: attributes always have a parent element')
+      const range = calculateElementPositions(mspaceNode)
+      return { range, v: width }
+    })))
+  }
+
+  public getValidationChecks(page: PageNode): ValidationCheck[] {
+    return [
+      {
+        message: MathValidationKind.NEGATIVE_MSPACE_WIDTH,
+        nodesToLoad: I.Set(),
+        fn: () => {
+          return I.Set(
+            expectValue(this._mspaceWidths.get(), `mspace not loaded [${page.absPath}]`)
+              .filter(i => {
+                const width = i.v.trim()
+                return width.length !== 0 && width[0] === '-'
+              }).map(i => i.range)
+          )
+        }
+      },
+      {
+        message: MathValidationKind.EMPTY_MSPACE_WIDTH,
+        nodesToLoad: I.Set(),
+        fn: () => {
+          return I.Set(
+            expectValue(this._mspaceWidths.get(), `mspace not loaded [${page.absPath}]`)
+              .filter(i => i.v.trim().length === 0)
+              .map(i => i.range)
+          )
+        }
+      }
+    ]
+  }
+}

--- a/server/src/model/mathml-validator.ts
+++ b/server/src/model/mathml-validator.ts
@@ -1,17 +1,15 @@
 import I from 'immutable'
 import * as Quarx from 'quarx'
 
-import { ValidationCheck, ValidationKind } from './fileish'
+import { Fileish, ValidationCheck, ValidationKind } from './fileish'
 import { Opt, WithRange, select, calculateElementPositions, expectValue } from './utils'
-import { ExternalValidator } from './external-validator'
-import { PageNode } from './page'
 
 export class MathValidationKind extends ValidationKind {
   static NEGATIVE_MSPACE_WIDTH = new MathValidationKind('mspace width cannot be negative')
   static EMPTY_MSPACE_WIDTH = new MathValidationKind('mspace width cannot be empty')
 }
 
-export class MMLValidator implements ExternalValidator {
+export class MMLValidator {
   private readonly _mspaceWidths = Quarx.observable.box<Opt<I.Set<WithRange<string>>>>(undefined)
 
   public parseXML(doc: Document): void {
@@ -24,14 +22,14 @@ export class MMLValidator implements ExternalValidator {
     })))
   }
 
-  public getValidationChecks(page: PageNode): ValidationCheck[] {
+  public getValidationChecks(file: Fileish): ValidationCheck[] {
     return [
       {
         message: MathValidationKind.NEGATIVE_MSPACE_WIDTH,
         nodesToLoad: I.Set(),
         fn: () => {
           return I.Set(
-            expectValue(this._mspaceWidths.get(), `mspace not loaded [${page.absPath}]`)
+            expectValue(this._mspaceWidths.get(), `mspace not loaded [${file.absPath}]`)
               .filter(i => {
                 const width = i.v.trim()
                 return width.length !== 0 && width[0] === '-'
@@ -44,7 +42,7 @@ export class MMLValidator implements ExternalValidator {
         nodesToLoad: I.Set(),
         fn: () => {
           return I.Set(
-            expectValue(this._mspaceWidths.get(), `mspace not loaded [${page.absPath}]`)
+            expectValue(this._mspaceWidths.get(), `mspace not loaded [${file.absPath}]`)
               .filter(i => i.v.trim().length === 0)
               .map(i => i.range)
           )

--- a/server/src/model/page.ts
+++ b/server/src/model/page.ts
@@ -3,6 +3,7 @@ import * as Quarx from 'quarx'
 import { Opt, Position, PathKind, WithRange, textWithRange, select, selectOne, calculateElementPositions, expectValue, HasRange, NOWHERE, join, equalsOpt, equalsWithRange, tripleEq, Range } from './utils'
 import { Fileish, ValidationCheck, ValidationKind, ValidationSeverity } from './fileish'
 import { ResourceNode } from './resource'
+import { MMLValidator } from './mathml-validator'
 
 enum ResourceLinkKind {
   Image,
@@ -87,6 +88,7 @@ export class PageNode extends Fileish {
   private readonly _resourceLinks = Quarx.observable.box<Opt<I.Set<ResourceLink>>>(undefined)
   private readonly _pageLinks = Quarx.observable.box<Opt<I.Set<PageLink>>>(undefined)
   private readonly _elementsMissingIds = Quarx.observable.box<Opt<I.Set<Range>>>(undefined)
+  private readonly _mmlvalidator = new MMLValidator()
 
   public uuid() { return this.ensureLoaded(this._uuid).v }
   public get optTitle() {
@@ -206,6 +208,7 @@ export class PageNode extends Fileish {
         range: NOWHERE
       })
     }
+    this._mmlvalidator.parseXML(doc)
   }
 
   protected getValidationChecks(): ValidationCheck[] {
@@ -258,7 +261,8 @@ export class PageNode extends Fileish {
         fn: () => {
           return this.ensureLoaded(this._elementsMissingIds)
         }
-      }
+      },
+      ...this._mmlvalidator.getValidationChecks(this)
     ]
   }
 }

--- a/server/src/model/utils.ts
+++ b/server/src/model/utils.ts
@@ -9,12 +9,13 @@ export const NS_COLLECTION = 'http://cnx.rice.edu/collxml'
 const NS_CNXML = 'http://cnx.rice.edu/cnxml'
 export const NS_METADATA = 'http://cnx.rice.edu/mdml'
 const NS_CONTAINER = 'https://openstax.org/namespaces/book-container'
+const NS_MATHML = 'http://www.w3.org/1998/Math/MathML'
 
 const NOWHERE_START: Position = { line: 0, character: 0 }
 const NOWHERE_END: Position = { line: 0, character: 0 /* Number.MAX_VALUE */ }
 export const NOWHERE: Range = { start: NOWHERE_START, end: NOWHERE_END }
 
-export const select = xpath.useNamespaces({ cnxml: NS_CNXML, col: NS_COLLECTION, md: NS_METADATA, bk: NS_CONTAINER })
+export const select = xpath.useNamespaces({ cnxml: NS_CNXML, col: NS_COLLECTION, md: NS_METADATA, bk: NS_CONTAINER, m: NS_MATHML })
 export const selectOne = (sel: string, doc: Node): Element => {
   const ret = select(sel, doc) as Node[]
   expectValue(ret.length === 1 || null, `ERROR: Expected one but found ${ret.length} results that match '${sel}'`)


### PR DESCRIPTION

https://user-images.githubusercontent.com/33585550/183145965-189b73b3-f3fe-44f5-beb1-5687d70b60f4.mov


Somewhat clunky: page.ts uses ensureLoaded to check if fields are
loaded; however, that function is protected.

I still like the idea of encapsulating math validation in an external
class to keep things neat and decoupled, but it needs more work.