### PR TITLE
Slug uri compare fix

### DIFF
--- a/server/src/model/_cli.ts
+++ b/server/src/model/_cli.ts
@@ -52,6 +52,7 @@ function loadNode(n: Fileish) {
 const pathHelper: PathHelper<string> = {
   join: (root, ...components) => path.join(root, ...components),
   dirname: (p) => path.dirname(p),
+  basename: (p) => path.basename(p),
   canonicalize: (x) => x
 }
 

--- a/server/src/model/book.ts
+++ b/server/src/model/book.ts
@@ -161,7 +161,7 @@ export class BookNode extends Fileish {
       {
         message: BookValidationKind.INVALID_BOOK_NAME,
         nodesToLoad: I.Set(),
-        fn: () => this.absPath.endsWith(`${this.slug}.collection.xml`)
+        fn: () => this.pathHelper.basename(this.absPath) === this.pathHelper.basename(`${this.slug}.collection.xml`)
           ? I.Set()
           : I.Set([NOWHERE])
       }

--- a/server/src/model/spec-helpers.spec.ts
+++ b/server/src/model/spec-helpers.spec.ts
@@ -20,12 +20,14 @@ export const read = (filePath: string) => readFileSync(filePath, 'utf-8')
 interface PathHelper<T> {
   join: (root: T, ...components: string[]) => T
   dirname: (p: T) => T
+  basename: (p: T) => T
   canonicalize: (p: T) => T
 }
 
 export const FS_PATH_HELPER: PathHelper<string> = {
   join: (root, ...components) => path.join(root, ...components),
   dirname: (p) => path.dirname(p),
+  basename: (p) => path.basename(p),
   canonicalize: (x) => x
 }
 

--- a/server/src/model/utils.ts
+++ b/server/src/model/utils.ts
@@ -34,6 +34,7 @@ export interface Position {
 export interface PathHelper<T> {
   join: (root: T, ...components: string[]) => T
   dirname: (p: T) => T
+  basename: (p: T) => T
   canonicalize: (p: T) => T
 }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -41,6 +41,7 @@ function getBundleForUri(uri: string): ModelManager {
 const pathHelper = {
   join: (uri: string, ...relPaths: string[]) => Utils.joinPath(URI.parse(uri), ...relPaths).toString(),
   dirname: (uri: string) => Utils.dirname(URI.parse(uri)).toString(),
+  basename: (uri: string) => Utils.basename(URI.parse(uri)).toString(),
   canonicalize: (uri: string) => {
     return URI.parse(uri).toString()
   }


### PR DESCRIPTION
Use `basename` to verify collection is named as expected 

The problem was that some characters were being uri encoded on one side of the comparison but not the other

Using basename on both side of the comparison should cause both strings to undergo the same transformation

As long as both results are the same, then the validation should pass