### PR TITLE
Submodule support

### DIFF
--- a/client/specs/push-content.spec.ts
+++ b/client/specs/push-content.spec.ts
@@ -27,6 +27,7 @@ describe('Push Button Test Suite', () => {
     // openAndValidate is tested fully later in this file
     sinon.stub(pushContent, 'openAndValidate')
       .resolves(new Map<string, Array<[vscode.Uri, vscode.Diagnostic]>>())
+    sinon.stub(utils, 'getRootPathUri').returns(vscode.Uri.file('test'))
   })
   afterEach(() => sinon.restore())
   const commitOptions: CommitOptions = { all: true }
@@ -57,10 +58,10 @@ describe('Push Button Test Suite', () => {
     })
   }
   // This was once an integration test, now it is kind of pointless.
-  test('getRepo returns a repository', async () => {
+  test('getBookRepo returns a repository', async () => {
     const getExtensionStub = Substitute.for<vscode.Extension<GitExtension>>()
     sinon.stub(vscode.extensions, 'getExtension').returns(getExtensionStub)
-    const repo = pushContent.getRepo()
+    const repo = pushContent.getBookRepo()
     expect(repo.rootUri).toBeDefined()
   })
   test('pushContent pushes with no conflict', async () => {
@@ -216,7 +217,6 @@ describe('Push Button Test Suite', () => {
     sinon.stub(utils, 'getErrorDiagnosticsBySource').resolves(new Map<string, Array<[vscode.Uri, vscode.Diagnostic]>>())
     sinon.stub(pushContent, 'getMessage').resolves('poet commit')
     sinon.stub(pushContent, 'canPush').returns(true)
-    sinon.stub(utils, 'getRootPathUri').returns(vscode.Uri.file('fjsdlf'))
     sinon.stub(vscode.window, 'withProgress').callsFake(withProgressNoCancel)
     const stubPushContentHelperInner = sinon.stub()
     sinon.stub(pushContent, '_pushContent').returns(stubPushContentHelperInner)
@@ -317,6 +317,9 @@ describe('Push Button Test Suite', () => {
 describe('tests with sinon', () => {
   const sinon = Sinon.createSandbox()
   afterEach(async () => sinon.restore())
+  beforeEach(() => {
+    sinon.stub(utils, 'getRootPathUri').returns(vscode.Uri.file('test'))
+  })
   describe('validateContent', () => {
     it('only runs when it should', async () => {
       const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage')
@@ -516,9 +519,8 @@ describe('tests with sinon', () => {
           setConfig: setConfigStub,
           getConfigs: sinon.stub().resolves([{ key, value: 'true' }])
         } as any as Repository
-        const stubGetRepo = sinon.stub(pushContent, 'getRepo').returns(stubRepo)
+        sinon.stub(pushContent, 'getRepos').returns([stubRepo])
         await pushContent.setDefaultGitConfig()
-        expect(stubGetRepo.callCount).toBe(1)
         expect(setConfigStub.callCount).toBe(0)
         expect(setConfigStub.calledWith('pull.ff', 'true')).toBe(false)
       })
@@ -529,9 +531,8 @@ describe('tests with sinon', () => {
         setConfig: setConfigStub,
         getConfigs: sinon.stub().resolves([])
       } as any as Repository
-      const stubGetRepo = sinon.stub(pushContent, 'getRepo').returns(stubRepo)
+      sinon.stub(pushContent, 'getRepos').returns([stubRepo])
       await pushContent.setDefaultGitConfig()
-      expect(stubGetRepo.callCount).toBe(1)
       expect(setConfigStub.callCount).toBe(1)
       expect(setConfigStub.calledWith('pull.ff', 'true')).toBe(true)
     })

--- a/client/specs/push-content.spec.ts
+++ b/client/specs/push-content.spec.ts
@@ -1,7 +1,7 @@
 import Sinon from 'sinon'
 import * as pushContent from '../src/push-content'
 import * as utils from '../src/utils'
-import { Repository, Change, Status, CommitOptions, GitExtension, GitErrorCodes, Branch, RepositoryState, RefType } from '../src/git-api/git.d'
+import { Repository, Change, Status, CommitOptions, GitExtension, GitErrorCodes, Branch, RepositoryState } from '../src/git-api/git.d'
 import vscode from 'vscode'
 import expect from 'expect'
 import { Substitute } from '@fluffy-spoon/substitute'
@@ -274,72 +274,6 @@ describe('Push Button Test Suite', () => {
   })
   test('validateMessage returns null for message that is long enough', async () => {
     expect(pushContent.validateMessage('abc')).toBe(null)
-  })
-  test('taggingDialog', async () => {
-    const mockDialog = sinon.stub(vscode.window, 'showInformationMessage')
-    mockDialog.resolves(undefined)
-    expect(await pushContent.taggingDialog()).toBe(undefined)
-    mockDialog.resolves(pushContent.Tag.release as any as vscode.MessageItem)
-    expect(await pushContent.taggingDialog()).toBe(pushContent.Tag.release)
-    mockDialog.resolves(pushContent.Tag.candidate as any as vscode.MessageItem)
-    expect(await pushContent.taggingDialog()).toBe(pushContent.Tag.candidate)
-  })
-  test('getNewTag', async () => {
-    const repoState = {
-      refs: [{
-        name: 'main',
-        type: RefType.Head,
-        commit: 'a'
-      }]
-    } as any as RepositoryState
-    const mockRepo = {
-      state: repoState
-    } as any as Repository
-    const mockHead = {
-      commit: 'a'
-    } as any as Branch
-
-    const showErrorMsgStub = sinon.stub(vscode.window, 'showErrorMessage')
-
-    expect(await pushContent.getNewTag(mockRepo, pushContent.Tag.candidate, mockHead)).toBe('1rc')
-    mockRepo.state.refs.push({
-      name: '1rc',
-      type: RefType.Tag,
-      commit: 'b'
-    })
-
-    expect(await pushContent.getNewTag(mockRepo, pushContent.Tag.candidate, mockHead)).toBe('2rc')
-    mockRepo.state.refs.push({
-      name: '2rc',
-      type: RefType.Tag,
-      commit: 'a'
-    })
-    expect(await pushContent.getNewTag(mockRepo, pushContent.Tag.candidate, mockHead)).toBe(undefined)
-    expect(showErrorMsgStub.calledOnceWith('Tag of this type already exists for this content version.', { modal: false })).toBe(true)
-    showErrorMsgStub.reset()
-
-    mockRepo.state.refs.length = 0
-    mockRepo.state.refs.push({
-      name: 'main',
-      type: RefType.Head,
-      commit: 'a'
-    })
-
-    expect(await pushContent.getNewTag(mockRepo, pushContent.Tag.release, mockHead)).toBe('1')
-    mockRepo.state.refs.push({
-      name: '1',
-      type: RefType.Tag,
-      commit: 'b'
-    })
-
-    expect(await pushContent.getNewTag(mockRepo, pushContent.Tag.release, mockHead)).toBe('2')
-    mockRepo.state.refs.push({
-      name: '2',
-      type: RefType.Tag,
-      commit: 'a'
-    })
-    expect(await pushContent.getNewTag(mockRepo, pushContent.Tag.release, mockHead)).toBe(undefined)
-    expect(showErrorMsgStub.calledOnceWith('Tag of this type already exists for this content version.', { modal: false })).toBe(true)
   })
   test('canPush returns correct values', async () => {
     const fileUri = { path: '/test.cnxml', scheme: 'file' } as any as vscode.Uri


### PR DESCRIPTION
These changes should prevent errors that could be caused by adding submodules to book repositories. These changes do not add support for committing and pushing changes to submodules.

- Stop assuming that the first repo is the book repo
- Get repo by pathHint (full path, partial path, or name)
- Set default git config on all repositories
