### PR TITLE
2165 push to private submodule

### DIFF
--- a/client/specs/extension.spec.ts
+++ b/client/specs/extension.spec.ts
@@ -17,7 +17,10 @@ import * as pushContent from '../src/push-content'
 
 describe('Extension', () => {
   const sinon = Sinon.createSandbox()
-  beforeEach(async () => sinon.stub(pushContent, 'setDefaultGitConfig').resolves())
+  beforeEach(async () => {
+    sinon.stub(pushContent, 'setDefaultGitConfig').resolves()
+    sinon.stub(pushContent, 'initPrivateSubmodule').resolves()
+  })
   afterEach(async () => { sinon.restore() })
   it('forwardOnDidChangeWorkspaceFolders sends a request to the language server', async function () {
     const stub = sinon.stub()

--- a/client/specs/push-content.spec.ts
+++ b/client/specs/push-content.spec.ts
@@ -15,10 +15,6 @@ const makeCaptureMessage = (messages: string[]): (message: string) => Promise<st
   }
 }
 
-const makeMockDialog = (message: string): () => Promise<string | undefined> => {
-  return async (): Promise<string | undefined> => { return message }
-}
-
 const ignore = async (message: string): Promise<string | undefined> => { return undefined }
 
 describe('Push Button Test Suite', () => {
@@ -67,7 +63,6 @@ describe('Push Button Test Suite', () => {
   test('pushContent pushes with no conflict', async () => {
     const messages: string[] = []
     const captureMessage = makeCaptureMessage(messages)
-    const mockMessageInput = makeMockDialog('poet commit')
 
     const getRepo = (): Repository => {
       const stubRepo = Substitute.for<Repository>()
@@ -80,8 +75,8 @@ describe('Push Button Test Suite', () => {
     }
 
     await pushContent._pushContent(
-      getRepo,
-      mockMessageInput,
+      getRepo(),
+      'poet commit',
       captureMessage,
       ignore
     )()
@@ -92,7 +87,6 @@ describe('Push Button Test Suite', () => {
   test('push with merge conflict', async () => {
     const messages: string[] = []
     const captureMessage = makeCaptureMessage(messages)
-    const mockMessageInput = makeMockDialog('poet commit')
     const error: any = { _fake: 'FakeSoStackTraceIsNotInConsole', message: '' }
 
     error.gitErrorCode = GitErrorCodes.Conflict
@@ -108,8 +102,8 @@ describe('Push Button Test Suite', () => {
     }
 
     await pushContent._pushContent(
-      getRepo,
-      mockMessageInput,
+      getRepo(),
+      'poet commit',
       ignore,
       captureMessage
     )()
@@ -120,7 +114,6 @@ describe('Push Button Test Suite', () => {
   test('unknown commit error', async () => {
     const messages: string[] = []
     const captureMessage = makeCaptureMessage(messages)
-    const mockMessageInput = makeMockDialog('poet commit')
     const error: any = { _fake: 'FakeSoStackTraceIsNotInConsole', message: '' }
 
     error.gitErrorCode = ''
@@ -136,8 +129,8 @@ describe('Push Button Test Suite', () => {
     }
 
     await pushContent._pushContent(
-      getRepo,
-      mockMessageInput,
+      getRepo(),
+      'poet commit',
       ignore,
       captureMessage
     )()
@@ -148,7 +141,6 @@ describe('Push Button Test Suite', () => {
   test('push with no changes', async () => {
     const messages: string[] = []
     const captureMessage = makeCaptureMessage(messages)
-    const mockMessageInput = makeMockDialog('poet commit')
     const error: any = { _fake: 'FakeSoStackTraceIsNotInConsole', message: '' }
 
     error.stdout = 'nothing to commit.'
@@ -164,8 +156,8 @@ describe('Push Button Test Suite', () => {
     }
 
     await pushContent._pushContent(
-      getRepo,
-      mockMessageInput,
+      getRepo(),
+      'poet commit',
       ignore,
       captureMessage
     )()
@@ -176,7 +168,6 @@ describe('Push Button Test Suite', () => {
   test('unknown push error', async () => {
     const messages: string[] = []
     const captureMessage = makeCaptureMessage(messages)
-    const mockMessageInput = makeMockDialog('poet commit')
     const error: any = { _fake: 'FakeSoStackTraceIsNotInConsole', message: '' }
 
     error.stdout = ''
@@ -192,8 +183,8 @@ describe('Push Button Test Suite', () => {
     }
 
     await pushContent._pushContent(
-      getRepo,
-      mockMessageInput,
+      getRepo(),
+      'poet commit',
       ignore,
       captureMessage
     )()
@@ -213,23 +204,106 @@ describe('Push Button Test Suite', () => {
     expect(stubPushContentHelperInner.notCalled).toBe(true)
     expect(sendRequestMock.notCalled).toBe(true)
   })
-  test('pushContent invokes _pushContent when canPush is true', async () => {
+  test('pushContent does not invoke _pushContent when private submodule exists and cannot be prepared for pushing', async () => {
+    const error: any = { _fake: 'FakeSoStackTraceIsNotInConsole', message: '' }
+    const stubRepo = {
+      fetch: async () => { throw error }
+    } as unknown as Repository
+    const getExtensionStub = Substitute.for<vscode.Extension<GitExtension>>()
+    const showErrorMsgStub = sinon.stub(vscode.window, 'showErrorMessage')
+    sinon.stub(vscode.extensions, 'getExtension').returns(getExtensionStub)
+    sinon.stub(utils, 'getErrorDiagnosticsBySource').resolves(new Map<string, Array<[vscode.Uri, vscode.Diagnostic]>>())
+    sinon.stub(pushContent, 'getMessage').resolves('poet commit')
+    sinon.stub(pushContent, 'canPush').returns(true)
+    sinon.stub(pushContent, '_getPrivateSubmodule').returns(stubRepo)
+    sinon.stub(vscode.window, 'withProgress').callsFake(withProgressNoCancel)
+    const stubPushContentHelperInner = sinon.stub()
+    sinon.stub(pushContent, '_pushContent').returns(stubPushContentHelperInner)
+    sendRequestMock.resolves(new Proxy({}, {
+      get() {
+        return 'fake-branch-name'
+      }
+    }))
+    await pushContent.pushContent(mockHostContext)()
+    expect(sendRequestMock.calledOnceWith(
+      ExtensionServerRequest.GetSubmoduleConfig
+    ))
+    expect(stubPushContentHelperInner.callCount).toBe(0)
+    expect(showErrorMsgStub.args[0][0]).toMatch(
+      /Could not checkout private submodule branch/
+    )
+    sendRequestMock.reset()
+  })
+  const configTests: Array<[string, object | null]> = [
+    ['submodule configuration missing', null],
+    ['submodule branch missing', {}]
+  ]
+  configTests.forEach(([testCase, value]) => {
+    const message = `pushContent does not invoke _pushContent when ${testCase}`
+    test(message, async () => {
+      const getExtensionStub = Substitute.for<vscode.Extension<GitExtension>>()
+      const showErrorMsgStub = sinon.stub(vscode.window, 'showErrorMessage')
+      sinon.stub(vscode.extensions, 'getExtension').returns(getExtensionStub)
+      sinon.stub(utils, 'getErrorDiagnosticsBySource').resolves(new Map<string, Array<[vscode.Uri, vscode.Diagnostic]>>())
+      sinon.stub(pushContent, 'getMessage').resolves('poet commit')
+      sinon.stub(pushContent, 'canPush').returns(true)
+      sinon.stub(vscode.window, 'withProgress').callsFake(withProgressNoCancel)
+      const stubPushContentHelperInner = sinon.stub()
+      sinon.stub(pushContent, '_pushContent').returns(stubPushContentHelperInner)
+      sendRequestMock.resolves(value)
+      await pushContent.pushContent(mockHostContext)()
+      expect(showErrorMsgStub.args[0][0]).toMatch(
+        /Could not determine which private submodule branch to use/
+      )
+      expect(sendRequestMock.calledOnceWith(
+        ExtensionServerRequest.GetSubmoduleConfig
+      ))
+      // One for book repo, one for private submodule
+      expect(stubPushContentHelperInner.callCount).toBe(0)
+      sendRequestMock.reset()
+    })
+  })
+  test('pushContent invokes _pushContent when canPush is true and private submodule is missing', async () => {
+    const getExtensionStub = Substitute.for<vscode.Extension<GitExtension>>()
+    sinon.stub(vscode.extensions, 'getExtension').returns(getExtensionStub)
+    sinon.stub(utils, 'getErrorDiagnosticsBySource').resolves(new Map<string, Array<[vscode.Uri, vscode.Diagnostic]>>())
+    sinon.stub(pushContent, 'getMessage').resolves('poet commit')
+    sinon.stub(pushContent, 'canPush').returns(true)
+    sinon.stub(pushContent, '_getPrivateSubmodule').returns(undefined)
+    sinon.stub(vscode.window, 'withProgress').callsFake(withProgressNoCancel)
+    const stubPushContentHelperInner = sinon.stub()
+    sinon.stub(pushContent, '_pushContent').returns(stubPushContentHelperInner)
+    await pushContent.pushContent(mockHostContext)()
+    expect(stubPushContentHelperInner.callCount).toBe(1)
+    expect(sendRequestMock.calledOnceWith(
+      ExtensionServerRequest.BundleEnsureIds
+    )).toBe(true)
+  })
+  test('pushContent invokes _pushContent with private submodule and book repository', async () => {
+    const getExtensionStub = Substitute.for<vscode.Extension<GitExtension>>()
+    sinon.stub(vscode.extensions, 'getExtension').returns(getExtensionStub)
     sinon.stub(utils, 'getErrorDiagnosticsBySource').resolves(new Map<string, Array<[vscode.Uri, vscode.Diagnostic]>>())
     sinon.stub(pushContent, 'getMessage').resolves('poet commit')
     sinon.stub(pushContent, 'canPush').returns(true)
     sinon.stub(vscode.window, 'withProgress').callsFake(withProgressNoCancel)
     const stubPushContentHelperInner = sinon.stub()
     sinon.stub(pushContent, '_pushContent').returns(stubPushContentHelperInner)
+    sendRequestMock.resolves(new Proxy({}, {
+      get() {
+        return 'fake-branch-name'
+      }
+    }))
     await pushContent.pushContent(mockHostContext)()
-    expect(stubPushContentHelperInner.calledOnce).toBe(true)
     expect(sendRequestMock.calledOnceWith(
-      ExtensionServerRequest.BundleEnsureIds
-    )).toBe(true)
+      ExtensionServerRequest.GetSubmoduleConfig
+    ))
+    // One for book repo, one for private submodule
+    expect(stubPushContentHelperInner.callCount).toBe(2)
+    sendRequestMock.reset()
   })
   test('pushes to new branch', async () => {
     const messages: string[] = []
     const captureMessage = makeCaptureMessage(messages)
-    const mockMessageInput = makeMockDialog('poet commit')
     const pushStub = sinon.stub()
     const newBranchName = 'newbranch'
 
@@ -255,8 +329,8 @@ describe('Push Button Test Suite', () => {
       return stubRepo
     }
     await pushContent._pushContent(
-      getRepo,
-      mockMessageInput,
+      getRepo(),
+      'poet commit',
       captureMessage,
       ignore
     )()

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import fs from 'fs'
 import vscode from 'vscode'
 import { type LanguageClient } from 'vscode-languageclient/node'
-import { pushContent, validateContent, setDefaultGitConfig } from './push-content'
+import { pushContent, validateContent, setDefaultGitConfig, initPrivateSubmodule } from './push-content'
 import { TocEditorPanel } from './panel-toc-editor'
 import { CnxmlPreviewPanel } from './panel-cnxml-preview'
 import { expect, ensureCatch, ensureCatchPromise, launchLanguageServer, populateXsdSchemaFiles, getRootPathUri, configureWorkspaceSettings } from './utils'
@@ -108,6 +108,7 @@ function doRest(client: LanguageClient): ExtensionExports {
   vscode.commands.registerCommand('openstax.toggleTocTreesFiltering', ensureCatch(toggleTocTreesFilteringHandler(tocTreesView, tocTreesProvider)))
   vscode.commands.registerCommand('openstax.validateContent', ensureCatch(validateContent))
   void ensureCatchPromise(setDefaultGitConfig())
+  void ensureCatchPromise(initPrivateSubmodule(hostContext))
 
   // It is a logic error for anything else to listen to this event from the client.
   // It is only allowed a single handler, from what we can tell

--- a/client/src/push-content.ts
+++ b/client/src/push-content.ts
@@ -272,7 +272,9 @@ export const pushContent = (hostContext: ExtensionHostContext) => async () => {
       if (privateSubmodule !== undefined) {
         try {
           await preparePrivateSubmodule(hostContext.client, privateSubmodule)
-          pushTargets.push(privateSubmodule)
+          // Private submodule should go first because that means the latest
+          // submodule version will be committed
+          pushTargets.unshift(privateSubmodule)
         } catch (e) {
           const err = e as Error
           await vscode.window.showErrorMessage(err.message)

--- a/common/src/requests.ts
+++ b/common/src/requests.ts
@@ -16,7 +16,8 @@ export type Opt<T> = T | undefined
 export enum ExtensionServerRequest {
   BundleEnsureIds = 'BUNDLE_ENSURE_IDS',
   TocModification = 'TOC_MODIFICATION',
-  GenerateReadme = 'GENREATE_README'
+  GenerateReadme = 'GENREATE_README',
+  GetSubmoduleConfig = 'GET_SUBMODULE_CONFIG'
 }
 
 export enum ExtensionServerNotification {
@@ -49,18 +50,22 @@ interface LanguageClient {
   sendRequest: <R>(method: string, param: any) => Promise<R>
 }
 
-export interface BundleEnsureIdsParams {
+export interface BundleRequestParams {
   workspaceUri: string
 }
 
-export interface BundleGenerateReadme {
-  workspaceUri: string
-}
+export interface BundleEnsureIdsParams extends BundleRequestParams { }
+export interface BundleGenerateReadmeParams extends BundleRequestParams { }
+export interface BundleGetSubmoduleConfigParams extends BundleRequestParams { }
 
 export const requestEnsureIds = async (client: LanguageClient, args: BundleEnsureIdsParams): Promise<void> => {
   await client.sendRequest(ExtensionServerRequest.BundleEnsureIds, args)
 }
 
-export const requestGenerateReadme = async (client: LanguageClient, args: BundleGenerateReadme): Promise<void> => {
+export const requestGenerateReadme = async (client: LanguageClient, args: BundleGenerateReadmeParams): Promise<void> => {
   await client.sendRequest(ExtensionServerRequest.GenerateReadme, args)
+}
+
+export const requestGetSubmoduleConfig = async (client: LanguageClient, args: BundleGetSubmoduleConfigParams): Promise<Record<string, string> | null> => {
+  return await client.sendRequest(ExtensionServerRequest.GetSubmoduleConfig, args)
 }

--- a/server/src/git-config-parser.spec.ts
+++ b/server/src/git-config-parser.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from '@jest/globals'
+import { parseGitConfig } from './git-config-parser'
+
+describe('Git config parser', () => {
+  it('parses well-formatted config as expected', () => {
+    const config = `\
+[submodule "private"]
+    path = private
+    url = super-cool-url
+    branch = super-cool-branch
+`
+    const sections = parseGitConfig(config)
+    expect(sections['submodule.private.path']).toBe('private')
+    expect(sections['submodule.private.url']).toBe('super-cool-url')
+    expect(sections['submodule.private.branch']).toBe('super-cool-branch')
+  })
+  it('parses some more interesting stuff', () => {
+    const config = `\
+rootlevelproperty = ignored
+[core]
+        filemode =          true
+        bare         =      false
+        logallrefupdates  = true
+              ignorecase  = true
+        precomposeunicode = true
+`
+    const sections = parseGitConfig(config)
+    expect(sections['root-level-property']).not.toBeDefined()
+    expect(sections['core.bare']).toBe('false')
+    expect(sections['core.ignorecase']).toBe('true')
+  })
+})

--- a/server/src/git-config-parser.ts
+++ b/server/src/git-config-parser.ts
@@ -1,0 +1,28 @@
+// RegExp from: vscode/extensions/git/src/git.ts
+const lineSep = /\r?\n/
+const propertyPattern = /^\s*(\w+)\s*=\s*"?([^"]+)"?$/
+const sectionPattern = /^\s*\[\s*([^\]]+?)\s*("[^"]+")*\]\s*$/
+
+export function parseGitConfig(config: string): Record<string, string> {
+  let sectionName = ''
+  const modulesConfig: Record<string, string> = {}
+  for (const line of config.split(lineSep)) {
+    // Sections
+    const sectionMatch = line.match(sectionPattern)
+    if (sectionMatch?.length === 3) {
+      const subSectionName = sectionMatch[2]?.replace(/"/g, '')
+      sectionName = subSectionName !== undefined
+        ? `${sectionMatch[1]}.${subSectionName}`
+        : sectionMatch[1]
+      continue
+    }
+    // Properties
+    const propertyMatch = line.match(propertyPattern)
+    if (propertyMatch?.length === 3) {
+      if (sectionName.length === 0) continue
+      const key = `${sectionName}.${propertyMatch[1]}`
+      modulesConfig[key] = propertyMatch[2]
+    }
+  }
+  return modulesConfig
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -15,7 +15,7 @@ import { URI, Utils } from 'vscode-uri'
 import { expectValue } from './model/utils'
 
 import { ExtensionServerRequest } from '../../common/src/requests'
-import { bundleEnsureIdsHandler, bundleGenerateReadme, resourceAutocompleteHandler } from './server-handler'
+import { bundleEnsureIdsHandler, bundleGenerateReadme, bundleGetSubmoduleConfig, resourceAutocompleteHandler } from './server-handler'
 
 import * as sourcemaps from 'source-map-support'
 import { Bundle } from './model/bundle'
@@ -154,6 +154,7 @@ connection.onRequest(ExtensionServerRequest.TocModification, async (params: TocM
 
 connection.onRequest(ExtensionServerRequest.BundleEnsureIds, bundleEnsureIdsHandler())
 connection.onRequest(ExtensionServerRequest.GenerateReadme, bundleGenerateReadme())
+connection.onRequest(ExtensionServerRequest.GetSubmoduleConfig, bundleGetSubmoduleConfig())
 
 connection.onCompletionResolve((a: CompletionItem, token: CancellationToken): CompletionItem => a)
 


### PR DESCRIPTION
fixes openstax/ce#2165

# Changes are backward compatible 
## GIVEN
* A book repository that does not have a private submodule
* [This](https://github.com/openstax/poet/actions/runs/8024151015/artifacts/1270765692) version of POET
## WHEN
* POET is activated (by opening its interface or opening a cnxml document)
## THEN
* It works as usual (private submodule is not required)
* Can push changes
* No errors on startup

# Push to private submodule and book repo
**NOTE**: It may be best to use the [private-submodule](https://github.com/openstax/osbooks-playground/tree/private-submodule) branch of osbooks-playground which has a private submodule preconfigured and ready to go.
## GIVEN
* A book repository contains a properly configured private submodule is opened in gitpod
* [This](https://github.com/openstax/poet/actions/runs/8024151015/artifacts/1270765692) version of POET
## WHEN (order is important)
1. You have read and write access to the private submodule
2. POET is activated (by opening its interface or opening a cnxml document)
3. You make a change to a file in the private submodule
## THEN
* The private submodule is checked out to the correct branch (defined in the .gitmodules file)

    * You can check this by running `git -C private branch --show-current` in the terminal

<img width="484" alt="Screenshot 2024-02-27 at 11 30 48 AM" src="https://github.com/openstax/poet/assets/33585550/4bbb5619-941b-4f3b-aae4-c6da392e984d">

* You can push changes to public and private submodule

# Making private submodule changes before POET is activted
**NOTE**: It may be best to use the [private-submodule](https://github.com/openstax/osbooks-playground/tree/private-submodule) branch of osbooks-playground which has a private submodule preconfigured and ready to go.
## GIVEN
* A book repository contains a properly configured private submodule is opened in gitpod
* [This](https://github.com/openstax/poet/actions/runs/8024151015/artifacts/1270765692) version of POET
## WHEN (order is important)
1. You have read and write access to the private submodule
2. You make a change to a file in the private submodule
3. POET is activated (by opening its interface or opening a cnxml document)
## THEN
* The private submodule is checked out to the correct branch (defined in the .gitmodules file)
    * You can check this by running `git -C private branch --show-current` in the terminal or looking in the git SCM panel

<img width="484" alt="Screenshot 2024-02-27 at 11 30 48 AM" src="https://github.com/openstax/poet/assets/33585550/4bbb5619-941b-4f3b-aae4-c6da392e984d">

* You can push changes to public and private submodule

# Error message when submodule is not initialized
**BACKGROUND**: These steps are supposed to create an uninitialized submodule in gitpod. Normally when you open gitpod, it does something like `git clone --recursive` which clones the repository and all submodules. When you start on a branch that does not contain submodules and then switch to one that does, however, the submodules are not cloned/initialized.
## GIVEN
* [no-private-submodule](https://github.com/openstax/osbooks-playground/tree/no-private-submodule) branch of osbooks-playground opened in gitpod
* [This](https://github.com/openstax/poet/actions/runs/8024151015/artifacts/1270765692) version of POET
## WHEN (order is important)
1. You switch to the private-submodule branch of osbooks-playground
2. POET is activated (by opening its interface or opening a cnxml document)
## THEN
* An error message appears warning you that your changes will not be pushed because the private submodule is not initialized
* Trying to push causes the error message to appear again
* If there are changes in the book repository, these are still pushed

---

# Summary of Changes

Unfortunately, the git extension [does not surface](https://github.com/microsoft/vscode/blob/7215958b3c57945b49d3b70afdba7fb47319ca85/extensions/git/src/api/git.d.ts#L65) the `branch` property of `.gitmodules`. It [parses the file](https://github.com/microsoft/vscode/blob/7215958b3c57945b49d3b70afdba7fb47319ca85/extensions/git/src/git.ts#L739) in nearly the exact same way, but [branch is omitted](https://github.com/microsoft/vscode/blob/7215958b3c57945b49d3b70afdba7fb47319ca85/extensions/git/src/git.ts#L854) for some reason.

The only alternative was to try to guess the edition of the book and construct the branch name using the guessed edition and workspace root directory name. Parsing the configuration seemed like the better of the two options since it makes fewer assumptions and is less reliant on repository file structure.

Making a PR to vscode to include the branch might be a good thing to do in the long-term.