### PR TITLE
generate broken links in CSV format

### DIFF
--- a/poet
+++ b/poet
@@ -27,4 +27,4 @@ readonly root_dir="$(cd "$(dirname "$actual_file")" && pwd)"
     popd
 }
 
-$(cd "$root_dir" && npm bin)/ts-node "$root_dir/server/src/model/_cli.ts" $@
+cd "$root_dir" && npx ts-node "$root_dir/server/src/model/_cli.ts" $@


### PR DESCRIPTION
This generates the "broken links" errors in a CSV format so it can easily be put into a spreadsheet [like this](https://docs.google.com/spreadsheets/d/18gttkMSICZ07oNlGJkCMZBbKiJnJm8GpyYniFVtQuFs/edit).

It also includes links directly to the source to make fixing them easier.


To run it:

```
./poet links /path/to/osbooks-biology-bundle/   | tee --append broken-links.csv
./poet links /path/to/osbooks-chemistry-bundle/ | tee --append broken-links.csv
# ...
# "osbooks-writing-guide","modules/m00173/index.cnxml",71,655,404,"https://openstax.org/r/Audacity","",""
# "osbooks-precalculo","modules/m49349/index.cnxml",2865,9,fetch_failed_maybe,"https://openstax.org/l/factortheorem","","fetch failed"
# "osbooks-life-liberty-and-pursuit-happiness","modules/m83575/index.cnxml",134,393,403,"https://catalog.archives.gov/id/38995458","",""
# "osbooks-life-liberty-and-pursuit-happiness","modules/m83575/index.cnxml",135,151,404,"https://www.amnestyusa.org/pdfs/RyanSignedLighterVersion.pdf","",""
# "osbooks-us-history","modules/m50119/index.cnxml",34,39,double_permanent_redirect_301,"https://openstax.org/l/twain1","http://historymatters.gmu.edu/d/4935/","https://historymatters.gmu.edu/d/4935/"
#
# Upload the CSV to Google Docs
```