### PR TITLE
More validation for assumptions made in Enki

### DIFF
--- a/server/src/model/book.spec.ts
+++ b/server/src/model/book.spec.ts
@@ -11,7 +11,7 @@ describe('Book validations', () => {
       { title: chapterTitle, children: [] },
       { title: chapterTitle, children: [] }
     ]
-    book.load(bookMaker({ toc }))
+    book.load(bookMaker({ toc, slug: 'test' }))
     expectErrors(book, [BookValidationKind.DUPLICATE_CHAPTER_TITLE, BookValidationKind.DUPLICATE_CHAPTER_TITLE])
   })
   it(BookValidationKind.MISSING_PAGE.title, () => {
@@ -28,10 +28,21 @@ describe('Book validations', () => {
       { title: 'Chapter 1', children: ['m00001'] },
       { title: 'Chapter 2', children: ['m00001'] }
     ]
-    book.load(bookMaker({ toc }))
+    book.load(bookMaker({ toc, slug: 'test' }))
     const page = first(book.pages)
     page.load(pageMaker({}))
     expectErrors(book, [BookValidationKind.DUPLICATE_PAGE, BookValidationKind.DUPLICATE_PAGE])
+  })
+  it(BookValidationKind.INVALID_BOOK_NAME.title, () => {
+    const bundle = makeBundle()
+    const book = first(loadSuccess(bundle).books)
+    const toc: BookMakerTocNode[] = [
+      { title: 'Chapter 1', children: ['m00001'] }
+    ]
+    book.load(bookMaker({ toc, slug: 'not-test' }))
+    const page = first(book.pages)
+    page.load(pageMaker({}))
+    expectErrors(book, [BookValidationKind.INVALID_BOOK_NAME])
   })
 })
 

--- a/server/src/model/book.ts
+++ b/server/src/model/book.ts
@@ -1,7 +1,7 @@
 import I from 'immutable'
 import * as Quarx from 'quarx'
 import { type PageNode } from './page'
-import { type Opt, type WithRange, textWithRange, select, selectOne, findDuplicates, calculateElementPositions, expectValue, type HasRange, join, equalsOpt, equalsWithRange, tripleEq, equalsPos, equalsArray, PathKind, TocNodeKind } from './utils'
+import { type Opt, type WithRange, textWithRange, select, selectOne, findDuplicates, calculateElementPositions, expectValue, type HasRange, join, equalsOpt, equalsWithRange, tripleEq, equalsPos, equalsArray, PathKind, TocNodeKind, NOWHERE } from './utils'
 import { Fileish, type ValidationCheck, ValidationKind } from './fileish'
 import { getCCLicense } from './cc-license'
 
@@ -157,12 +157,21 @@ export class BookNode extends Fileish {
         message: BookValidationKind.DUPLICATE_PAGE,
         nodesToLoad: I.Set(),
         fn: () => I.Set(pageLeaves.filter(p => duplicatePages.has(p.page)).map(l => l.range))
+      },
+      {
+        message: BookValidationKind.INVALID_BOOK_NAME,
+        nodesToLoad: I.Set(),
+        fn: () => this.absPath.endsWith(`${this.slug}.collection.xml`)
+          ? I.Set()
+          : I.Set([NOWHERE])
       }
     ]
   }
 }
 
 export class BookValidationKind extends ValidationKind {
+  // openstax/enki/bakery-js/src/epub/toc.tsx#L74
+  static INVALID_BOOK_NAME = new BookValidationKind('Book must be named <slug>.collection.xml')
   static MISSING_PAGE = new BookValidationKind('Missing Page')
   static DUPLICATE_CHAPTER_TITLE = new BookValidationKind('Duplicate chapter title')
   static DUPLICATE_PAGE = new BookValidationKind('Duplicate page')

--- a/server/src/model/bundle.spec.ts
+++ b/server/src/model/bundle.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@jest/globals'
 import { type Bundle, BundleValidationKind } from './bundle'
-import { bundleMaker, expectErrors, first, loadSuccess, makeBundle, read } from './spec-helpers.spec'
+import { bookMaker, bundleMaker, expectErrors, first, loadSuccess, makeBundle, read } from './spec-helpers.spec'
 
 describe('Bundle validations', () => {
   it(BundleValidationKind.NO_BOOKS.title, () => {
@@ -13,6 +13,12 @@ describe('Bundle validations', () => {
     const book = first(bundle.books)
     book.load(undefined)
     expectErrors(bundle, [BundleValidationKind.MISSING_BOOK])
+  })
+  it(BundleValidationKind.MISMATCHED_SLUG.title, () => {
+    const bundle = loadSuccess(makeBundle())
+    const book = first(bundle.books)
+    book.load(bookMaker({ slug: 'something' }))
+    expectErrors(bundle, [BundleValidationKind.MISMATCHED_SLUG])
   })
 })
 

--- a/server/src/model/bundle.ts
+++ b/server/src/model/bundle.ts
@@ -114,18 +114,22 @@ export class Bundle extends Fileish implements Bundleish {
       {
         message: BundleValidationKind.MISMATCHED_SLUG,
         nodesToLoad: this.books,
-        fn: () => booksXMLBooks
-          .filter(
-            ({ v: bx, range: xr }) => books.filter(
-              ({ v: b, range: br }) =>
-                xr.start === br.start &&
-                xr.end === br.end &&
-                b.isValidXML &&
-                b.exists &&
-                b.slug === bx.slug
-            ).size === 0
-          )
-          .map(bx => bx.range)
+        fn: () => {
+          return booksXMLBooks
+            .filter(({ v: bx, range: rx }) => {
+              const maybeBookNode = books.find(
+                ({ range: r }) => r.start === rx.start && r.end === rx.end
+              )
+              if (maybeBookNode !== undefined) {
+                const { v: book } = maybeBookNode
+                if (book.isValidXML && book.exists) {
+                  return book.slug !== bx.slug
+                }
+              }
+              return false
+            })
+            .map(({ range }) => range)
+        }
       }
     ]
   }
@@ -133,7 +137,7 @@ export class Bundle extends Fileish implements Bundleish {
 
 export class BundleValidationKind extends ValidationKind {
   // openstax/enki/bakery-src/scripts/link_single.py#L59
-  static MISMATCHED_SLUG = new BundleValidationKind('Slug does not match any defined in a book')
+  static MISMATCHED_SLUG = new BundleValidationKind('Slug does not match the one defined in the book')
   static MISSING_BOOK = new BundleValidationKind('Missing book')
   static NO_BOOKS = new BundleValidationKind('No books defined')
 }

--- a/server/src/model/bundle.ts
+++ b/server/src/model/bundle.ts
@@ -116,8 +116,13 @@ export class Bundle extends Fileish implements Bundleish {
         nodesToLoad: this.books,
         fn: () => booksXMLBooks
           .filter(
-            ({ v: bx }) => books.filter(
-              ({ v: b }) => b.isValidXML && b.exists && b.slug === bx.slug
+            ({ v: bx, range: xr }) => books.filter(
+              ({ v: b, range: br }) =>
+                xr.start === br.start &&
+                xr.end === br.end &&
+                b.isValidXML &&
+                b.exists &&
+                b.slug === bx.slug
             ).size === 0
           )
           .map(bx => bx.range)

--- a/server/src/model/bundle.ts
+++ b/server/src/model/bundle.ts
@@ -127,6 +127,7 @@ export class Bundle extends Fileish implements Bundleish {
 }
 
 export class BundleValidationKind extends ValidationKind {
+  // openstax/enki/bakery-src/scripts/link_single.py#L59
   static MISMATCHED_SLUG = new BundleValidationKind('Slug does not match any defined in a book')
   static MISSING_BOOK = new BundleValidationKind('Missing book')
   static NO_BOOKS = new BundleValidationKind('No books defined')


### PR DESCRIPTION
Book slugs are defined in three places--books.xml, collection file name, collection file metadata--and must match in all three places. This is a common source of build errors in newly created books. Most processes in Enki use the slug from the books.xml file, however, there are a few exceptions. 

Codify the assumptions made about book slugs.

- Validate that the slug in the books.xml matches the one in the associated collection metadata (bakery-scripts)
- Validate that the collection name matches what epub builds would expect (bakery-js and CORGI)