### PR TITLE
Set pull.ff if pull.rebase and pull.ff are unset

### DIFF
--- a/client/specs/extension.spec.ts
+++ b/client/specs/extension.spec.ts
@@ -13,9 +13,11 @@ import { TocEditorPanel } from '../src/panel-toc-editor'
 import { BooksAndOrphans, ExtensionServerNotification } from '../../common/src/requests'
 import { PanelManager } from '../src/panel'
 import { CnxmlPreviewPanel } from '../src/panel-cnxml-preview'
+import * as pushContent from '../src/push-content'
 
 describe('Extension', () => {
   const sinon = Sinon.createSandbox()
+  beforeEach(async () => sinon.stub(pushContent, 'setDefaultGitConfig').resolves())
   afterEach(async () => sinon.restore())
   it('forwardOnDidChangeWorkspaceFolders sends a request to the language server', async function () {
     const stub = sinon.stub()

--- a/client/specs/push-content.spec.ts
+++ b/client/specs/push-content.spec.ts
@@ -669,4 +669,32 @@ describe('tests with sinon', () => {
       expect(progressReportCount).toBe(1) // Just the 1 to get the progress bar spinning
     })
   })
+  describe('setDefaultGitConfig', () => {
+    ['pull.rebase', 'pull.ff'].forEach(key => {
+      it(`is not called when ${key} is set`, async () => {
+        const setConfigStub = sinon.stub().resolves()
+        const stubRepo = {
+          setConfig: setConfigStub,
+          getConfigs: sinon.stub().resolves([{ key, value: 'true' }])
+        } as any as Repository
+        const stubGetRepo = sinon.stub(pushContent, 'getRepo').returns(stubRepo)
+        await pushContent.setDefaultGitConfig()
+        expect(stubGetRepo.callCount).toBe(1)
+        expect(setConfigStub.callCount).toBe(0)
+        expect(setConfigStub.calledWith('pull.ff', 'true')).toBe(false)
+      })
+    })
+    it('is called when pull.ff and pull.rebase are unset', async () => {
+      const setConfigStub = sinon.stub().resolves()
+      const stubRepo = {
+        setConfig: setConfigStub,
+        getConfigs: sinon.stub().resolves([])
+      } as any as Repository
+      const stubGetRepo = sinon.stub(pushContent, 'getRepo').returns(stubRepo)
+      await pushContent.setDefaultGitConfig()
+      expect(stubGetRepo.callCount).toBe(1)
+      expect(setConfigStub.callCount).toBe(1)
+      expect(setConfigStub.calledWith('pull.ff', 'true')).toBe(true)
+    })
+  })
 })

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -2,10 +2,10 @@ import path from 'path'
 import fs from 'fs'
 import vscode from 'vscode'
 import { LanguageClient } from 'vscode-languageclient/node'
-import { pushContent, tagContent, validateContent } from './push-content'
+import { pushContent, tagContent, validateContent, setDefaultGitConfig } from './push-content'
 import { TocEditorPanel } from './panel-toc-editor'
 import { CnxmlPreviewPanel } from './panel-cnxml-preview'
-import { expect, ensureCatch, launchLanguageServer, populateXsdSchemaFiles, getRootPathUri, configureWorkspaceSettings } from './utils'
+import { expect, ensureCatch, ensureCatchPromise, launchLanguageServer, populateXsdSchemaFiles, getRootPathUri, configureWorkspaceSettings } from './utils'
 import { OpenstaxCommand } from './extension-types'
 import { ExtensionHostContext, Panel, PanelManager } from './panel'
 import { ImageManagerPanel } from './panel-image-manager'
@@ -106,6 +106,7 @@ function doRest(client: LanguageClient): ExtensionExports {
   tocTreesView = vscode.window.createTreeView('tocTrees', { treeDataProvider: tocTreesProvider, showCollapseAll: true })
   vscode.commands.registerCommand('openstax.toggleTocTreesFiltering', ensureCatch(toggleTocTreesFilteringHandler(tocTreesView, tocTreesProvider)))
   vscode.commands.registerCommand('openstax.validateContent', ensureCatch(validateContent))
+  void ensureCatchPromise(setDefaultGitConfig())
 
   // It is a logic error for anything else to listen to this event from the client.
   // It is only allowed a single handler, from what we can tell

--- a/client/src/push-content.ts
+++ b/client/src/push-content.ts
@@ -173,6 +173,14 @@ export const getRepo = (): Repository => {
   return result
 }
 
+export const setDefaultGitConfig = async (): Promise<void> => {
+  const repo = getRepo()
+  const config = await repo.getConfigs()
+  if (!config.some(p => p.key === 'pull.ff' || p.key === 'pull.rebase')) {
+    await repo.setConfig('pull.ff', 'true')
+  }
+}
+
 export const taggingDialog = async (): Promise<Tag | undefined> => {
   const tagMode = await vscode.window.showInformationMessage(
     'Tag for release candidate or release?',


### PR DESCRIPTION
- [ ] openstax/ce#2030

Prevent fatal error on content push caused by the strategy for handling divergent branches being unset. I tried to be non-intrusive by only setting our default value when the other options have not been set.

I added steps to recreate the problem to the issue. You can try it the same way, using a local remote, with POET.

