### PR TITLE
In gitpod, port 6009 was not working for debugging, use 16009 instead

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
       "name": "Attach to Language Server",
       "type": "node",
       "request": "attach",
-      "port": 6009,
+      "port": 16009,
       "restart": true,
       "outFiles": [
         "${workspaceRoot}/server/dist/**/*.js"
@@ -41,17 +41,6 @@
         "node_modules"
       ],
       "type": "node"
-    },
-    {
-      "name": "Run Extension <gitpod>. Make sure .vscode-test/ exists by running the client tests. Open port 6080 to see the app inside vnc",
-      "type": "node",
-      "request": "launch",
-      "runtimeExecutable": "${workspaceFolder}/.vscode-test/vscode-linux-x64-1.56.2/VSCode-linux-x64/code",
-      "args": [
-        "${workspaceFolder}",
-        "--no-sandbox",
-        "--extensionDevelopmentPath=${workspaceFolder}"
-      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ The unit tests can be debugged using the VSCode debugger. There are 2 ways to ru
 1. If you run the Unit tests from the `[Run and Debug]` VSCode panel then breakpoints will work.
 1. If you want to run the tests from a terminal, follow the instructions to set the [Auto-Attach setting in VSCode](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_auto-attach) and then run `npm run test:unit` or `npm run test:unit:watch`.
 
+### Debugging in Gitpod (Client and Language Server)
+
+You can debug POET in Gitpod thusly:
+
+1. Open `[Run and Debug]` in the VSCode panel
+1. Select and run the `Run Extension` debug configuration from the dropdown
+1. Wait for the extension to start in a new tab/window
+1. Select and run `Attach to Language Server` debug configuration from the dropdown
+1. If all is well, you should be able to set breakpoints in the server and client scripts and debug all the things
+
 # Commandline
 
 A commandline version of POET is available at [./poet](./poet).

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -147,7 +147,7 @@ export function launchLanguageServer(context: vscode.ExtensionContext): Language
   )
   // The debug options for the server
   // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-  const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] }
+  const debugOptions = { execArgv: ['--nolazy', '--inspect=16009'] }
 
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used


### PR DESCRIPTION
Adding a 1 in front seemed to fix the problem. It was probably some kind of port conflict. After this change, we do not need a gitpod-specific launch configuration either.