### PR TITLE
1946 CNXML Preview Panel Not Updating

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -132,6 +132,7 @@ connection.onDidChangeWatchedFiles(({ changes }) => {
       const manager = getBundleForUri(change.uri)
       await manager.processFilesystemChange(change)
     }
+    await connection.sendRequest('onDidChangeWatchedFiles')
   }
   inner().catch(err => { throw err })
 })


### PR DESCRIPTION
- [ ] openstax/CE#1946

Previously, the client listened for a onDidChangeWatchedFiles and used it to drive many updates. Since then, the ToC was updated to use a different mechanism for updates.

The TocEditorPanel references onDidChangeWatchedFiles; however, there is a second mechanism that causes it to update to match the server's ToC. The reference to onDidChangeWatchedFiles in TocEditorPanel may be redundant.

As far as I can tell, the only thing that still uses this request to drive updates is the CNXML preview panel. This line that sends the `onDidChangeWatchedFiles` request was present in the past; however, it was removed (perhaps by mistake).