### PR TITLE
1796 fix infinite enqueue

### DIFF
--- a/server/src/book-toc-utils.ts
+++ b/server/src/book-toc-utils.ts
@@ -88,7 +88,7 @@ export function toString(t: BookToc) {
 }
 
 export function fromPage(tocIdMap: IdMap<string, TocSubbookWithRange | PageNode>, n: PageNode): TocPage<ClientPageish> {
-  return { type: TocNodeKind.Page, value: { token: tocIdMap.add(n), title: n.optTitle, absPath: n.absPath, fileId: pageToModuleId(n) } }
+  return { type: TocNodeKind.Page, value: { token: tocIdMap.add(n), title: n.title, absPath: n.absPath, fileId: pageToModuleId(n) } }
 }
 function recTree(tocIdMap: IdMap<string, TocSubbookWithRange | PageNode>, parent: TocSubbookWithRange | null, n: TocNodeWithRange): ClientTocNode {
   if (n.type === TocNodeKind.Page) {

--- a/server/src/model-manager.spec.ts
+++ b/server/src/model-manager.spec.ts
@@ -662,7 +662,7 @@ describe('modifyToc()', () => {
     }
 
     await manager.modifyToc(evt)
-    expect(page.optTitle).toBe(newTitle)
+    expect(page.title).toBe(newTitle)
   })
   it('SubbookRename', async () => {
     const book = loadSuccess(first(loadSuccess(manager.bundle).books))
@@ -776,7 +776,7 @@ describe('modifyToc()', () => {
 
     expect(book.pages.size).toBe(2)
     expect(I.Set(book.pages).has(loadedPage)).toBe(true)
-    expect(loadedPage.optTitle).toBe('TEST_TITLE')
+    expect(loadedPage.title).toBe('TEST_TITLE')
 
     // Add another page for code coverage reasons
     await manager.createPage(bookIndex, 'TEST_TITLE2')

--- a/server/src/model-manager.ts
+++ b/server/src/model-manager.ts
@@ -618,7 +618,7 @@ export class ModelManager {
           type: TocNodeKind.Page,
           value: {
             token: evt.nodeToken,
-            title: pageNode.optTitle,
+            title: pageNode.title,
             fileId: pageToModuleId(pageNode),
             absPath: pageNode.absPath
           }

--- a/server/src/model/fileish.ts
+++ b/server/src/model/fileish.ts
@@ -92,14 +92,13 @@ export abstract class Fileish {
           this._isLoaded.set(true)
           this._exists.set(true)
         }
-        if (process.env.NODE_ENV !== 'production') {
+        try {
           fn()
-        } else {
-          try {
-            fn()
-          } catch (err) {
-            const e = err as Error
-            this._parseError.set(new WrappedParseError(this, e))
+        } catch (err) {
+          const e = err as Error
+          this._parseError.set(new WrappedParseError(this, e))
+          if (process.env.NODE_ENV !== 'production') {
+            throw e
           }
         }
         Fileish.debug(this.workspacePath, 'parsing XML (done)')

--- a/server/src/model/page.spec.ts
+++ b/server/src/model/page.spec.ts
@@ -9,27 +9,15 @@ describe('Page', () => {
   beforeEach(() => {
     page = new PageNode(makeBundle(), FS_PATH_HELPER, '/some/path/filename')
   })
-  it('can return a title before being loaded', () => {
-    const quickTitle = 'quick title'
+  it('defaults to untitled before being loaded', () => {
     expect(page.isLoaded).toBe(false)
-    const title = page.title(() => `a regexp reads this string so it does not have to be XML <title>${quickTitle}</title>.`)
-    expect(title).toBe(quickTitle)
-    expect(page.isLoaded).toBe(false)
-  })
-  it('falls back if the quick-title did not find a title', () => {
-    const quickTitle = 'quick title'
-    expect(page.isLoaded).toBe(false)
-    let title = page.title(() => 'no title element to be seen in this contents')
-    expect(title).toBe(UNTITLED_FILE)
-    title = page.title(() => `<title>${quickTitle}</title>`)
-    expect(title).toBe(quickTitle)
-    title = page.title(() => 'Just an opening <title>but no closing tag')
+    const title = page.title
     expect(title).toBe(UNTITLED_FILE)
     expect(page.isLoaded).toBe(false)
   })
   it('sets Untitled when there is no title element in the CNXML', () => {
     page.load(pageMaker({ title: null }))
-    expect(page.optTitle).toBe(UNTITLED_FILE)
+    expect(page.title).toBe(UNTITLED_FILE)
   })
   it('errors if there are two uuid elements (or any element that should occur exactly once in the doc)', () => {
     expect(() => { page.load(pageMaker({ uuid: 'little bobby drop tables</md:uuid><md:uuid>injection is fun' })) })

--- a/server/src/model/page.ts
+++ b/server/src/model/page.ts
@@ -1,6 +1,6 @@
 import I from 'immutable'
 import * as Quarx from 'quarx'
-import { type Opt, type Position, PathKind, type WithRange, textWithRange, select, selectOne, calculateElementPositions, expectValue, type HasRange, NOWHERE, join, equalsOpt, equalsWithRange, tripleEq, type Range } from './utils'
+import { type Opt, PathKind, type WithRange, textWithRange, select, selectOne, calculateElementPositions, expectValue, type HasRange, NOWHERE, join, equalsOpt, equalsWithRange, tripleEq, type Range } from './utils'
 import { Fileish, type ValidationCheck, ValidationKind, ValidationSeverity } from './fileish'
 import { type ResourceNode } from './resource'
 import { H5PExercise } from './h5p-exercise'
@@ -43,11 +43,6 @@ export type PageLink = HasRange & ({
   url: string
   h5p: H5PExercise
 })
-
-function convertToPos(str: string, cursor: number): Position {
-  const lines = str.substring(cursor).split('\n')
-  return { line: lines.length, character: lines[lines.length - 1].length }
-}
 
 function filterNull<T>(set: I.Set<Opt<T>>): I.Set<T> {
   return I.Set<T>().withMutations(s => {
@@ -100,55 +95,24 @@ function termSpecificSelector(e: string): string {
   return e === 'term' ? '[not(parent::cnxml:definition)]' : ''
 }
 
+const DEFAULT_TITLE = {
+  v: UNTITLED_FILE,
+  range: NOWHERE
+}
+
 export const ELEMENTS_MISSING_IDS_SEL = Array.from(ELEMENT_TO_PREFIX.keys()).map(e => `//cnxml:${e}[not(@id)]${termSpecificSelector(e)}`).join('|')
 export class PageNode extends Fileish {
   private readonly _uuid = Quarx.observable.box<Opt<WithRange<string>>>(undefined, { equals: equalsOptWithRange })
-  private readonly _title = Quarx.observable.box<Opt<WithRange<string>>>(undefined, { equals: equalsOptWithRange })
+  private readonly _title = Quarx.observable.box<WithRange<string>>(DEFAULT_TITLE, { equals: equalsOptWithRange })
   private readonly _elementIds = Quarx.observable.box<Opt<I.Set<WithRange<string>>>>(undefined)
   private readonly _resourceLinks = Quarx.observable.box<Opt<I.Set<ResourceLink>>>(undefined)
   private readonly _pageLinks = Quarx.observable.box<Opt<I.Set<PageLink>>>(undefined)
   private readonly _elementsMissingIds = Quarx.observable.box<Opt<I.Set<Range>>>(undefined)
 
   public uuid() { return this.ensureLoaded(this._uuid).v }
-  public get optTitle() {
-    const t = this._title.get()
-    return t?.v
-  }
 
-  public title(fileReader: () => string) {
-    // A quick way to get the title for the ToC
-    const v = this._title.get()
-    if (v === undefined) {
-      const data = fileReader()
-      return this.guessTitle(data)?.v ?? UNTITLED_FILE
-    }
-    return v.v
-  }
-
-  private guessTitle(data: string): Opt<WithRange<string>> {
-    const openTag = '<title>'
-    const closeTag = '</title>'
-    const titleTagStart = data.indexOf(openTag)
-    const titleTagEnd = data.indexOf(closeTag)
-    if (titleTagStart === -1 || titleTagEnd === -1) {
-      return
-    }
-    const actualTitleStart = titleTagStart + openTag.length
-    /* istanbul ignore if */
-    if (titleTagEnd - actualTitleStart > 280) {
-      // If the title is so long you can't tweet it,
-      // then something probably went wrong.
-      /* istanbul ignore next */
-      return
-    }
-    const range = {
-      start: convertToPos(data, actualTitleStart),
-      end: convertToPos(data, titleTagEnd)
-    }
-    return {
-      v: data.substring(actualTitleStart, titleTagEnd).trim(),
-      range
-    }
+  public get title() {
+    return this._title.get().v
   }
 
   public get resources() {
@@ -240,10 +204,7 @@ export class PageNode extends Fileish {
     if (titleNode.length > 0) {
       this._title.set(textWithRange(titleNode[0]))
     } else {
-      this._title.set({
-        v: UNTITLED_FILE,
-        range: NOWHERE
-      })
+      this._title.set(DEFAULT_TITLE)
     }
   }
 

--- a/server/src/model/page.ts
+++ b/server/src/model/page.ts
@@ -200,7 +200,7 @@ export class PageNode extends Fileish {
       }
     })))
 
-    const titleNode = select('//cnxml:title', doc) as Element[]
+    const titleNode = select('/cnxml:document/cnxml:title', doc) as Element[]
     if (titleNode.length > 0) {
       this._title.set(textWithRange(titleNode[0]))
     } else {

--- a/server/src/model/quarx.spec.ts
+++ b/server/src/model/quarx.spec.ts
@@ -1,19 +1,15 @@
 import { expect } from '@jest/globals'
 import * as Quarx from 'quarx'
 import { type TocNode, TocNodeKind } from './utils'
-import { bookMaker, first, loadSuccess, makeBundle, read } from './spec-helpers.spec'
+import { bookMaker, first, loadSuccess, makeBundle, pageMaker } from './spec-helpers.spec'
 import { type PageNode } from './page'
 
 describe('Quarx.autorun code', () => {
   it('Triggers a ToC autorun when the Page title changes', () => {
-    const bugTosser = () => { throw new Error('BUG: Title should already have been loaded') }
     const bundle = loadSuccess(makeBundle())
     const book = loadSuccess(first(bundle.books))
     const page = loadSuccess(first(book.pages))
-    const origTitle = page.title(bugTosser)
-    const xml = read(page.absPath)
-    const xml2 = xml.replace(origTitle, `${origTitle}2`)
-    const xml3 = xml2 + ' '
+    page.load(pageMaker({ title: 'test' }))
 
     let autorunCalls = 0
     let tocSideEffect = ''
@@ -25,10 +21,10 @@ describe('Quarx.autorun code', () => {
     })
     expect(autorunCalls).toBe(1)
     // Change the page title
-    page.load(xml2)
+    page.load(pageMaker({ title: 'test2' }))
     expect(autorunCalls).toBe(2)
-    // Changing page whitespace
-    page.load(xml3)
+    // Title remains the same
+    page.load(pageMaker({ title: 'test2' }))
     expect(autorunCalls).toBe(2)
 
     // just so that the tocSideEffect does not get marked as an unused variable by the linter
@@ -60,6 +56,6 @@ function tocToString(n: TocNode<PageNode>): string {
   if (n.type === TocNodeKind.Subbook) {
     return n.children.map(tocToString).join(' ')
   } else {
-    return n.page.title(() => { throw new Error('BUG: Title should have been loaded by now') })
+    return n.page.title
   }
 }


### PR DESCRIPTION
part of openstax/ce#1796

# Background:

When parse error occurred, the node was not set to loaded (`node.isLoaded` and `node.exists` continued to return `false`)

Since these nodes were never considered loaded, they were re-enqueued for loading forever.

The immediate trigger for the problem was the `BookValidationKind.MISSING_PAGE` validation in `book.ts` requiring pages to be loaded to check if they exist.

The underlying issue is a much deeper problem related to the job queue. If too many jobs are enqueued in a short time, poet halts without error. When this occurs, poet must be reloaded.

Limiting re-enqueued `nodesToLoad` to those that do not have a parse error fixes the immediate issue.

I thought about `isLoaded` returning `this._isLoaded.get() && this._parseError.get() === undefined` potentially being a better long-term; however, because of the nature of the bug, I feared that `isLoaded` may have unintentionally become synonymous with `isValid`.