### PR TITLE
2216 handle directory creation

### DIFF
--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -165,7 +165,6 @@ export function launchLanguageServer(context: vscode.ExtensionContext): Language
     documentSelector: [{ scheme: 'file', language: 'xml' }],
     synchronize: {
       fileEvents: [
-        // FIXME: media, modules, collections, etc. should not be hardcoded here
         // NOTE: these patterns do not support matching directories without matching files
         // '**/*/' and '**/**/' both match all directories AND files
         // Additionally, events are sent for each pattern that matches. This can cause
@@ -173,12 +172,7 @@ export function launchLanguageServer(context: vscode.ExtensionContext): Language
         // It is a known issue and a completely new watcher system is being created to address
         // the shortcomings of this one
         // See: https://github.com/microsoft/vscode/wiki/File-Watcher-Internals
-        vscode.workspace.createFileSystemWatcher('**/META-INF/books.xml'),
-        vscode.workspace.createFileSystemWatcher('**/media/**'),
-        vscode.workspace.createFileSystemWatcher('**/modules/**'),
-        vscode.workspace.createFileSystemWatcher('**/*.collection.xml'),
-        vscode.workspace.createFileSystemWatcher('**/interactives/*/'),
-        vscode.workspace.createFileSystemWatcher('**/interactives/*/h5p.json')
+        vscode.workspace.createFileSystemWatcher('**/*')
       ]
     }
   }

--- a/server/src/fs-utils.spec.ts
+++ b/server/src/fs-utils.spec.ts
@@ -1,0 +1,192 @@
+import { expect, beforeEach, jest } from '@jest/globals'
+import { type Dirent, type Walker, followSymbolicLinks, walkDir, adaptFSDirent, isDirectorySync, isFileSync } from './fs-utils'
+import { expectValue } from './model/utils'
+import { type Dirent as FSDirent } from 'fs'
+import SinonRoot from 'sinon'
+import { Substitute } from '@fluffy-spoon/substitute'
+import path from 'path'
+import mockfs from 'mock-fs'
+
+let iota = 0
+
+enum EntryType {
+  File = 1 << iota++,
+  Directory = 1 << iota++,
+  SymbolicLink = 1 << iota++
+}
+
+describe('FS Utils', () => {
+  const sinon = SinonRoot.createSandbox()
+  afterEach(() => {
+    sinon.restore()
+  })
+  describe('walkDir', () => {
+    let mockFS: Record<string, Dirent>
+    const createEntry = (
+      path: string, type: EntryType, realpath: (p: string) => string
+    ): Dirent => {
+      const name = path.split('/').slice(-1)[0]
+      return {
+        name,
+        path,
+        get realpath() { return realpath(this.path) },
+        isFile: jest.fn<() => boolean>().mockReturnValue((type & EntryType.File) === EntryType.File),
+        isDirectory: jest.fn<() => boolean>().mockReturnValue((type & EntryType.Directory) === EntryType.Directory),
+        isSymbolicLink: jest.fn<() => boolean>().mockReturnValue((type & EntryType.SymbolicLink) === EntryType.SymbolicLink)
+      }
+    }
+    const getOrAddEntry = (
+      path: string, type: EntryType, realpath = (p: string) => p
+    ) => {
+      if (!(path in mockFS)) {
+        const entry = createEntry(path, type, realpath)
+        mockFS[path] = entry
+      }
+      return expectValue(mockFS[path], path)
+    }
+    const getEntry = (path: string): Dirent | undefined => mockFS[path]
+    beforeEach(() => {
+      mockFS = Object.create(null)
+    })
+    it('walks regular directories', () => {
+      const walker: Walker = {
+        readdir: (dir) => Object.values(mockFS).filter((v) =>
+          v.path !== dir && v.path.split('/').slice(0, -1).join('/') === dir
+        ),
+        shouldWalk: (dirent) => dirent.isDirectory(),
+        onError: (err) => { throw err }
+      }
+      const entries = [
+        getOrAddEntry('/a.txt', EntryType.File),
+        getOrAddEntry('/dir1', EntryType.Directory),
+        getOrAddEntry('/dir1/b.txt', EntryType.File)
+      ]
+      const result = Array.from(walkDir(walker, ''))
+      entries.forEach((e) => {
+        expect(e.isDirectory).toHaveBeenCalled()
+      })
+      expect(result).toStrictEqual(entries)
+    })
+    it('can handle symbolic links', () => {
+      const symlinkMap: Record<string, string> = {
+        '/dir1/dir2': '/dir1',
+        '/b.txt': '/a.txt',
+        '/dir1/dir2/dir3': '/dir1'
+      }
+      const realpath = (p: string) => (p in symlinkMap) ? symlinkMap[p] : p
+      const { File, Directory, SymbolicLink } = EntryType
+      getOrAddEntry('/a.txt', File, realpath)
+      getOrAddEntry('/b.txt', SymbolicLink | File, realpath)
+      getOrAddEntry('/dir1', Directory, realpath)
+      getOrAddEntry('/dir1/something.txt', File, realpath)
+      getOrAddEntry('/dir1/something2.txt', File, realpath)
+      getOrAddEntry('/dir1/dir2', SymbolicLink | Directory, realpath)
+      getOrAddEntry('/dir1/dir2/dir3', SymbolicLink | Directory, realpath)
+      getOrAddEntry('/dir1/dir2/something.txt', SymbolicLink | File, realpath)
+      getOrAddEntry('/dir1/dir2/something2.txt', SymbolicLink | File, realpath)
+      const shouldWalk = followSymbolicLinks()
+      const walker: Walker = {
+        readdir: (dir) => Object.values(mockFS).filter((v) =>
+          v.path !== dir && v.path.split('/').slice(0, -1).join('/') === dir
+        ),
+        shouldWalk,
+        onError: (err) => { throw err }
+      }
+      const results = Array.from(walkDir(walker, ''))
+      // It should not yield the contents of dir2 because dir2 is dir1, which
+      // was already visited
+      const expectedResults = [
+        getEntry('/a.txt'),
+        getEntry('/b.txt'),
+        getEntry('/dir1'),
+        getEntry('/dir1/something.txt'),
+        getEntry('/dir1/something2.txt'),
+        getEntry('/dir1/dir2')
+      ]
+      expect(results).toStrictEqual(expectedResults)
+    })
+    it('handles errors correctly', () => {
+      const onErrorStub = jest.fn<() => void>()
+      const readdirStub = jest.fn<(wd: string) => Dirent[]>().mockImplementation(() => {
+        throw new Error('My readdir error message')
+      })
+      getOrAddEntry('/a.txt', EntryType.File)
+      const walker: Walker = {
+        readdir: readdirStub,
+        shouldWalk: (dirent) => dirent.isDirectory(),
+        onError: onErrorStub
+      }
+      expect(Array.from(walkDir(walker, '/'))).toStrictEqual([])
+      expect(readdirStub).toHaveBeenCalled()
+      expect(onErrorStub).toHaveBeenCalled()
+    })
+  })
+  describe('file system tests', () => {
+    const mockFileName = 'file-that-does-exist'
+    const mockDirName = 'directory-that-does-exist'
+    beforeEach(() => {
+      mockfs({
+        [mockFileName]: '',
+        [mockDirName]: {}
+      })
+    })
+    afterEach(() => {
+      mockfs.restore()
+    })
+    it('adaptFSDirent adapts fs dirents correctly', () => {
+      const mock = {
+        name: 'test',
+        isFile: jest.fn<() => boolean>(),
+        isDirectory: jest.fn<() => boolean>(),
+        isSymbolicLink: jest.fn<() => boolean>()
+      }
+      const fakeFSDirent = new Proxy(Substitute.for<FSDirent>(), {
+        get: (target, p) => Reflect.get(mock, p) ?? Reflect.get(target, p)
+      })
+      const fakePath = 'fs-utils.spec.ts-fake-dir-for-test'
+      const adapted = adaptFSDirent(fakePath, (p) => `realpath-${p}`, fakeFSDirent)
+      expect(adapted.path).toBe(path.join(fakePath, mock.name))
+      expect(adapted.realpath).toBe(path.join(`realpath-${fakePath}`, mock.name))
+
+      // Ensure everything is adapted correctly
+      expect(mock.isFile).not.toHaveBeenCalled()
+      adapted.isFile()
+      expect(mock.isFile).toHaveBeenCalled()
+      expect(mock.isSymbolicLink).toHaveBeenCalledTimes(1)
+
+      adapted.isSymbolicLink()
+      expect(mock.isSymbolicLink).toHaveBeenCalledTimes(2)
+
+      expect(mock.isDirectory).not.toHaveBeenCalled()
+      adapted.isDirectory()
+      expect(mock.isDirectory).toHaveBeenCalled()
+      expect(mock.isSymbolicLink).toHaveBeenCalledTimes(3)
+
+      mock.isDirectory.mockReset()
+      mock.isDirectory.mockReturnValue(false)
+      mock.isSymbolicLink.mockReset()
+      mock.isSymbolicLink.mockReturnValue(true)
+      // When a path does not exist, isDirectorySync returns `false`
+      expect(isDirectorySync(fakePath)).toBe(false)
+      expect(adapted.isDirectory()).toBe(false)
+      expect(mock.isDirectory).toBeCalledTimes(1)
+      expect(mock.isSymbolicLink).toBeCalledTimes(1)
+
+      mock.isFile.mockReset()
+      mock.isFile.mockReturnValue(false)
+      mock.isSymbolicLink.mockReset()
+      mock.isSymbolicLink.mockReturnValue(true)
+      // When a path does not exist, isFileSync returns `false`
+      expect(isFileSync(fakePath)).toBe(false)
+      expect(adapted.isFile()).toBe(false)
+      expect(mock.isFile).toBeCalledTimes(1)
+      expect(mock.isSymbolicLink).toBeCalledTimes(1)
+    })
+    it('checks type', () => {
+      expect(isFileSync(mockFileName)).toBe(true)
+      expect(isDirectorySync(mockDirName)).toBe(true)
+      expect(isFileSync('not-existing-file')).toBe(false)
+      expect(isDirectorySync('not-existing-dir')).toBe(false)
+    })
+  })
+})

--- a/server/src/fs-utils.ts
+++ b/server/src/fs-utils.ts
@@ -1,0 +1,104 @@
+import fs from 'fs'
+import path from 'path'
+import I from 'immutable'
+
+export interface Dirent {
+  readonly name: string
+  readonly path: string
+  readonly realpath: string
+  /**
+   * Returns true if a path is a directory or a symbolic link pointing to a directory
+   */
+  readonly isDirectory: () => boolean
+  readonly isFile: () => boolean
+  readonly isSymbolicLink: () => boolean
+}
+
+export interface Walker {
+  readonly readdir: (dir: string) => Dirent[]
+  readonly shouldWalk: (dirent: Dirent) => boolean
+  readonly onError: (err: Error) => void
+}
+
+export const followSymbolicLinks = () => {
+  let visited = I.Set()
+  return (dirent: Dirent) => {
+    if (dirent.isDirectory()) {
+      const p = dirent.realpath
+      if (!visited.has(p)) {
+        visited = visited.add(p)
+        return true
+      }
+    }
+    return false
+  }
+}
+
+export function * walkDir(
+  walker: Walker,
+  start: string
+): Generator<Dirent, void, unknown> {
+  const toVisit = [start]
+  let next: string | undefined
+  while ((next = toVisit.shift()) !== undefined) {
+    try {
+      const entries = walker.readdir(next)
+      for (const entry of entries) {
+        if (walker.shouldWalk(entry)) {
+          toVisit.push(entry.path)
+        }
+        yield entry
+      }
+    } catch (e) {
+      walker.onError(e as Error)
+    }
+  }
+}
+
+// Most implementations of dirent use d_type which ORs together types like
+// dt_type = DT_DIR | DT_LNK and then isDirectory() would return
+// (dt_type & DT_DIR) == DT_DIR
+// For whatever reason, node's FS implementation is different. This
+// adaptation addresses that difference
+export const adaptFSDirent = (
+  wd: string, realpath: (p: string) => string, dirent: fs.Dirent
+): Dirent => ({
+  name: dirent.name,
+  get path() { return path.join(wd, dirent.name) },
+  get realpath() { return realpath(this.path) },
+  isDirectory() {
+    return dirent.isDirectory() || (
+      dirent.isSymbolicLink() && isDirectorySync(this.path)
+    )
+  },
+  isFile() {
+    return dirent.isFile() || (
+      dirent.isSymbolicLink() && isFileSync(this.path)
+    )
+  },
+  isSymbolicLink: dirent.isSymbolicLink.bind(dirent)
+})
+
+export const readdirSync = (wd: string) => {
+  return fs
+    .readdirSync(wd, { withFileTypes: true })
+    .map((dirent) => adaptFSDirent(wd, fs.realpathSync, dirent))
+}
+
+export const isDirectorySync = (p: string) => {
+  try {
+    const stat = fs.statSync(p)
+    return stat.isDirectory()
+  } catch {
+    return false
+  }
+}
+
+export const isFileSync = (p: string) => {
+  try {
+    const stat = fs.statSync(p)
+    return stat.isFile()
+  } catch {
+    return false
+  }
+}

--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -270,7 +270,13 @@ describe('processFilesystemChange()', () => {
       'META-INF/books.xml': bundleMaker({ books: [bookSlug] }),
       'collections/slug2.collection.xml': bookMaker({ slug: bookSlug, toc: [{ title: 'subbook', children: [pageId] }] }),
       'modules/m1234/index.cnxml': pageMaker({}),
-      'media/newpic.png': ''
+      'modules/a/ignored.txt': '',
+      'media/newpic.png': '',
+      'interactives/abc': {
+        'h5p.json': '',
+        'content.json': '',
+        'metadata.json': ''
+      }
     })
     const bundle = new Bundle(FS_PATH_HELPER, process.cwd())
     manager = new ModelManager(bundle, conn)
@@ -284,7 +290,7 @@ describe('processFilesystemChange()', () => {
     sinon.resetBehavior()
     sinon.resetHistory()
   })
-  it('creates Images/Pages/Books', async () => {
+  it('creates Images/Pages/Books/H5P', async () => {
     // Verify each type of object gets loaded
     expect(manager.bundle.isLoaded).toBe(false)
     expect((await fireChange(FileChangeType.Created, 'META-INF/books.xml')).size).toBe(1)
@@ -294,7 +300,18 @@ describe('processFilesystemChange()', () => {
     expect((await fireChange(FileChangeType.Created, 'modules/m1234/index.cnxml')).size).toBe(1)
     expect((await fireChange(FileChangeType.Created, 'media/newpic.png')).size).toBe(1)
     expect((await fireChange(FileChangeType.Created, 'media/does-not-exist.png')).size).toBe(1)
-    expect((await fireChange(FileChangeType.Created, `${manager.bundle.paths.publicRoot}/does-not-exist/h5p.json`)).size).toBe(1)
+    expect((await fireChange(FileChangeType.Created, 'interactives/abc/h5p.json')).size).toBe(1)
+  })
+  it('handles directory creation', async () => {
+    // Verify each type of object gets loaded
+    expect(manager.bundle.isLoaded).toBe(false)
+    expect((await fireChange(FileChangeType.Created, 'META-INF')).size).toBe(1)
+    expect(manager.bundle.isLoaded).toBe(true)
+
+    expect((await fireChange(FileChangeType.Created, 'collections')).size).toBe(1)
+    expect((await fireChange(FileChangeType.Created, 'modules')).size).toBe(1)
+    expect((await fireChange(FileChangeType.Created, 'media')).size).toBe(1)
+    expect((await fireChange(FileChangeType.Created, 'interactives')).size).toBe(1)
   })
   it('does not create things it does not understand', async () => {
     expect((await fireChange(FileChangeType.Created, 'README.md')).toArray()).toEqual([])
@@ -311,7 +328,7 @@ describe('processFilesystemChange()', () => {
     expect(sendDiagnosticsStub.callCount).toBe(1)
 
     expect((await fireChange(FileChangeType.Changed, 'media/newpic.png')).toArray()).toEqual([]) // Since the model was not aware of the file yet
-    expect((await fireChange(FileChangeType.Changed, `${manager.bundle.paths.publicRoot}/does-not-exist/h5p.json`)).toArray()).toEqual([]) // Since the model was not aware of the file yet
+    expect((await fireChange(FileChangeType.Changed, 'interactives/does-not-exist/h5p.json')).toArray()).toEqual([]) // Since the model was not aware of the file yet
   })
   it('deletes Files and directories', async () => {
     // Load the Bundle, Book, and Page

--- a/server/src/model-manager.ts
+++ b/server/src/model-manager.ts
@@ -19,6 +19,7 @@ import { type BookNode, type TocSubbookWithRange } from './model/book'
 import { mkdirp } from 'fs-extra'
 import { DOMParser, XMLSerializer } from 'xmldom'
 import { H5PExercise } from './model/h5p-exercise'
+import { walkDir, readdirSync, isDirectorySync, followSymbolicLinks } from './fs-utils'
 
 // Note: `[^/]+` means "All characters except slash"
 const IMAGE_RE = /\/media\/[^/]+\.[^.]+$/
@@ -47,6 +48,8 @@ function loadedAndExists(n: Fileish) {
 }
 
 function findOrCreateNode(bundle: Bundle, absPath: string) {
+  // TODO: Support `bundle.paths` (variable paths for modules, media,
+  // collections, etc)
   if (bundle.absPath === absPath) {
     return bundle
   } else if (IMAGE_RE.test(absPath)) {
@@ -55,7 +58,7 @@ function findOrCreateNode(bundle: Bundle, absPath: string) {
     return bundle.allPages.getOrAdd(absPath)
   } else if (BOOK_RE.test(absPath)) {
     return bundle.allBooks.getOrAdd(absPath)
-  } else if (absPath.endsWith('h5p.json')) {
+  } else if (absPath.endsWith('/h5p.json')) {
     return bundle.allH5P.getOrAdd(absPath)
   }
   return undefined
@@ -84,6 +87,12 @@ const checkFileExists = async (s: string): Promise<boolean> => {
   } catch {
     return false
   }
+}
+
+function walkDirectorySync(start: string, onError: (err: Error) => void) {
+  const shouldWalk = followSymbolicLinks()
+  const readdir = readdirSync
+  return walkDir({ readdir, shouldWalk, onError }, start)
 }
 
 function toStringFileChangeType(t: FileChangeType) {
@@ -258,17 +267,34 @@ export class ModelManager {
 
     if (type === FileChangeType.Created) {
       // Check if we are adding an Image/Page/Book
-      const node = findOrCreateNode(bundle, uri)
+      const tryGetUpdatedNode = async (bundle: Bundle, uri: string) => {
+        const node = findOrCreateNode(bundle, uri)
+        if (node !== undefined) await this.readAndUpdate(node)
+        return node
+      }
+      const relatedNodes: Fileish[] = []
+      const node = await tryGetUpdatedNode(bundle, uri)
       if (node !== undefined) {
         ModelManager.debug('[FILESYSTEM_EVENT] Adding item')
-        await this.readAndUpdate(node)
-        this.sendAllDiagnostics()
-        return I.Set([node])
+        relatedNodes.push(node)
       } else {
-        // No, we are adding something unknown. Ignore
-        ModelManager.debug('[FILESYSTEM_EVENT] New file did not match anything we understand. Ignoring', uri)
-        return I.Set()
+        const { fsPath } = URI.parse(uri)
+        if (!isDirectorySync(fsPath)) {
+          // No, we are adding something unknown. Ignore
+          ModelManager.debug('[FILESYSTEM_EVENT] New path did not match anything we understand. Ignoring', uri)
+          return I.Set()
+        }
+        ModelManager.debug('[FILESYSTEM_EVENT] Searching directory', fsPath)
+        const onError = (err: Error) => { ModelManager.debug('[MODEL_MANAGER]', err) }
+        for (const dirent of walkDirectorySync(fsPath, onError)) {
+          if (!dirent.isFile()) continue
+          const node = await tryGetUpdatedNode(bundle, dirent.path)
+          if (node === undefined) continue
+          relatedNodes.push(node)
+        }
       }
+      this.sendAllDiagnostics()
+      return I.Set(relatedNodes)
     } else if (type === FileChangeType.Changed) {
       const item = findNode(bundle, uri)
       if (item !== undefined) {


### PR DESCRIPTION
part of openstax/ce#2216

Directory events are separate from file events. When a directory is created, that results in a single event for the directory itself. For poet, this can create issues because copying a module directory, for example, will not result in a new page node being created.