### PR TITLE
Use modal error for submodule errors during push

### DIFF
--- a/client/src/push-content.ts
+++ b/client/src/push-content.ts
@@ -291,10 +291,12 @@ export const pushContent = (hostContext: ExtensionHostContext) => async () => {
         }
       } catch (e) {
         const err = e as Error
-        // Add '.' if the message does not end in '.', '?', or '!'.
-        const errMsg = err.message.trimEnd().replace(/[^.?!]$/, (s) => `${s}.`)
+        const errMsg = [
+          'Your changes will not be committed/pushed to the private submodule!',
+          `Underlying reason: ${err.message}`
+        ].join('\n\n')
         const response = await vscode.window.showErrorMessage(
-          `${errMsg} Your changes will not be committed/pushed to the private submodule!`,
+          errMsg,
           { modal: true, detail: 'Continue pushing to book repository?' },
           'OK'
         )


### PR DESCRIPTION
Some changes suggested by @omehes to improve user experience:

When changes cannot be pushed to the private submodule:
  - A modal error dialog displays the error
  - There is an option to continue pushing changes to the book repository

Prior to this change, errors in preparing the private submodule would cause the entire push process to be aborted. Now there is an option to continue or bail out

<img width="583" alt="Screenshot 2024-03-08 at 9 22 50 AM" src="https://github.com/openstax/poet/assets/33585550/cd29560f-d0d5-4270-87c2-4daba40d7b25">

<img width="583" alt="Screenshot 2024-03-08 at 10 07 30 AM" src="https://github.com/openstax/poet/assets/33585550/548ca25f-ce13-43d3-a220-79c8c8226345">
