### PR TITLE
:bug: fix dangling comment node

### DIFF
--- a/client/src/webview-js/cnxml-preview/cnxml-preview.js
+++ b/client/src/webview-js/cnxml-preview/cnxml-preview.js
@@ -242,7 +242,7 @@ const handleRefresh = (xml, xsl) => {
       }
       case Node.DOCUMENT_FRAGMENT_NODE: {
         // Wrap the children of the document fragment in a <div>
-        const children = [...xmlNode.childNodes].map(c => recBuildVDom(c))
+        const children = [...xmlNode.childNodes].map(c => recBuildVDom(c)).filter(c => !!c)
         return vdom_h('DIV', {}, ...children)
       }
       default: {

--- a/cypress/integration/cnxml-preview-spec.ts
+++ b/cypress/integration/cnxml-preview-spec.ts
@@ -17,7 +17,7 @@ import { PanelStateMessage, PanelStateMessageType } from '../../common/src/webvi
       })
     }
     function createCnxmlFromContent(content: string): string {
-      return `<document xmlns="http://cnx.rice.edu/cnxml"><content>${content}</content></document>`
+      return `<document xmlns="http://cnx.rice.edu/cnxml"><content>${content}</content></document><!-- extra bit for testing -->`
     }
     function sendScrollToLine(line: number): void {
       sendMessage({ type: 'scroll-in-preview', line })


### PR DESCRIPTION
This was causing the preview to fail when a comment occurred after the root `<document>` element.

refs https://github.com/openstax/ce/issues/2129