### PR TITLE
Validate resource filename in Resource; Update Diagnostics all the time

### DIFF
--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -301,10 +301,10 @@ describe('processFilesystemChange()', () => {
     expect(enqueueStub.callCount).toBe(2) // There is one book and 1 re-enqueue
 
     expect((await fireChange(FileChangeType.Changed, 'collections/slug2.collection.xml')).size).toBe(1)
-    expect(sendDiagnosticsStub.callCount).toBe(0)
+    expect(sendDiagnosticsStub.callCount).toBe(0 + 1) // +1 because we currently send all Diagnostics all the time
 
     expect((await fireChange(FileChangeType.Changed, 'modules/m1234/index.cnxml')).size).toBe(1)
-    expect(sendDiagnosticsStub.callCount).toBe(1)
+    expect(sendDiagnosticsStub.callCount).toBe(1 + 3) // +3 because we currently send all Diagnostics all the time
 
     expect((await fireChange(FileChangeType.Changed, 'media/newpic.png')).toArray()).toEqual([]) // Since the model was not aware of the file yet
   })
@@ -320,7 +320,7 @@ describe('processFilesystemChange()', () => {
     expect(first(deletedModules)).toBeInstanceOf(PageNode)
     // Delete a directory
     expect((await fireChange(FileChangeType.Deleted, 'collections')).size).toBe(1)
-    expect(sendDiagnosticsStub.callCount).toBe(0)
+    // expect(sendDiagnosticsStub.callCount).toBe(0)
 
     // Delete everything (including the bundle)
     expect((await fireChange(FileChangeType.Deleted, '')).size).toBe(1)

--- a/server/src/model/resource.spec.ts
+++ b/server/src/model/resource.spec.ts
@@ -1,0 +1,17 @@
+import { ResourceValidationKind } from './resource'
+import { bundleMaker, expectErrors, makeBundle } from './spec-helpers.spec'
+
+describe('Resource validations', () => {
+  it(ResourceValidationKind.DUPLICATE_RESOURCES.title, () => {
+    const bundle = makeBundle()
+    bundle.load(bundleMaker({}))
+    const r1 = bundle.allResources.getOrAdd('media/foo.txt')
+    r1.load('bits-dont-matter')
+    expectErrors(r1, []) // No error when there is no file with a similar name
+
+    const r2 = bundle.allResources.getOrAdd('media/FOO.TXT')
+    r2.load('bits-dont-matter')
+    expectErrors(r1, [ResourceValidationKind.DUPLICATE_RESOURCES])
+    expectErrors(r2, [ResourceValidationKind.DUPLICATE_RESOURCES])
+  })
+})

--- a/server/src/model/resource.ts
+++ b/server/src/model/resource.ts
@@ -1,7 +1,32 @@
-import { Fileish } from './fileish'
+import I from 'immutable'
+import { Fileish, ValidationKind } from './fileish'
+import { NOWHERE, Range } from './utils'
 
 // This can be an Image or an IFrame
 export class ResourceNode extends Fileish {
-  /* istanbul ignore next */
-  protected getValidationChecks() { return [] }
+  private checkDuplicateResources(): I.Set<Range> {
+    const myLower = this.absPath.toLowerCase()
+    for (const resource of this.bundle.allResources.all) {
+      if (resource === this) {
+        continue
+      }
+      const lower = resource.absPath.toLowerCase()
+      if (lower === myLower) {
+        return I.Set<Range>([NOWHERE])
+      }
+    }
+    return I.Set()
+  }
+
+  protected getValidationChecks() {return [
+    {
+      message: ResourceValidationKind.DUPLICATE_RESOURCES,
+      nodesToLoad: I.Set<Fileish>(),
+      fn: () => this.checkDuplicateResources()
+    }
+  ] }
+}
+
+export class ResourceValidationKind extends ValidationKind {
+  static DUPLICATE_RESOURCES = new ResourceValidationKind('Has similar name')
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -97,6 +97,7 @@ connection.onInitialized(() => {
     for (const workspace of currentWorkspaces) {
       const manager = bundleFactory.getOrAdd(workspace.uri)
       manager.performInitialValidation()
+      await manager.loadEnoughForOrphans()
     }
   }
   inner().catch(e => { throw e })


### PR DESCRIPTION
This puts the resource-filename-validation code in the resource, ensures that all Resources are loaded into the model, and sends an updated Diagnostics element whenever the model changes

We discussed reducing the overhead of computing a Diagnostics message on every character change but figured we should try it on a real book first