### PR TITLE
Update schema with new 'noindex' document attribute

### DIFF
--- a/client/static/xsd/cnxml.xsd
+++ b/client/static/xsd/cnxml.xsd
@@ -41,6 +41,14 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="module-id"/>
+      <xs:attribute name="noindex">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:group name="title">


### PR DESCRIPTION
part of openstax/ce#2240

Update schema to allow `noindex` attribute on `document`