### PR TITLE
2105 resource count quarx

### DIFF
--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -168,8 +168,6 @@ export function launchLanguageServer(context: vscode.ExtensionContext): Language
       fileEvents: [
         vscode.workspace.createFileSystemWatcher('**/META-INF/books.xml'),
         vscode.workspace.createFileSystemWatcher('**/media/**'),
-        vscode.workspace.createFileSystemWatcher('**/modules/**'),
-        vscode.workspace.createFileSystemWatcher('**/collections/**'),
         vscode.workspace.createFileSystemWatcher('**/*.cnxml'),
         vscode.workspace.createFileSystemWatcher('**/*.collection.xml')
       ]

--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -303,10 +303,10 @@ describe('processFilesystemChange()', () => {
     expect(enqueueStub.callCount).toBe(2) // There is one book and 1 re-enqueue
 
     expect((await fireChange(FileChangeType.Changed, 'collections/slug2.collection.xml')).size).toBe(1)
-    expect(sendDiagnosticsStub.callCount).toBe(0 + 1) // +1 because we currently send all Diagnostics all the time
+    expect(sendDiagnosticsStub.callCount).toBe(0)
 
     expect((await fireChange(FileChangeType.Changed, 'modules/m1234/index.cnxml')).size).toBe(1)
-    expect(sendDiagnosticsStub.callCount).toBe(1 + 3) // +3 because we currently send all Diagnostics all the time
+    expect(sendDiagnosticsStub.callCount).toBe(1)
 
     expect((await fireChange(FileChangeType.Changed, 'media/newpic.png')).toArray()).toEqual([]) // Since the model was not aware of the file yet
   })

--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -268,7 +268,8 @@ describe('processFilesystemChange()', () => {
     mockfs({
       'META-INF/books.xml': bundleMaker({ books: [bookSlug] }),
       'collections/slug2.collection.xml': bookMaker({ slug: bookSlug, toc: [{ title: 'subbook', children: [pageId] }] }),
-      'modules/m1234/index.cnxml': pageMaker({})
+      'modules/m1234/index.cnxml': pageMaker({}),
+      'media/newpic.png': ''
     })
     const bundle = new Bundle(FS_PATH_HELPER, process.cwd())
     manager = new ModelManager(bundle, conn)
@@ -291,6 +292,7 @@ describe('processFilesystemChange()', () => {
     expect((await fireChange(FileChangeType.Created, 'collections/slug2.collection.xml')).size).toBe(1)
     expect((await fireChange(FileChangeType.Created, 'modules/m1234/index.cnxml')).size).toBe(1)
     expect((await fireChange(FileChangeType.Created, 'media/newpic.png')).size).toBe(1)
+    expect((await fireChange(FileChangeType.Created, 'media/does-not-exist.png')).size).toBe(1)
   })
   it('does not create things it does not understand', async () => {
     expect((await fireChange(FileChangeType.Created, 'README.md')).toArray()).toEqual([])

--- a/server/src/model-manager.ts
+++ b/server/src/model-manager.ts
@@ -308,7 +308,7 @@ export class ModelManager {
       const stat = await fs.promises.stat(fsPath)
       if (stat.isFile()) { // Example: <image src=""/> resolves to 'modules/m123' which is a directory.
         return ['.jpg', '.png'].some((ext) => uri.endsWith(ext))
-          ? 'image'
+          ? '<fakeimagedata>'
           : await fs.promises.readFile(fsPath, 'utf-8')
       }
     }

--- a/server/src/model-manager.ts
+++ b/server/src/model-manager.ts
@@ -299,7 +299,9 @@ export class ModelManager {
     if (await checkFileExists(fsPath)) {
       const stat = await fs.promises.stat(fsPath)
       if (stat.isFile()) { // Example: <image src=""/> resolves to 'modules/m123' which is a directory.
-        return await fs.promises.readFile(fsPath, 'utf-8')
+        return ['.jpg', '.png'].some((ext) => uri.endsWith(ext))
+          ? 'image'
+          : await fs.promises.readFile(fsPath, 'utf-8')
       }
     }
   }
@@ -319,7 +321,7 @@ export class ModelManager {
     const { errors, nodesToLoad } = node.validationErrors
     if (nodesToLoad.isEmpty()) {
       const uri = node.absPath
-      const diagnostics = errors.toSet().map(err => {
+      const diagnostics = errors.map(err => {
         return Diagnostic.create(err.range, err.title, err.severity, undefined, DiagnosticSource.poet)
       }).toArray()
       this.conn.sendDiagnostics({

--- a/server/src/model-manager.ts
+++ b/server/src/model-manager.ts
@@ -11,7 +11,7 @@ import { BookToc, ClientTocNode, TocModification, TocModificationKind, TocSubboo
 import { Opt, expectValue, Position, inRange, Range, equalsArray, selectOne } from './model/utils'
 import { Bundle } from './model/bundle'
 import { PageLinkKind, PageNode } from './model/page'
-import { Fileish } from './model/fileish'
+import { Fileish, ValidationResponse } from './model/fileish'
 import { JobRunner } from './job-runner'
 import { equalsBookToc, equalsClientPageishArray, fromBook, fromPage, IdMap, renameTitle, toString } from './book-toc-utils'
 import { BooksAndOrphans, DiagnosticSource, ExtensionServerNotification } from '../../common/src/requests'
@@ -117,6 +117,7 @@ export class ModelManager {
 
   public readonly jobRunner = new JobRunner()
   private readonly openDocuments = new Map<string, string>()
+  private readonly errorHashesByPath = new Map<string, I.Set<number>>()
   private didLoadOrphans = false
   private bookTocs: BookToc[] = []
   private tocIdMap = new IdMap<string, TocSubbookWithRange|PageNode>(x => {

--- a/server/src/model/resource.ts
+++ b/server/src/model/resource.ts
@@ -4,25 +4,13 @@ import { NOWHERE, Range } from './utils'
 
 // This can be an Image or an IFrame
 export class ResourceNode extends Fileish {
-  private checkDuplicateResources(): I.Set<Range> {
-    const myLower = this.absPath.toLowerCase()
-    for (const resource of this.bundle.allResources.all) {
-      if (resource === this) {
-        continue
-      }
-      const lower = resource.absPath.toLowerCase()
-      if (lower === myLower) {
-        return I.Set<Range>([NOWHERE])
-      }
-    }
-    return I.Set()
-  }
-
   protected getValidationChecks() {
     return [{
       message: ResourceValidationKind.DUPLICATE_RESOURCES,
       nodesToLoad: I.Set<Fileish>(),
-      fn: () => this.checkDuplicateResources()
+      fn: () => this.bundle.isDuplicateResourcePath(this.absPath)
+        ? I.Set([NOWHERE])
+        : I.Set<Range>()
     }]
   }
 }

--- a/server/src/model/utils.ts
+++ b/server/src/model/utils.ts
@@ -71,6 +71,7 @@ export interface Bundleish {
   allResources: Factory<ResourceNode>
   workspaceRootUri: string
   isDuplicateUuid: (uuid: string) => boolean
+  isDuplicateResourcePath: (path: string) => boolean
 }
 
 export enum PathKind {


### PR DESCRIPTION
# Summary
Replaces excessive looping with a shared lists in the bundle for duplicate UUID and resource checks. These lists are automatically updated by quarx when the underlying models change.

Fixes openstax/ce#2105


# Duplicate Resources are Reported Correctly
## GIVEN
* [This](https://github.com/openstax/poet/suites/16545432679/artifacts/945128665) version of POET installed
* Any book repository open
## WHEN
* Two image names differ only by letter casing (i.e. `a.jpg` vs. `A.jpg`)
## THEN
* The images are highlighted red and a problem appears in the `Problems` pane

## GIVEN
* ... (same as above)
* Duplicate resource error reported by POET
## WHEN
* Two images that had names names differing only by letter casing are renamed to something different
## THEN
* The duplicate resource error goes away 

# Duplicate UUIDs are Reported Correctly
## GIVEN
* ...
## WHEN
* Two modules/pages have the same UUID
## THEN
* There is an error reported by POET

## GIVEN
* ...
* Duplicate UUID error reported by POET
## WHEN
* Two modules/pages that had the same UUID are updated to have different UUIDs
## THEN
* The duplicate UUID error goes away