### PR TITLE
1985 Update table schema: add aria-label attribute and make summary optional

### DIFF
--- a/client/static/xsd/cnxml.xsd
+++ b/client/static/xsd/cnxml.xsd
@@ -1071,7 +1071,7 @@
             </xs:simpleType>
           </xs:attribute>
           <xs:attribute name="summary"/>
-          <xs:attribute name="screenreader-table-description"/>
+          <xs:attribute name="aria-label"/>
           <xs:attribute name="colsep">
             <xs:simpleType>
               <xs:restriction base="xs:integer">
@@ -5887,7 +5887,7 @@
             </xs:simpleType>
           </xs:attribute>
           <xs:attribute name="summary"/>
-          <xs:attribute name="screenreader-table-description"/>
+          <xs:attribute name="aria-label"/>
           <xs:attribute name="colsep">
             <xs:simpleType>
               <xs:restriction base="xs:integer">

--- a/client/static/xsd/cnxml.xsd
+++ b/client/static/xsd/cnxml.xsd
@@ -1070,7 +1070,8 @@
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>
-          <xs:attribute name="summary" use="required"/>
+          <xs:attribute name="summary"/>
+          <xs:attribute name="screenreader-table-description"/>
           <xs:attribute name="colsep">
             <xs:simpleType>
               <xs:restriction base="xs:integer">
@@ -5885,7 +5886,8 @@
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>
-          <xs:attribute name="summary" use="required"/>
+          <xs:attribute name="summary"/>
+          <xs:attribute name="screenreader-table-description"/>
           <xs:attribute name="colsep">
             <xs:simpleType>
               <xs:restriction base="xs:integer">


### PR DESCRIPTION
 - [ ] openstax/ce#1985

These changes were made by following the steps in the README using the [1985-update-poet-schema](https://github.com/openstax/cnxml/tree/1985-update-poet-schema) branch of cnxml.