### PR TITLE
Mark nodes removed instead of deleting them

### DIFF
--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -317,6 +317,8 @@ describe('processFilesystemChange()', () => {
     // Load the Bundle, Book, and Page
     loadSuccess(first(loadSuccess(first(loadSuccess(manager.bundle).books)).pages))
 
+    const sizeBefore = manager.bundle.allNodes.size
+
     // Delete non-existent file
     expect((await fireChange(FileChangeType.Deleted, 'media/newpic.png')).toArray()).toEqual([])
     // Delete a file
@@ -328,8 +330,10 @@ describe('processFilesystemChange()', () => {
     // expect(sendDiagnosticsStub.callCount).toBe(0)
 
     // Delete everything (including the bundle)
-    expect((await fireChange(FileChangeType.Deleted, '')).size).toBe(1)
+    // All nodes should still be in bundle, but they should no longer exist
+    expect((await fireChange(FileChangeType.Deleted, '')).size).toBe(sizeBefore)
     expect(manager.bundle.exists).toBe(false)
+    expect(manager.bundle.allNodes.every((n) => !n.exists))
   })
   it('deletes Image/Page/Book', async () => {
     // Load the Bundle, Book, and Page

--- a/server/src/model/bundle.ts
+++ b/server/src/model/bundle.ts
@@ -14,7 +14,7 @@ export class Bundle extends Fileish implements Bundleish {
   public readonly allH5P: Factory<H5PExercise> = new Factory<H5PExercise>((absPath: string) => new H5PExercise(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
   public readonly allBooks = new Factory((absPath: string) => new BookNode(this, this.pathHelper, absPath), (x) => this.pathHelper.canonicalize(x))
   private readonly _books = Quarx.observable.box<Opt<I.Set<WithRange<BookNode>>>>(undefined)
-  private readonly _duplicateResourcePaths = Quarx.observable.box<I.Set<string>>(I.Set<string>())
+  private readonly _duplicateFilePaths = Quarx.observable.box<I.Set<string>>(I.Set<string>())
   private readonly _duplicateUUIDs = Quarx.observable.box<I.Set<string>>(I.Set<string>())
   // TODO: parse these from META-INF/books.xml
   public readonly paths = {
@@ -29,10 +29,12 @@ export class Bundle extends Fileish implements Bundleish {
     super(undefined, pathHelper, pathHelper.join(workspaceRootUri, 'META-INF/books.xml'))
     super.setBundle(this)
     Quarx.autorun(() => {
-      this._duplicateResourcePaths.set(
+      this._duplicateFilePaths.set(
         I.Set(
-          findDuplicates(I.List(this.allResources.all)
-            .map(n => n.absPath.toLowerCase())
+          findDuplicates(
+            I.List(this.allNodes)
+              .filter(n => n.exists)
+              .map(n => n.absPath.toLowerCase())
           )
         )
       )
@@ -40,9 +42,8 @@ export class Bundle extends Fileish implements Bundleish {
     Quarx.autorun(() => {
       this._duplicateUUIDs.set(
         I.Set(
-          findDuplicates(I.List(this.allPages.all)
-            .filter(n => n.exists)
-            .map(n => n.uuid())
+          findDuplicates(
+            I.List(this.allPages.all).filter(n => n.exists).map(n => n.uuid())
           )
         )
       )
@@ -62,16 +63,21 @@ export class Bundle extends Fileish implements Bundleish {
     })))
   }
 
+  public get allFactories() {
+    return I.Set([this.allBooks, this.allPages, this.allResources, this.allH5P])
+  }
+
   public get allNodes() {
-    return I.Set([this]).union(this.allBooks.all).union(this.allPages.all).union(this.allResources.all).union(this.allH5P.all)
+    // TODO: Will all nodes continue to be fileish in future?
+    return I.Set([this]).union(this.allFactories.flatMap<Bundle | BookNode | PageNode | ResourceNode | H5PExercise>((f) => f.all))
   }
 
   public get books() {
     return this.__books().map(b => b.v)
   }
 
-  public isDuplicateResourcePath(path: string): boolean {
-    return this._duplicateResourcePaths.get().has(path.toLowerCase())
+  public isDuplicateFilePath(path: string): boolean {
+    return this._duplicateFilePaths.get().has(path.toLowerCase())
   }
 
   private __books() {

--- a/server/src/model/factory.spec.ts
+++ b/server/src/model/factory.spec.ts
@@ -14,7 +14,7 @@ describe('Factory', () => {
     expect(f.getOrAdd('key2').thing).toEqual(1)
     expect(f.get('key2')).not.toBeUndefined()
   })
-  it('removesByKeyPrefix works', () => {
+  it('findByKeyPrefix works', () => {
     const f = new Factory((x) => ({ foo: x, bar: 'dummy-object' }), (x) => x)
     f.getOrAdd('keyPrefix1')
     f.getOrAdd('keyPrefix2')
@@ -22,8 +22,8 @@ describe('Factory', () => {
     f.getOrAdd('not_a_keyPrefix')
 
     expect(f.size).toEqual(4)
-    const removed = f.removeByKeyPrefix('keyPrefix')
-    expect(removed.size).toEqual(2)
-    expect(f.size).toEqual(2)
+    const found = f.findByKeyPrefix('keyPrefix')
+    expect(found.size).toEqual(2)
+    expect(f.size).toEqual(4)
   })
 })

--- a/server/src/model/factory.ts
+++ b/server/src/model/factory.ts
@@ -22,20 +22,11 @@ export class Factory<T> {
     }
   }
 
-  public remove(absPath: string) {
-    absPath = this.canonicalizer(absPath)
-    const m = this._map.get()
-    const item = m.get(absPath)
-    this._map.set(m.delete(absPath))
-    return item
-  }
-
-  public removeByKeyPrefix(pathPrefix: string) {
+  public findByKeyPrefix(pathPrefix: string) {
     pathPrefix = this.canonicalizer(pathPrefix)
     const m = this._map.get()
-    const removedItems = m.filter((_, key) => key.startsWith(pathPrefix))
-    this._map.set(m.filter((_, key) => !key.startsWith(pathPrefix)))
-    return I.Set(removedItems.values())
+    const matchingItems = m.filter((_, key) => key.startsWith(pathPrefix))
+    return I.Set(matchingItems.values())
   }
 
   public get size() { return this._map.get().size }

--- a/server/src/model/resource.ts
+++ b/server/src/model/resource.ts
@@ -8,7 +8,7 @@ export class ResourceNode extends Fileish {
     return [{
       message: ResourceValidationKind.DUPLICATE_RESOURCES,
       nodesToLoad: I.Set<Fileish>(),
-      fn: () => this.bundle.isDuplicateResourcePath(this.absPath)
+      fn: () => this.bundle.isDuplicateFilePath(this.absPath)
         ? I.Set([NOWHERE])
         : I.Set<Range>()
     }]

--- a/server/src/model/utils.ts
+++ b/server/src/model/utils.ts
@@ -81,7 +81,7 @@ export interface Bundleish {
   allH5P: Factory<H5PExercise>
   workspaceRootUri: string
   isDuplicateUuid: (uuid: string) => boolean
-  isDuplicateResourcePath: (path: string) => boolean
+  isDuplicateFilePath: (path: string) => boolean
   paths: Paths
 }
 

--- a/server/src/server-handler.ts
+++ b/server/src/server-handler.ts
@@ -50,7 +50,7 @@ export async function autocompleteHandler(documentPosition: CompletionParams, ma
   const cursor = documentPosition.position
   const page = manager.bundle.allPages.get(documentPosition.textDocument.uri)
 
-  if (page !== undefined) {
+  if (page !== undefined && page.exists) {
     return [
       ...manager.autocompleteResources(page, cursor),
       ...manager.autocompleteUrls(page, cursor)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -166,7 +166,7 @@ connection.onDocumentLinks(async ({ textDocument }) => {
   const { uri } = textDocument
   const manager = getBundleForUri(uri)
   const page = manager.bundle.allPages.get(uri)
-  if (page !== undefined) {
+  if (page !== undefined && page.exists) {
     return await manager.getDocumentLinks(page)
   } else {
     return []


### PR DESCRIPTION
fixes openstax/ce#2217

# Problem:

- When POET loads a page, references to resources on the page are stored in the  page node (see _resourceLinks)

- When a resource was removed from the bundle, perhaps via a filesystem event, the references in the page remained, even though the resources no longer existed in the bundle.

- When a resource with the same absPath was created, it was added to the bundle again. This new resource instance, however, was distinct from the one that existed within the page, even though they pointed to the same content on the filesystem.

- Until the page was updated, which causes the links to be reconstructed, resource links stored in the page did not correlate with the ones stored in the bundle. Consequently, the `exists` property of the resource node was not being updated

# Solution:

- Keep all nodes in the bundle

- When a file referenced by a node is deleted from the filesystem, update the node's contents to `undefined` so that the node's `exists` property will be set to false

# Possible problems & justifications:

- This technically introduces a memory leak where nodes continue to accumulate in the bundle forever; however, there are many ways this memory leak could be addressed if it becomes a real problem.

- Out of all the approaches I explored, this one made the best use of Quarx, required the least number of changes, and exhibited the best performance.