### PR TITLE
Make content-id optional in collxml schema

### DIFF
--- a/client/static/xsd/collxml.xsd
+++ b/client/static/xsd/collxml.xsd
@@ -31,7 +31,7 @@
   <xs:element name="metadata">
     <xs:complexType>
       <xs:all>
-        <xs:element ref="mdml:content-id"/>
+        <xs:element minOccurs="0" ref="mdml:content-id"/>
         <xs:element ref="mdml:title"/>
         <xs:element ref="mdml:license"/>
         <xs:element ref="mdml:uuid"/>

--- a/client/static/xsd/trang.patch
+++ b/client/static/xsd/trang.patch
@@ -84,7 +84,7 @@ index 43d3127..744f1b7 100644
 -        <xs:group ref="mathml:language"/>
 -      </xs:choice>
 +      <xs:all>
-+        <xs:element ref="mdml:content-id"/>
++        <xs:element minOccurs="0" ref="mdml:content-id"/>
 +        <xs:element ref="mdml:title"/>
 +        <xs:element ref="mdml:license"/>
 +        <xs:element ref="mdml:uuid"/>


### PR DESCRIPTION
Since this element is not used anymore and the ToC editor omits it when it rewrites the ToC, it should be optional until it can be completely phased out.

See related PR:
- openstax/cnxml#61