### PR TITLE
2209 h5p exercise url

### DIFF
--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -165,10 +165,20 @@ export function launchLanguageServer(context: vscode.ExtensionContext): Language
     documentSelector: [{ scheme: 'file', language: 'xml' }],
     synchronize: {
       fileEvents: [
+        // FIXME: media, modules, collections, etc. should not be hardcoded here
+        // NOTE: these patterns do not support matching directories without matching files
+        // '**/*/' and '**/**/' both match all directories AND files
+        // Additionally, events are sent for each pattern that matches. This can cause
+        // massively degraded performance if there are many overlapping patterns
+        // It is a known issue and a completely new watcher system is being created to address
+        // the shortcomings of this one
+        // See: https://github.com/microsoft/vscode/wiki/File-Watcher-Internals
         vscode.workspace.createFileSystemWatcher('**/META-INF/books.xml'),
         vscode.workspace.createFileSystemWatcher('**/media/**'),
-        vscode.workspace.createFileSystemWatcher('**/*.cnxml'),
-        vscode.workspace.createFileSystemWatcher('**/*.collection.xml')
+        vscode.workspace.createFileSystemWatcher('**/modules/**'),
+        vscode.workspace.createFileSystemWatcher('**/*.collection.xml'),
+        vscode.workspace.createFileSystemWatcher('**/interactives/*/'),
+        vscode.workspace.createFileSystemWatcher('**/interactives/*/h5p.json')
       ]
     }
   }

--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -440,9 +440,11 @@ describe('Image Autocomplete', () => {
 describe('URL Autocomplete', () => {
   const sinon = SinonRoot.createSandbox()
   const h5pName = 'abc'
+  const orphanedH5PName = '123'
   let manager = null as unknown as ModelManager
   let page: PageNode
   let h5p: H5PExercise
+  let orphanedH5P: H5PExercise
 
   beforeEach(() => {
     const bundle = makeBundle()
@@ -450,6 +452,8 @@ describe('URL Autocomplete', () => {
     page = first(loadSuccess(first(loadSuccess(manager.bundle).books)).pages)
     h5p = manager.bundle.allH5P.getOrAdd(newH5PPath(manager.bundle, h5pName))
     h5p.load('any-string')
+    orphanedH5P = manager.bundle.allH5P.getOrAdd(newH5PPath(manager.bundle, orphanedH5PName))
+    orphanedH5P.load('any-string')
     manager.updateFileContents(page.absPath, pageMaker({ pageLinks: [{ url: `${H5PExercise.PLACEHOLDER}/abc` }] }))
   })
 
@@ -457,7 +461,7 @@ describe('URL Autocomplete', () => {
     sinon.restore()
   })
 
-  it('Returns all H5P interactives', () => {
+  it('Returns orphaned H5P interactives', () => {
     expect(page.validationErrors.nodesToLoad.toArray()).toEqual([])
     expect(page.validationErrors.errors.toArray()).toEqual([])
 
@@ -471,7 +475,7 @@ describe('URL Autocomplete', () => {
       }
     )
     expect(results).not.toEqual([])
-    expect(results[0].label).toBe(`${H5PExercise.PLACEHOLDER}/${h5pName}`)
+    expect(results[0].label).toBe(`${H5PExercise.PLACEHOLDER}/${orphanedH5PName}`)
   })
 
   it('Returns no results outside url tag', () => {

--- a/server/src/model-manager.ts
+++ b/server/src/model-manager.ts
@@ -186,6 +186,12 @@ export class ModelManager {
     return this.bundle.allResources.all.filter(loadedAndExists).subtract(pages.flatMap(p => p.resources))
   }
 
+  public get orphanedH5P() {
+    const books = this.bundle.books.filter(loadedAndExists)
+    const pages = books.flatMap(b => b.pages)
+    return this.bundle.allH5P.all.filter(loadedAndExists).subtract(pages.flatMap(p => p.h5p))
+  }
+
   public async loadEnoughForToc() {
     // The only reason this is not implemented as a Job is because we need to send a timely response to the client
     // and there is no code for being notified when a Job completes
@@ -464,7 +470,7 @@ export class ModelManager {
       },
       getRange: this.rangeFinderFactory('url="', '"'),
       getCompletionItems: (_page, range) => {
-        return this.bundle.allH5P.all.toArray().filter((h) => h.exists)
+        return this.orphanedH5P.toArray().filter((h) => h.exists)
           .map((h) => path.dirname(h.absPath))
           .map((p) => path.basename(p))
           .map((name) => {

--- a/server/src/model/bundle.ts
+++ b/server/src/model/bundle.ts
@@ -63,7 +63,7 @@ export class Bundle extends Fileish implements Bundleish {
   }
 
   public get allNodes() {
-    return I.Set([this]).union(this.allBooks.all).union(this.allPages.all).union(this.allResources.all)
+    return I.Set([this]).union(this.allBooks.all).union(this.allPages.all).union(this.allResources.all).union(this.allH5P.all)
   }
 
   public get books() {

--- a/server/src/model/bundle.ts
+++ b/server/src/model/bundle.ts
@@ -6,10 +6,12 @@ import { PageNode } from './page'
 import { BookNode } from './book'
 import { Fileish, type ValidationCheck, ValidationKind } from './fileish'
 import { ResourceNode } from './resource'
+import { H5PExercise } from './h5p-exercise'
 
 export class Bundle extends Fileish implements Bundleish {
   public readonly allResources: Factory<ResourceNode> = new Factory<ResourceNode>((absPath: string) => new ResourceNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
   public readonly allPages: Factory<PageNode> = new Factory<PageNode>((absPath: string) => new PageNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
+  public readonly allH5P: Factory<H5PExercise> = new Factory<H5PExercise>((absPath: string) => new H5PExercise(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
   public readonly allBooks = new Factory((absPath: string) => new BookNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
   private readonly _books = Quarx.observable.box<Opt<I.Set<WithRange<BookNode>>>>(undefined)
   private readonly _duplicateResourcePaths = Quarx.observable.box<I.Set<string>>(I.Set<string>())

--- a/server/src/model/bundle.ts
+++ b/server/src/model/bundle.ts
@@ -14,6 +14,14 @@ export class Bundle extends Fileish implements Bundleish {
   private readonly _books = Quarx.observable.box<Opt<I.Set<WithRange<BookNode>>>>(undefined)
   private readonly _duplicateResourcePaths = Quarx.observable.box<I.Set<string>>(I.Set<string>())
   private readonly _duplicateUUIDs = Quarx.observable.box<I.Set<string>>(I.Set<string>())
+  // TODO: parse these from META-INF/books.xml
+  public readonly paths = {
+    publicRoot: 'interactives',
+    privateRoot: 'private',
+    booksRoot: 'collections',
+    pagesRoot: 'modules',
+    mediaRoot: 'media'
+  }
 
   constructor(pathHelper: PathHelper<string>, public readonly workspaceRootUri: string) {
     super(undefined, pathHelper, pathHelper.join(workspaceRootUri, 'META-INF/books.xml'))

--- a/server/src/model/h5p-exercise.spec.ts
+++ b/server/src/model/h5p-exercise.spec.ts
@@ -1,0 +1,12 @@
+import { ResourceValidationKind } from './resource'
+import { bundleMaker, expectErrors, makeBundle, newH5PPath } from './spec-helpers.spec'
+
+describe('Resource validations', () => {
+  it(ResourceValidationKind.DUPLICATE_RESOURCES.title, () => {
+    const bundle = makeBundle()
+    bundle.load(bundleMaker({}))
+    const h5p = bundle.allH5P.getOrAdd(newH5PPath(bundle, 'abc'))
+    h5p.load('bits-dont-matter')
+    expectErrors(h5p, [])
+  })
+})

--- a/server/src/model/h5p-exercise.spec.ts
+++ b/server/src/model/h5p-exercise.spec.ts
@@ -1,7 +1,7 @@
 import { ResourceValidationKind } from './resource'
 import { bundleMaker, expectErrors, makeBundle, newH5PPath } from './spec-helpers.spec'
 
-describe('Resource validations', () => {
+describe('H5P validations', () => {
   it(ResourceValidationKind.DUPLICATE_RESOURCES.title, () => {
     const bundle = makeBundle()
     bundle.load(bundleMaker({}))

--- a/server/src/model/h5p-exercise.ts
+++ b/server/src/model/h5p-exercise.ts
@@ -1,0 +1,9 @@
+import { Fileish, type ValidationCheck } from './fileish'
+
+export class H5PExercise extends Fileish {
+  public static readonly PLACEHOLDER = '{INTERACTIVES_ROOT}'
+
+  protected getValidationChecks(): ValidationCheck[] {
+    return []
+  }
+}

--- a/server/src/model/page.ts
+++ b/server/src/model/page.ts
@@ -155,6 +155,12 @@ export class PageNode extends Fileish {
     return this.resourceLinks.map(l => l.target)
   }
 
+  public get h5p() {
+    return this.pageLinks
+      .filter((l): l is PageLink & { type: PageLinkKind.H5P } => l.type === PageLinkKind.H5P)
+      .map((l) => l.h5p)
+  }
+
   public get resourceLinks() {
     return this.ensureLoaded(this._resourceLinks)
   }

--- a/server/src/model/page.ts
+++ b/server/src/model/page.ts
@@ -3,6 +3,7 @@ import * as Quarx from 'quarx'
 import { type Opt, type Position, PathKind, type WithRange, textWithRange, select, selectOne, calculateElementPositions, expectValue, type HasRange, NOWHERE, join, equalsOpt, equalsWithRange, tripleEq, type Range } from './utils'
 import { Fileish, type ValidationCheck, ValidationKind, ValidationSeverity } from './fileish'
 import { type ResourceNode } from './resource'
+import { H5PExercise } from './h5p-exercise'
 
 enum ResourceLinkKind {
   Image,
@@ -20,6 +21,7 @@ export interface IFrameLink extends HasRange {
 
 export enum PageLinkKind {
   URL,
+  H5P,
   PAGE,
   PAGE_ELEMENT,
   UNKNOWN
@@ -36,6 +38,10 @@ export type PageLink = HasRange & ({
   targetElementId: string
 } | {
   type: PageLinkKind.UNKNOWN
+} | {
+  type: PageLinkKind.H5P
+  url: string
+  h5p: H5PExercise
 })
 
 function convertToPos(str: string, cursor: number): Position {
@@ -59,7 +65,17 @@ const equalsOptWithRange = equalsOpt(equalsWithRange(tripleEq))
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
-const URL_RE = /^(#(exercise|ost\/api\/ex)\/[A-Za-z0-9\-_]+|(https?:\/\/|www.)[^\s$.?#].[^\s]*)$/i
+const URL_RE = /^(https?:\/\/|www\.)[^\s$.?#].[^\s]*$/i
+
+// NOTE: These should be case sensitive because matching is case sensitive during exercise injection
+// Match exercise nickname or exercise tag, respectively
+const EXERCISES_RE = /^#(exercise|ost\/api\/ex)\/[A-Za-z0-9\-_]+[^\s$.?#].[^\s]*$/
+// Match placeholder followed by any valid path name
+const H5P_RE = new RegExp(`^${H5PExercise.PLACEHOLDER}/[^\\?/:*"<>#|\0]+$`)
+
+const isWebPath = URL_RE.test.bind(URL_RE)
+const isExercisePath = EXERCISES_RE.test.bind(EXERCISES_RE)
+const isH5PPath = H5P_RE.test.bind(H5P_RE)
 
 export const ELEMENT_TO_PREFIX = new Map<string, string>()
 ELEMENT_TO_PREFIX.set('para', 'para')
@@ -187,6 +203,15 @@ export class PageNode extends Fileish {
       const toTargetId = changeEmptyToNull(linkNode.getAttribute('target-id'))
       const toUrl = changeEmptyToNull(linkNode.getAttribute('url'))
       if (toUrl !== undefined) {
+        if (isH5PPath(toUrl)) {
+          const absPath = this.pathHelper.join(
+            super.bundle.workspaceRootUri,
+            toUrl.replace(H5PExercise.PLACEHOLDER, super.bundle.paths.publicRoot),
+            'h5p.json'
+          )
+          const target = super.bundle.allH5P.getOrAdd(absPath)
+          return { range, type: PageLinkKind.H5P, url: toUrl, h5p: target }
+        }
         return { range, type: PageLinkKind.URL, url: toUrl }
       }
       if (toDocument === undefined && toTargetId === undefined && toUrl === undefined) {
@@ -228,6 +253,9 @@ export class PageNode extends Fileish {
       {
         message: PageValidationKind.MISSING_TARGET,
         nodesToLoad: filterNull(pageLinks.map(l => {
+          if (l.type === PageLinkKind.H5P) {
+            return l.h5p
+          }
           if (l.type !== PageLinkKind.URL && l.type !== PageLinkKind.UNKNOWN && l.page !== this) {
             return l.page
           }
@@ -236,6 +264,7 @@ export class PageNode extends Fileish {
         fn: () => pageLinks.filter(l => {
           if (l.type === PageLinkKind.UNKNOWN) return false // unknown links are bad (but we can't check them)
           if (l.type === PageLinkKind.URL) return false // URL links are ok
+          if (l.type === PageLinkKind.H5P) return !l.h5p.exists
           if (!l.page.exists) return true // link to non-existent page are bad
           if (l.type === PageLinkKind.PAGE) return false // linking to the whole page and it exists is ok
           return !l.page.hasElementId(l.targetElementId)
@@ -279,7 +308,9 @@ export class PageNode extends Fileish {
         message: PageValidationKind.INVALID_URL,
         nodesToLoad: I.Set(),
         fn: () => this.pageLinks.filter(l => {
-          return l.type === PageLinkKind.URL && !URL_RE.test(l.url)
+          return l.type === PageLinkKind.URL && !(
+            isWebPath(l.url) || isExercisePath(l.url) || isH5PPath(l.url)
+          )
         }).map(l => l.range)
       }
     ]

--- a/server/src/model/spec-helpers.spec.ts
+++ b/server/src/model/spec-helpers.spec.ts
@@ -169,3 +169,9 @@ export function bundleMaker(info: BundleMakerInfo) {
 ${i.books.map(({ slug, href }) => `<book slug="${slug}" href="${href}" />`).join('\n')}
 </container>`
 }
+
+export function newH5PPath(bundle: Bundle, nickname: string) {
+  return bundle.pathHelper.join(
+    bundle.workspaceRootUri, bundle.paths.publicRoot, nickname, 'h5p.json'
+  )
+}

--- a/server/src/model/utils.ts
+++ b/server/src/model/utils.ts
@@ -66,12 +66,21 @@ export type TocNode<T> = TocSubbook<T> | TocPage<T>
 export interface TocSubbook<T> { type: TocNodeKind.Subbook, readonly title: string, readonly children: Array<TocNode<T>> }
 export interface TocPage<T> { type: TocNodeKind.Page, readonly page: T }
 
+export interface Paths {
+  booksRoot: string
+  pagesRoot: string
+  mediaRoot: string
+  privateRoot: string
+  publicRoot: string
+}
+
 export interface Bundleish {
   allPages: Factory<PageNode>
   allResources: Factory<ResourceNode>
   workspaceRootUri: string
   isDuplicateUuid: (uuid: string) => boolean
   isDuplicateResourcePath: (path: string) => boolean
+  paths: Paths
 }
 
 export enum PathKind {

--- a/server/src/model/utils.ts
+++ b/server/src/model/utils.ts
@@ -4,6 +4,7 @@ import * as xpath from 'xpath-ts'
 import { type PageNode } from './page'
 import { type Factory } from './factory'
 import { type ResourceNode } from './resource'
+import { type H5PExercise } from './h5p-exercise'
 
 export const NS_COLLECTION = 'http://cnx.rice.edu/collxml'
 const NS_CNXML = 'http://cnx.rice.edu/cnxml'
@@ -77,6 +78,7 @@ export interface Paths {
 export interface Bundleish {
   allPages: Factory<PageNode>
   allResources: Factory<ResourceNode>
+  allH5P: Factory<H5PExercise>
   workspaceRootUri: string
   isDuplicateUuid: (uuid: string) => boolean
   isDuplicateResourcePath: (path: string) => boolean

--- a/server/src/server-handler.ts
+++ b/server/src/server-handler.ts
@@ -45,13 +45,16 @@ export function bundleGetSubmoduleConfig(): (request: BundleGetSubmoduleConfigPa
   }
 }
 
-export async function resourceAutocompleteHandler(documentPosition: CompletionParams, manager: ModelManager): Promise<CompletionItem[]> {
+export async function autocompleteHandler(documentPosition: CompletionParams, manager: ModelManager): Promise<CompletionItem[]> {
   await manager.loadEnoughForOrphans()
   const cursor = documentPosition.position
   const page = manager.bundle.allPages.get(documentPosition.textDocument.uri)
 
   if (page !== undefined) {
-    return manager.autocompleteResources(page, cursor)
+    return [
+      ...manager.autocompleteResources(page, cursor),
+      ...manager.autocompleteUrls(page, cursor)
+    ]
   }
   return []
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -15,7 +15,7 @@ import { URI, Utils } from 'vscode-uri'
 import { expectValue } from './model/utils'
 
 import { ExtensionServerRequest } from '../../common/src/requests'
-import { bundleEnsureIdsHandler, bundleGenerateReadme, bundleGetSubmoduleConfig, resourceAutocompleteHandler } from './server-handler'
+import { bundleEnsureIdsHandler, bundleGenerateReadme, bundleGetSubmoduleConfig, autocompleteHandler } from './server-handler'
 
 import * as sourcemaps from 'source-map-support'
 import { Bundle } from './model/bundle'
@@ -160,7 +160,7 @@ connection.onCompletionResolve((a: CompletionItem, token: CancellationToken): Co
 
 connection.onCompletion(async (params: CompletionParams): Promise<CompletionItem[]> => {
   const manager = getBundleForUri(params.textDocument.uri)
-  return await resourceAutocompleteHandler(params, manager)
+  return await autocompleteHandler(params, manager)
 })
 connection.onDocumentLinks(async ({ textDocument }) => {
   const { uri } = textDocument


### PR DESCRIPTION
fixes openstax/ce#2209

# Summary

- Add H5P exercise type (not part of resources because of the number of assumptions made about resources).
- Add note about paths being hardcoded into file system watchers and likelihood of watcher system changing.
- Check H5P exercise exists as part of page validation.
- Add H5P exercise url autocompletion.

# Known issues

While making these changes, I found a few problems and I am working on making new issues for each since they are outside of the scope of 2209.

- Directory creation events are not handled at all. Moving a directory containing content that POET understands into an area POET is watching does not result in that content being added to the bundle.
- Page validation errors related to content not existing, i.e. resource or h5p, do not update until the page updates.
- Content paths are hardcoded into client where file system watchers are created.