### PR TITLE
Add support for coderunner IFrame

### DIFF
--- a/client/static/cnxml-preview.html
+++ b/client/static/cnxml-preview.html
@@ -12,6 +12,7 @@
 		 script-src 'self' ${WEBVIEW_CSPSOURCE} https: data: 'nonce-${NONCE}';
 		  style-src 'self' ${WEBVIEW_CSPSOURCE} https: data: 'unsafe-inline';
 		   font-src 'self' ${WEBVIEW_CSPSOURCE} https: data:;
+                  frame-src 'self' ${WEBVIEW_CSPSOURCE} https: data: 'unsafe-inline';
 	" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 


### PR DESCRIPTION
This was the error in the VSCode terminal because the webview did not have permission to load local assets in the IFrame.

```
Refused to frame 'https://file+.vscode-resource.vscode-cdn.net/' because it violates the following Content Security Policy directive: "default-src 'none'". Note that 'frame-src' was not explicitly set, so 'default-src' is used as a fallback.
```

Refs https://github.com/openstax/ce/issues/2071


[Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src)